### PR TITLE
chore: sanitize internal references and test data for open source release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,11 @@ bin/
 *.exe
 *.log
 
-# Claude Code
-.claude/
-CLAUDE.md
-CC-*.md
-TASK*.md
-CONTINUE.md
-REVIEW*.md
-thread-*.md
+# IDE / tool workspace (not tracked)
+.idea/
+.vscode/
+*.swp
+*~
 
 # Deployment config
 docker-compose.yml

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -82,7 +82,7 @@ const (
 	SourceDirect = 3
 )
 
-// Channel type constants (aligned with WuKongIM).
+// Channel type constants (aligned with the IM server protocol).
 const (
 	ChannelTypeDM    = 1
 	ChannelTypeGroup = 2

--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -192,7 +192,7 @@ func NormalizeDMChannelID(channelID string, selfUID string, channelType int) str
 }
 
 // mapFrontendSourceType maps frontend source_type to backend channelType.
-// Frontend: 1=group, 3=DM; Backend WuKongIM: 1=DM, 2=group
+// Frontend: 1=group, 3=DM; Backend IM server: 1=DM, 2=group
 func mapFrontendSourceType(frontendType int) int {
 	switch frontendType {
 	case 1: // frontend group -> backend group

--- a/internal/pipeline/resolve_channel.go
+++ b/internal/pipeline/resolve_channel.go
@@ -60,11 +60,11 @@ var resolveChannelScopeTool = service.Tool{
 							"person_mode": map[string]interface{}{
 								"type":        "string",
 								"enum":        []string{"intersection", "union"},
-								"description": "persons 之间的组合模式。\"intersection\"：所有人需同时出现在频道中（如'我和托马斯聊了什么'）；\"union\"：任一人出现即可（如'我、托马斯、Jeff在搞什么'）。默认 \"intersection\"",
+								"description": "persons 之间的组合模式。\"intersection\"：所有人需同时出现在频道中（如'我和Alice聊了什么'）；\"union\"：任一人出现即可（如'我、Alice、Bob在搞什么'）。默认 \"intersection\"",
 							},
 							"include_self": map[string]interface{}{
 								"type":        "boolean",
-								"description": "主题中'我'是否作为对话参与方出现。如'我和Jeff聊了什么'→true；'托马斯最近在忙什么'→false",
+								"description": "主题中'我'是否作为对话参与方出现。如'我和Bob聊了什么'→true；'Alice最近在忙什么'→false",
 							},
 							"channel_ids": map[string]interface{}{
 								"type":        "array",
@@ -125,18 +125,18 @@ const resolveChannelScopeSystemPrompt = `你是一个频道范围解析器。根
   - "我参与但不管理的群" → ["member"]
   - 没有明确提到 → 省略或空数组
 - 当主题包含多个独立约束条件需要并集时，拆分为多条 rules
-  - 例："总结下我的全部私聊，以及我和托马斯所在群聊" → 两条规则
+  - 例："总结下我的全部私聊，以及我和Alice所在群聊" → 两条规则
 - 如果主题不包含任何频道范围约束（如"项目进度"、"最近在聊什么"），has_constraint 为 false，rules 为空数组
 
 示例：
-- "我和托马斯聊了什么"
-  → has_constraint=true, rules=[{persons:[托马斯UID], include_self:true, person_mode:"intersection"}]
-- "我、托马斯、Jeff在搞什么"
-  → has_constraint=true, rules=[{persons:[托马斯UID, JeffUID], include_self:true, person_mode:"union"}]
+- "我和Alice聊了什么"
+  → has_constraint=true, rules=[{persons:[AliceUID], include_self:true, person_mode:"intersection"}]
+- "我、Alice、Bob在搞什么"
+  → has_constraint=true, rules=[{persons:[AliceUID, BobUID], include_self:true, person_mode:"union"}]
 - "octo-dev群最近在聊什么"
   → has_constraint=true, rules=[{channel_ids:[octo-dev的ID]}]
-- "私聊里Jeff说了什么"
-  → has_constraint=true, rules=[{persons:[JeffUID], channel_type:["dm"], person_mode:"intersection"}]
+- "私聊里Bob说了什么"
+  → has_constraint=true, rules=[{persons:[BobUID], channel_type:["dm"], person_mode:"intersection"}]
 - "dev相关的群"
   → has_constraint=true, rules=[{channel_ids:[所有含dev的频道ID], channel_type:["group"]}]
 - "最近大家在讨论什么"
@@ -145,8 +145,8 @@ const resolveChannelScopeSystemPrompt = `你是一个频道范围解析器。根
   → has_constraint=true, rules=[{ownership:["creator"]}]
 - "我参与但不管理的群"
   → has_constraint=true, rules=[{ownership:["member"]}]
-- "总结下我的全部私聊，以及我和托马斯所在群聊的全部信息"
-  → has_constraint=true, rules=[{channel_type:["dm"], include_self:true}, {persons:[托马斯UID], include_self:true, channel_type:["group"], person_mode:"intersection"}]
+- "总结下我的全部私聊，以及我和Alice所在群聊的全部信息"
+  → has_constraint=true, rules=[{channel_type:["dm"], include_self:true}, {persons:[AliceUID], include_self:true, channel_type:["group"], person_mode:"intersection"}]
 
 你必须调用 resolve_channel_scope 工具来返回结果，不要以文本形式回复。`
 

--- a/internal/pipeline/resolve_topic.go
+++ b/internal/pipeline/resolve_topic.go
@@ -43,7 +43,7 @@ var resolveTopicTargetTool = service.Tool{
 				},
 				"include_self": map[string]interface{}{
 					"type":        "boolean",
-					"description": "主题中创建者以第一人称作为对话参与者出现时为 true（如'我和Jeff聊了什么'、'我跟团队讨论的内容'）；只关注他人时为 false（如'辉哥的发言'、'Jeff和Thomas的讨论'）",
+					"description": "主题中创建者以第一人称作为对话参与者出现时为 true（如'我和Alice聊了什么'、'我跟团队讨论的内容'）；只关注他人时为 false（如'老王的发言'、'Alice和Tom的讨论'）",
 				},
 			},
 			"required": []string{"has_target", "uids", "include_self", "reasoning"},
@@ -87,23 +87,23 @@ func ResolveTopicTarget(ctx context.Context, topic string, nameMap map[string]st
 	systemPrompt := `你是一个人物指代解析器。根据总结主题和成员列表，判断主题是否指向特定成员。
 
 规则：
-- 主题是关于某个特定成员的内容（如"辉哥的发言"、"CTO的观点"），返回该成员 UID
-- 主题包含多个人（如"辉哥和小明的讨论"），返回所有相关成员的 UID
+- 主题是关于某个特定成员的内容（如"老王的发言"、"CTO的观点"），返回该成员 UID
+- 主题包含多个人（如"老王和小李的讨论"），返回所有相关成员的 UID
 - 主题是自我指代（如"我的工作"、"我说了什么"），has_target 为 true，uids 为空数组，include_self 为 true
 - 主题不涉及特定人物（如"项目进度"、"最近在聊什么"），has_target 为 false
 - uids 只能从成员列表中选取，不得编造或推测不存在的 UID
 - 主题中提到的人物在成员列表中找不到匹配时，忽略该人物；所有人物都找不到时，has_target 为 false（此规则不影响"我"的处理——"我"始终通过 include_self 标识，不需要出现在成员列表中）
 - 名字匹配支持语义关联：昵称、简称、姓氏称呼、职位等，但必须与成员姓名存在明确的语义关联（如包含关系、谐音、常见缩写）
 - 两个名字之间没有语义关联时，不算匹配
-- 主题中"我"作为对话参与者出现（如"我和Jeff聊了什么"、"我跟团队讨论的内容"），include_self 为 true
-- 主题只关注他人的内容（如"辉哥的发言"、"Jeff和Thomas的讨论"），include_self 为 false
+- 主题中"我"作为对话参与者出现（如"我和Alice聊了什么"、"我跟团队讨论的内容"），include_self 为 true
+- 主题只关注他人的内容（如"老王的发言"、"Alice和Tom的讨论"），include_self 为 false
 
 示例：
-  ✅ "辉哥" → "李光辉"（辉 是 光辉 的简称，语义关联明确）
+  ✅ "老王" → "王明"（老+姓氏 = 常见称呼方式，语义关联明确）
   ✅ "老王" → "王建国"（老+姓氏 = 常见称呼方式）
-  ✅ "Thomas" → "托马斯"（同一名字的中英文形式）
-  ❌ "Jeff" → "Angie"（两个名字之间没有任何语义关联）
-  ❌ "小明" → "张伟"（没有语义关联，即使只有这一个成员）
+  ✅ "Tom" → "汤姆"（同一名字的中英文形式）
+  ❌ "Alice" → "Carol"（两个名字之间没有任何语义关联）
+  ❌ "小李" → "张伟"（没有语义关联，即使只有这一个成员）
 
 你必须调用 resolve_topic_target 工具来返回结果，不要以文本形式回复。`
 

--- a/internal/pipeline/resolve_topic_test.go
+++ b/internal/pipeline/resolve_topic_test.go
@@ -16,34 +16,34 @@ func mockToolCallFn(result TopicResolveResult) LLMToolCallFn {
 	}
 }
 
-func TestResolveTopicTarget_IncludeSelf_MeAndJeff(t *testing.T) {
+func TestResolveTopicTarget_IncludeSelf_MeAndAlice(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"jeff_uid":    "Jeff",
+		"alice_uid":    "Alice",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
-		UIDs:        []string{"jeff_uid"},
+		UIDs:        []string{"alice_uid"},
 		IncludeSelf: true,
-		Reasoning:   "主题'我和Jeff聊了什么'包含第一人称参与者",
+		Reasoning:   "主题'我和Alice聊了什么'包含第一人称参与者",
 	})
 
-	result := ResolveTopicTarget(context.Background(), "我和Jeff聊了什么", nameMap, "creator_uid", stubFn)
+	result := ResolveTopicTarget(context.Background(), "我和Alice聊了什么", nameMap, "creator_uid", stubFn)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 UIDs, got %d: %v", len(result), result)
 	}
-	hasJeff, hasCreator := false, false
+	hasAlice, hasCreator := false, false
 	for _, uid := range result {
-		if uid == "jeff_uid" {
-			hasJeff = true
+		if uid == "alice_uid" {
+			hasAlice = true
 		}
 		if uid == "creator_uid" {
 			hasCreator = true
 		}
 	}
-	if !hasJeff {
-		t.Error("expected jeff_uid in result")
+	if !hasAlice {
+		t.Error("expected alice_uid in result")
 	}
 	if !hasCreator {
 		t.Error("expected creator_uid in result (include_self=true)")
@@ -53,22 +53,22 @@ func TestResolveTopicTarget_IncludeSelf_MeAndJeff(t *testing.T) {
 func TestResolveTopicTarget_IncludeSelf_False(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"hui_uid":     "辉哥",
+		"wang_uid":     "老王",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
-		UIDs:        []string{"hui_uid"},
+		UIDs:        []string{"wang_uid"},
 		IncludeSelf: false,
-		Reasoning:   "主题'辉哥的发言'只关注辉哥",
+		Reasoning:   "主题'老王的发言'只关注老王",
 	})
 
-	result := ResolveTopicTarget(context.Background(), "辉哥的发言", nameMap, "creator_uid", stubFn)
+	result := ResolveTopicTarget(context.Background(), "老王的发言", nameMap, "creator_uid", stubFn)
 
 	if len(result) != 1 {
 		t.Fatalf("expected 1 UID, got %d: %v", len(result), result)
 	}
-	if result[0] != "hui_uid" {
-		t.Errorf("expected hui_uid, got %s", result[0])
+	if result[0] != "wang_uid" {
+		t.Errorf("expected wang_uid, got %s", result[0])
 	}
 }
 
@@ -106,16 +106,16 @@ func TestResolveTopicTarget_IncludeSelf_MultiplePersons(t *testing.T) {
 func TestResolveTopicTarget_IncludeSelf_NoDuplicate(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"jeff_uid":    "Jeff",
+		"alice_uid":    "Alice",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
-		UIDs:        []string{"jeff_uid", "creator_uid"},
+		UIDs:        []string{"alice_uid", "creator_uid"},
 		IncludeSelf: true,
 		Reasoning:   "LLM已返回creator_uid",
 	})
 
-	result := ResolveTopicTarget(context.Background(), "我和Jeff聊了什么", nameMap, "creator_uid", stubFn)
+	result := ResolveTopicTarget(context.Background(), "我和Alice聊了什么", nameMap, "creator_uid", stubFn)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 UIDs (no duplicate), got %d: %v", len(result), result)
@@ -155,7 +155,7 @@ func TestResolveTopicTarget_IncludeSelf_ZeroValue_BackwardCompat(t *testing.T) {
 func TestResolveTopicTarget_NoTarget_GeneralTopic(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"jeff_uid":    "Jeff",
+		"alice_uid":    "Alice",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   false,
@@ -193,7 +193,7 @@ func TestResolveTopicTarget_NoTarget_SummarizeAll(t *testing.T) {
 func TestResolveTopicTarget_SelfReference(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"jeff_uid":    "Jeff",
+		"alice_uid":    "Alice",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
@@ -215,7 +215,7 @@ func TestResolveTopicTarget_SelfReference(t *testing.T) {
 func TestResolveTopicTarget_AllUIDsInvalid_IncludeSelf(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"jeff_uid":    "Jeff",
+		"alice_uid":    "Alice",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
@@ -234,66 +234,66 @@ func TestResolveTopicTarget_AllUIDsInvalid_IncludeSelf(t *testing.T) {
 	}
 }
 
-func TestResolveTopicTarget_NoSemanticMatch_JeffNotAngie(t *testing.T) {
+func TestResolveTopicTarget_NoSemanticMatch_AliceNotCarol(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"angie_uid":   "Angie",
+		"carol_uid":   "Carol",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   false,
 		UIDs:        []string{},
 		IncludeSelf: false,
-		Reasoning:   "Jeff与成员Angie之间没有语义关联，不算匹配",
+		Reasoning:   "Alice与成员Carol之间没有语义关联，不算匹配",
 	})
 
-	result := ResolveTopicTarget(context.Background(), "Jeff的发言", nameMap, "creator_uid", stubFn)
+	result := ResolveTopicTarget(context.Background(), "Alice的发言", nameMap, "creator_uid", stubFn)
 
 	if result != nil {
 		t.Fatalf("expected nil when topic name has no semantic match in members, got %v", result)
 	}
 }
 
-func TestResolveTopicTarget_SemanticMatch_HuiGe(t *testing.T) {
+func TestResolveTopicTarget_SemanticMatch_Nickname(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid":    "我",
-		"liguanghui_uid": "李光辉",
+		"wang_uid": "王明",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
-		UIDs:        []string{"liguanghui_uid"},
+		UIDs:        []string{"wang_uid"},
 		IncludeSelf: false,
-		Reasoning:   "辉哥中的'辉'与李光辉的'光辉'存在语义关联",
+		Reasoning:   "老王中的'王'与王明的'王'存在语义关联",
 	})
 
-	result := ResolveTopicTarget(context.Background(), "辉哥的发言", nameMap, "creator_uid", stubFn)
+	result := ResolveTopicTarget(context.Background(), "老王的发言", nameMap, "creator_uid", stubFn)
 
 	if len(result) != 1 {
 		t.Fatalf("expected 1 UID, got %d: %v", len(result), result)
 	}
-	if result[0] != "liguanghui_uid" {
-		t.Errorf("expected liguanghui_uid, got %s", result[0])
+	if result[0] != "wang_uid" {
+		t.Errorf("expected wang_uid, got %s", result[0])
 	}
 }
 
-func TestResolveTopicTarget_SemanticMatch_ThomasChinese(t *testing.T) {
+func TestResolveTopicTarget_SemanticMatch_BilingualName(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"thomas_uid":  "托马斯",
+		"tom_uid":  "汤姆",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   true,
-		UIDs:        []string{"thomas_uid"},
+		UIDs:        []string{"tom_uid"},
 		IncludeSelf: false,
-		Reasoning:   "Thomas是托马斯的英文形式，语义关联明确",
+		Reasoning:   "Tom是汤姆的英文形式，语义关联明确",
 	})
 
-	result := ResolveTopicTarget(context.Background(), "Thomas说了什么", nameMap, "creator_uid", stubFn)
+	result := ResolveTopicTarget(context.Background(), "Tom说了什么", nameMap, "creator_uid", stubFn)
 
 	if len(result) != 1 {
 		t.Fatalf("expected 1 UID, got %d: %v", len(result), result)
 	}
-	if result[0] != "thomas_uid" {
-		t.Errorf("expected thomas_uid, got %s", result[0])
+	if result[0] != "tom_uid" {
+		t.Errorf("expected tom_uid, got %s", result[0])
 	}
 }
 
@@ -313,13 +313,13 @@ func TestResolveTopicTarget_EmptyTopic(t *testing.T) {
 func TestResolveTopicTarget_LLMError(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"jeff_uid":    "Jeff",
+		"alice_uid":    "Alice",
 	}
 	errorFn := func(ctx context.Context, msgs []service.ChatMessage, tools []service.Tool, forceFn string) (string, error) {
 		return "", fmt.Errorf("LLM service unavailable")
 	}
 
-	result := ResolveTopicTarget(context.Background(), "Jeff的观点", nameMap, "creator_uid", errorFn)
+	result := ResolveTopicTarget(context.Background(), "Alice的观点", nameMap, "creator_uid", errorFn)
 
 	if result != nil {
 		t.Fatalf("expected nil on LLM error, got %v", result)

--- a/internal/pipeline/resolve_topic_test.go
+++ b/internal/pipeline/resolve_topic_test.go
@@ -75,7 +75,7 @@ func TestResolveTopicTarget_IncludeSelf_False(t *testing.T) {
 func TestResolveTopicTarget_IncludeSelf_MultiplePersons(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"person1_uid": "小明",
+		"person1_uid": "小李",
 		"person2_uid": "小红",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
@@ -174,7 +174,7 @@ func TestResolveTopicTarget_NoTarget_GeneralTopic(t *testing.T) {
 func TestResolveTopicTarget_NoTarget_SummarizeAll(t *testing.T) {
 	nameMap := map[string]string{
 		"creator_uid": "我",
-		"person1_uid": "小明",
+		"person1_uid": "小李",
 	}
 	stubFn := mockToolCallFn(TopicResolveResult{
 		HasTarget:   false,

--- a/internal/pipeline/shard.go
+++ b/internal/pipeline/shard.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MessageTable returns the sharded message table name for a given channel ID.
-// Uses CRC32 IEEE to match the Go dmworkim implementation:
+// Uses CRC32 IEEE for consistent table sharding:
 //
 //	crc32.ChecksumIEEE([]byte(channelID)) % uint32(tableCount)
 //

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -14,7 +14,7 @@ import (
 
 const MapFailedMarker = "总结失败"
 
-// LLMClient handles calls to the OpenAI-compatible LLM gateway.
+// LLMClient handles calls to a chat-completions-compatible LLM API.
 type LLMClient struct {
 	apiURL          string
 	apiKey          string

--- a/internal/worker/tokenutil_test.go
+++ b/internal/worker/tokenutil_test.go
@@ -46,7 +46,7 @@ func TestSanitizeErrorForUser(t *testing.T) {
 		{"context deadline", "context deadline exceeded", "AI 处理超时，请稍后重试"},
 		{"all chunks failed", "all 3 chunk(s) failed during Map phase (LLM unreachable)", "AI 服务暂时不可用，所有分片处理失败"},
 		{"unknown short", "some random error", "AI 处理失败，请稍后重试"},
-		{"unknown dsn leak", "dial tcp 10.0.0.5:3306: user=root password=secret", "AI 处理失败，请稍后重试"},
+		{"unknown dsn leak", "dial tcp 192.0.2.1:3306: user=testuser password=***", "AI 处理失败，请稍后重试"},
 		{"unknown stack trace", "goroutine 12 [running]: runtime.gopanic(...)", "AI 处理失败，请稍后重试"},
 		{"empty", "", "AI 处理失败，请稍后重试"},
 	}

--- a/migrations/legacy/002_p2_personal_summary.sql
+++ b/migrations/legacy/002_p2_personal_summary.sql
@@ -5,7 +5,7 @@ CREATE TABLE summary_personal_result (
     id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
     task_id             BIGINT NOT NULL,
     participant_ref_id  BIGINT NOT NULL COMMENT '关联 summary_participant.id',
-    user_id             VARCHAR(64) NOT NULL COMMENT '冗余 DMWork uid，方便按用户查询',
+    user_id             VARCHAR(64) NOT NULL COMMENT 'redundant IM platform uid for per-user queries',
     content             MEDIUMTEXT NOT NULL,
     msg_count           INT NOT NULL DEFAULT 0,
     total_token_used    INT NOT NULL DEFAULT 0,

--- a/migrations/sql/20260101-00-baseline.sql
+++ b/migrations/sql/20260101-00-baseline.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS `summary_personal_result` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `task_id` bigint NOT NULL,
   `participant_ref_id` bigint NOT NULL COMMENT 'FK summary_participant.id',
-  `user_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'redundant DMWork uid for per-user queries',
+  `user_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'redundant IM platform uid for per-user queries',
   `content` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `citations_json` mediumtext COLLATE utf8mb4_unicode_ci,
   `msg_count` int NOT NULL DEFAULT '0',


### PR DESCRIPTION
## Summary

Sanitize internal references and sensitive test data in preparation for open source release.

## Changes (11 files, 74+/77-)

### 1. Person Name Anonymization (3 files)
- `resolve_topic.go`: Jeff→Alice, 辉哥→老王, Thomas/托马斯→Tom/汤姆 in LLM prompt examples
- `resolve_channel.go`: 托马斯→Alice, Jeff→Bob in LLM prompt examples  
- `resolve_topic_test.go`: All person names, UIDs, variable names, and test function names updated

### 2. Internal Product Name Cleanup (5 files)
- `shard.go`: `dmworkim implementation` → `consistent table sharding`
- `fetch.go`: `WuKongIM` → `IM server`
- `model.go`: `WuKongIM` → `the IM server protocol`
- `002_p2_personal_summary.sql`: `DMWork uid` → `IM platform uid`
- `20260101-00-baseline.sql`: `DMWork uid` → `IM platform uid`

### 3. AI Tool Trace Cleanup (2 files)
- `.gitignore`: Claude Code section replaced with standard IDE/tool patterns
- `llm.go`: `OpenAI-compatible LLM gateway` → `chat-completions-compatible LLM API`

### 4. Test Data Cleanup (1 file)
- `tokenutil_test.go`: Private IP `10.0.0.5` with `user=root` → RFC 5737 documentation IP `192.0.2.1` with `user=testuser`

## NOT changed (by design)
- License headers: not added (will be handled separately)
- `mininglamp.com` email addresses: kept as-is (public entity)
- No business logic changes

## Verification
- All grep residue checks pass (zero matches for old names/products/traces)
- Independent code review: PASS