### PR TITLE
feat: add Kimi K2.6 thinking adaptation (disable reasoning, temperature constraint)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,6 +180,8 @@ var modelMaxTokensDefaults = map[string]int{
 	"qwen3.6-flash":     400000,
 	"deepseek-v4-flash": 400000,
 	"deepseek-v4-pro":   400000,
+	"kimi-k2":           150000,
+	"kimi_k2":           150000,
 }
 
 const defaultMapMaxTokens = 100000
@@ -202,14 +204,14 @@ func (c *Config) ResolveMapMaxTokens() int {
 }
 
 // ResolveCharsPerTokenCJK returns the CJK chars-per-token ratio.
-// For qwen models, defaults to 2 if not explicitly configured.
+// For qwen/deepseek/kimi models, defaults to 2 if not explicitly configured.
 // For other models, uses the configured value (default 1).
 func (c *Config) ResolveCharsPerTokenCJK() int {
 	if os.Getenv("CHARS_PER_TOKEN_CJK") != "" {
-		// Explicitly configured, use as-is
 		return c.CharsPerTokenCJK
 	}
-	if strings.Contains(strings.ToLower(c.LLMModel), "qwen3.6") || strings.Contains(strings.ToLower(c.LLMModel), "deepseek-v4") {
+	m := strings.ToLower(c.LLMModel)
+	if IsKimiModel(m) || IsQwenOrDeepSeekModel(m) {
 		return 2
 	}
 	return c.CharsPerTokenCJK

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 )
 
@@ -21,6 +20,10 @@ func TestResolveMapMaxTokens_QwenModels(t *testing.T) {
 		{"Qwen3.6-Max", 400000},
 		{"DEEPSEEK-V4-FLASH", 400000},
 		{"ali/Qwen3.6-Flash", 400000},
+		{"kimi-k2.6", 150000},
+		{"kimi-k2.5", 150000},
+		{"mlamp/kimi-k2.6", 150000},
+		{"KIMI-K2.6", 150000},
 		{"unknown-model", 100000},
 	}
 	for _, tt := range tests {
@@ -41,9 +44,6 @@ func TestResolveMapMaxTokens_ExplicitOverride(t *testing.T) {
 }
 
 func TestResolveCharsPerTokenCJK(t *testing.T) {
-	// Ensure env is clean
-	os.Unsetenv("CHARS_PER_TOKEN_CJK")
-
 	tests := []struct {
 		name  string
 		model string
@@ -53,11 +53,16 @@ func TestResolveCharsPerTokenCJK(t *testing.T) {
 		{"qwen3.6-max defaults to 2", "qwen3.6-max", 2},
 		{"deepseek-v4-flash defaults to 2", "deepseek-v4-flash", 2},
 		{"deepseek-v4-pro defaults to 2", "deepseek-v4-pro", 2},
+		{"kimi-k2.6 defaults to 2", "kimi-k2.6", 2},
+		{"kimi-k2.5 defaults to 2", "kimi-k2.5", 2},
+		{"mlamp/kimi-k2.6 defaults to 2", "mlamp/kimi-k2.6", 2},
+		{"kimi_k2.6 defaults to 2", "kimi_k2.6", 2},
 		{"claude model defaults to 1", "claude-haiku-4-5", 1},
 		{"unknown model defaults to 1", "some-model", 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CHARS_PER_TOKEN_CJK", "")
 			cfg := &Config{LLMModel: tt.model, CharsPerTokenCJK: 1}
 			if got := cfg.ResolveCharsPerTokenCJK(); got != tt.want {
 				t.Errorf("ResolveCharsPerTokenCJK() for model %q = %d, want %d", tt.model, got, tt.want)
@@ -67,10 +72,9 @@ func TestResolveCharsPerTokenCJK(t *testing.T) {
 }
 
 func TestResolveCharsPerTokenCJK_ExplicitEnvOverride(t *testing.T) {
-	os.Setenv("CHARS_PER_TOKEN_CJK", "3")
-	defer os.Unsetenv("CHARS_PER_TOKEN_CJK")
+	t.Setenv("CHARS_PER_TOKEN_CJK", "3")
 
-	cfg := &Config{LLMModel: "qwen3.6-flash", CharsPerTokenCJK: 3}
+	cfg := &Config{LLMModel: "kimi-k2.6", CharsPerTokenCJK: 3}
 	if got := cfg.ResolveCharsPerTokenCJK(); got != 3 {
 		t.Errorf("ResolveCharsPerTokenCJK() with explicit env = %d, want 3", got)
 	}

--- a/internal/config/model_detect.go
+++ b/internal/config/model_detect.go
@@ -1,0 +1,16 @@
+package config
+
+import "strings"
+
+// IsKimiModel returns true for Kimi K2 series models.
+// Matches: kimi-k2.6, kimi-k2.5, mlamp/kimi-k2.6, kimi_k2.6, etc.
+func IsKimiModel(model string) bool {
+	m := strings.ToLower(model)
+	return strings.Contains(m, "kimi-k2") || strings.Contains(m, "kimi_k2")
+}
+
+// IsQwenOrDeepSeekModel returns true for Qwen 3.6 / DeepSeek V4 models.
+func IsQwenOrDeepSeekModel(model string) bool {
+	m := strings.ToLower(model)
+	return strings.Contains(m, "qwen3.6") || strings.Contains(m, "deepseek-v4")
+}

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -10,9 +10,13 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 )
 
 const MapFailedMarker = "总结失败"
+
+const kimiRequiredTemperature = 0.6
 
 // LLMClient handles calls to a chat-completions-compatible LLM API.
 type LLMClient struct {
@@ -70,14 +74,23 @@ type ToolChoiceFunction struct {
 	Name string `json:"name"`
 }
 
+// ThinkingParam controls the thinking/reasoning behavior for supported models.
+type ThinkingParam struct {
+	Type string `json:"type"` // "enabled" or "disabled"
+}
+
 type chatRequestWithTools struct {
 	Model              string                 `json:"model"`
 	Messages           []ChatMessage          `json:"messages"`
 	Temperature        float64                `json:"temperature"`
 	MaxTokens          int                    `json:"max_tokens"`
 	Tools              []Tool                 `json:"tools"`
-	ToolChoice         ToolChoice             `json:"tool_choice"`
+	// ToolChoice controls function calling behavior.
+	// For Kimi models: string "auto" (Kimi does not support forced function calling).
+	// For other models: ToolChoice struct with Type="function" and Function specification.
+	ToolChoice interface{} `json:"tool_choice"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
+	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
 }
 
 type chatResponseWithTools struct {
@@ -89,6 +102,8 @@ type chatResponseWithTools struct {
 					Arguments string `json:"arguments"`
 				} `json:"function"`
 			} `json:"tool_calls"`
+			ReasoningContent string `json:"reasoning_content"`
+			Reasoning        string `json:"reasoning"`
 		} `json:"message"`
 	} `json:"choices"`
 	Usage struct {
@@ -102,21 +117,48 @@ type chatRequest struct {
 	Temperature        float64                `json:"temperature"`
 	MaxTokens          int                    `json:"max_tokens"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
+	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
 }
 
 type chatResponse struct {
 	Choices []struct {
 		Message struct {
-			Content string `json:"content"`
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			Reasoning        string `json:"reasoning"`
 		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 	Usage struct {
-		TotalTokens int `json:"total_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
+}
+
+// buildThinkingConfig returns model-specific thinking parameters.
+// For Kimi: top-level thinking field. For Qwen/DeepSeek: chat_template_kwargs.
+func (c *LLMClient) buildThinkingConfig() (*ThinkingParam, map[string]interface{}) {
+	if c.enableThinking {
+		return nil, nil
+	}
+	if config.IsKimiModel(c.model) {
+		return &ThinkingParam{Type: "disabled"}, nil
+	}
+	if config.IsQwenOrDeepSeekModel(c.model) {
+		return nil, map[string]interface{}{"enable_thinking": false}
+	}
+	return nil, nil
 }
 
 // Call makes a chat completion request. Returns (content, tokenUsed, error).
 func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, error) {
+	if config.IsKimiModel(c.model) && temperature != kimiRequiredTemperature {
+		log.Printf("[llm] overriding temperature from %.2f to %.2f (model constraint)",
+			temperature, kimiRequiredTemperature)
+		temperature = kimiRequiredTemperature
+	} else if config.IsKimiModel(c.model) {
+		temperature = kimiRequiredTemperature
+	}
 	log.Printf("[llm] calling model=%s temperature=%.2f max_tokens=%d", c.model, temperature, c.maxTokens)
 	reqBody := chatRequest{
 		Model:       c.model,
@@ -124,9 +166,10 @@ func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperatur
 		Temperature: temperature,
 		MaxTokens:   c.maxTokens,
 	}
-	if !c.enableThinking && (strings.Contains(strings.ToLower(c.model), "qwen3.6") || strings.Contains(strings.ToLower(c.model), "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := c.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
+
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", 0, err
@@ -160,7 +203,24 @@ func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperatur
 	if len(chatResp.Choices) == 0 {
 		return "", 0, fmt.Errorf("LLM returned no choices")
 	}
-	return chatResp.Choices[0].Message.Content, chatResp.Usage.TotalTokens, nil
+
+	content := chatResp.Choices[0].Message.Content
+	// Check both field names: "reasoning_content" (official Kimi) and "reasoning" (gateway proxy)
+	reasoningPresent := chatResp.Choices[0].Message.ReasoningContent != "" || chatResp.Choices[0].Message.Reasoning != ""
+	if content == "" && reasoningPresent {
+		reasoningLen := len(chatResp.Choices[0].Message.ReasoningContent) + len(chatResp.Choices[0].Message.Reasoning)
+		log.Printf("[llm] WARNING: content is empty but reasoning present (%d chars), "+
+			"finish_reason=%s, completion_tokens=%d. Reasoning consumed entire budget.",
+			reasoningLen, chatResp.Choices[0].FinishReason, chatResp.Usage.CompletionTokens)
+		return "", chatResp.Usage.TotalTokens, fmt.Errorf("LLM returned empty content: reasoning consumed entire max_tokens budget")
+	}
+	if content == "" && chatResp.Choices[0].FinishReason == "length" {
+		log.Printf("[llm] WARNING: content is empty and finish_reason=length, completion_tokens=%d",
+			chatResp.Usage.CompletionTokens)
+		return "", chatResp.Usage.TotalTokens, fmt.Errorf("LLM returned empty content due to token limit")
+	}
+
+	return content, chatResp.Usage.TotalTokens, nil
 }
 
 // CallRaw is a simple single-turn call returning text only. Used for topic narrowing.
@@ -173,11 +233,28 @@ func (c *LLMClient) CallRaw(ctx context.Context, prompt string) (string, error) 
 	return content, nil
 }
 
-// CallWithTools makes a chat completion request with forced function calling.
+// CallWithTools makes a chat completion request with function calling.
 // Returns the raw JSON string from tool_calls[0].function.arguments and token count.
 func (c *LLMClient) CallWithTools(ctx context.Context, messages []ChatMessage, tools []Tool, forceFn string, temperature float64) (string, int, error) {
+	if config.IsKimiModel(c.model) && temperature != kimiRequiredTemperature {
+		log.Printf("[llm] overriding temperature from %.2f to %.2f (model constraint)",
+			temperature, kimiRequiredTemperature)
+		temperature = kimiRequiredTemperature
+	} else if config.IsKimiModel(c.model) {
+		temperature = kimiRequiredTemperature
+	}
 	log.Printf("[llm] CallWithTools: tool=%s temperature=%.2f model=%s", forceFn, temperature, c.model)
 	start := time.Now()
+
+	var toolChoice interface{}
+	if config.IsKimiModel(c.model) {
+		toolChoice = "auto"
+	} else {
+		toolChoice = ToolChoice{
+			Type:     "function",
+			Function: ToolChoiceFunction{Name: forceFn},
+		}
+	}
 
 	reqBody := chatRequestWithTools{
 		Model:       c.model,
@@ -185,14 +262,12 @@ func (c *LLMClient) CallWithTools(ctx context.Context, messages []ChatMessage, t
 		Temperature: temperature,
 		MaxTokens:   c.maxTokens,
 		Tools:       tools,
-		ToolChoice: ToolChoice{
-			Type:     "function",
-			Function: ToolChoiceFunction{Name: forceFn},
-		},
+		ToolChoice:  toolChoice,
 	}
-	if !c.enableThinking && (strings.Contains(strings.ToLower(c.model), "qwen3.6") || strings.Contains(strings.ToLower(c.model), "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := c.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
+
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return "", 0, fmt.Errorf("marshal request: %w", err)
@@ -254,7 +329,44 @@ func (c *LLMClient) CallWithTools(ctx context.Context, messages []ChatMessage, t
 			continue
 		}
 		if len(chatResp.Choices[0].Message.ToolCalls) == 0 {
+			reasoningPresent := chatResp.Choices[0].Message.ReasoningContent != "" || chatResp.Choices[0].Message.Reasoning != ""
+			if reasoningPresent {
+				reasoningLen := len(chatResp.Choices[0].Message.ReasoningContent) + len(chatResp.Choices[0].Message.Reasoning)
+				log.Printf("[llm] CallWithTools: no tool_calls but reasoning present (%d chars). Reasoning consumed entire budget.",
+					reasoningLen)
+				return "", chatResp.Usage.TotalTokens, fmt.Errorf("CallWithTools: reasoning consumed entire max_tokens budget, no tool_calls produced")
+			}
 			lastErr = fmt.Errorf("LLM returned no tool_calls")
+			log.Printf("[llm] CallWithTools attempt %d: no tool_calls returned", attempt+1)
+			continue
+		}
+
+		if config.IsKimiModel(c.model) {
+			matched := false
+			for _, tc := range chatResp.Choices[0].Message.ToolCalls {
+				if tc.Function.Name == forceFn {
+					matched = true
+					args := tc.Function.Arguments
+					if args == "" {
+						lastErr = fmt.Errorf("LLM returned empty arguments")
+						break
+					}
+					log.Printf("[llm] CallWithTools: tool=%s took %dms tokens=%d", forceFn, time.Since(start).Milliseconds(), chatResp.Usage.TotalTokens)
+					return args, chatResp.Usage.TotalTokens, nil
+				}
+			}
+			if !matched {
+				calledFn := chatResp.Choices[0].Message.ToolCalls[0].Function.Name
+				lastErr = fmt.Errorf("LLM called function %q instead of expected %q", calledFn, forceFn)
+				log.Printf("[llm] CallWithTools attempt %d: wrong function called: %s", attempt+1, calledFn)
+			}
+			continue
+		}
+
+		calledFn := chatResp.Choices[0].Message.ToolCalls[0].Function.Name
+		if calledFn != forceFn {
+			lastErr = fmt.Errorf("LLM called function %q instead of expected %q", calledFn, forceFn)
+			log.Printf("[llm] CallWithTools attempt %d: wrong function called: %s", attempt+1, calledFn)
 			continue
 		}
 
@@ -378,6 +490,10 @@ func (c *LLMClient) CallMap(ctx context.Context, formattedMessages string, sourc
 			return content, tokens, nil
 		}
 		log.Printf("[llm] Map chunk %d attempt %d failed: %v", chunkIndex, attempt+1, err)
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "reasoning consumed") || strings.Contains(errMsg, "empty content due to token limit") {
+			return "", tokens, fmt.Errorf("reasoning budget exhausted on chunk %d", chunkIndex)
+		}
 		if attempt < 2 {
 			time.Sleep(time.Duration(1<<uint(attempt)) * time.Second)
 		}

--- a/internal/service/llm_kimi_test.go
+++ b/internal/service/llm_kimi_test.go
@@ -1,0 +1,449 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestKimiThinkingDisabled_Call(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"total_tokens":10}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 30, 4096, false, 30)
+	content, tokens, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, 0.1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "hello" {
+		t.Errorf("expected content=hello, got %q", content)
+	}
+	if tokens != 10 {
+		t.Errorf("expected tokens=10, got %d", tokens)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+
+	thinking, ok := parsed["thinking"]
+	if !ok {
+		t.Fatal("expected thinking field in request body for kimi model")
+	}
+	thinkingMap := thinking.(map[string]interface{})
+	if thinkingMap["type"] != "disabled" {
+		t.Errorf("expected thinking.type=disabled, got %v", thinkingMap["type"])
+	}
+
+	if _, ok := parsed["chat_template_kwargs"]; ok {
+		t.Error("kimi model should not have chat_template_kwargs")
+	}
+
+	temp := parsed["temperature"].(float64)
+	if temp != 0.6 {
+		t.Errorf("expected temperature=0.6 for kimi model, got %.2f", temp)
+	}
+}
+
+func TestKimiThinkingDisabled_CallWithTools(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"resolve_topic","arguments":"{\"topic\":\"test\"}"}}]}}],"usage":{"total_tokens":50}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 30, 4096, false, 30)
+	args, tokens, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "analyze"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic", Description: "test", Parameters: nil}}},
+		"resolve_topic", 0.1,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args != `{"topic":"test"}` {
+		t.Errorf("unexpected args: %s", args)
+	}
+	if tokens != 50 {
+		t.Errorf("expected tokens=50, got %d", tokens)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(capturedBody, &parsed); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+
+	tc := parsed["tool_choice"]
+	if tc != "auto" {
+		t.Errorf("expected tool_choice=\"auto\" for kimi, got %v (%T)", tc, tc)
+	}
+
+	thinking, ok := parsed["thinking"]
+	if !ok {
+		t.Fatal("expected thinking field for kimi model")
+	}
+	thinkingMap := thinking.(map[string]interface{})
+	if thinkingMap["type"] != "disabled" {
+		t.Errorf("expected thinking.type=disabled, got %v", thinkingMap["type"])
+	}
+
+	if _, ok := parsed["chat_template_kwargs"]; ok {
+		t.Error("kimi model should not have chat_template_kwargs")
+	}
+
+	temp := parsed["temperature"].(float64)
+	if temp != 0.6 {
+		t.Errorf("expected temperature=0.6 for kimi model, got %.2f", temp)
+	}
+}
+
+func TestNonKimiModel_NoThinking(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"total_tokens":10}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "claude-sonnet-4-6", 30, 4096, false, 30)
+	_, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, 0.1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	json.Unmarshal(capturedBody, &parsed)
+
+	if _, ok := parsed["thinking"]; ok {
+		t.Error("claude model should not have thinking field")
+	}
+	if _, ok := parsed["chat_template_kwargs"]; ok {
+		t.Error("claude model should not have chat_template_kwargs")
+	}
+}
+
+func TestQwenModel_ChatTemplateKwargs(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"total_tokens":10}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "qwen3.6-flash", 30, 4096, false, 30)
+	_, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, 0.1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	json.Unmarshal(capturedBody, &parsed)
+
+	if _, ok := parsed["thinking"]; ok {
+		t.Error("qwen model should not have thinking field")
+	}
+
+	kwargs, ok := parsed["chat_template_kwargs"]
+	if !ok {
+		t.Fatal("expected chat_template_kwargs for qwen model")
+	}
+	kwargsMap := kwargs.(map[string]interface{})
+	if kwargsMap["enable_thinking"] != false {
+		t.Errorf("expected enable_thinking=false, got %v", kwargsMap["enable_thinking"])
+	}
+}
+
+func TestKimiThinkingEnabled_NoInjection(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"total_tokens":10}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 30, 4096, true, 30)
+	_, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, 0.1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	json.Unmarshal(capturedBody, &parsed)
+
+	if _, ok := parsed["thinking"]; ok {
+		t.Error("expected no thinking field when enableThinking=true")
+	}
+}
+
+func TestKimiContentEmpty_ReasoningPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"content":"","reasoning_content":"I think therefore I am..."}}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 30, 4096, false, 30)
+	_, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, 0.1)
+	if err == nil {
+		t.Fatal("expected error when content is empty but reasoning present")
+	}
+	expected := "LLM returned empty content: reasoning consumed entire max_tokens budget"
+	if err.Error() != expected {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestKimiContentEmpty_ReasoningField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"content":"","reasoning":"Thinking about this..."}, "finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 30, 4096, false, 30)
+	_, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, 0.1)
+	if err == nil {
+		t.Fatal("expected error when content is empty but reasoning present")
+	}
+	if !strings.Contains(err.Error(), "reasoning consumed entire max_tokens budget") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestKimiCallWithTools_ReasoningBudgetExhausted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"tool_calls":[],"reasoning_content":"very long reasoning..."}}],"usage":{"total_tokens":100}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	_, _, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "analyze"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic", Description: "test", Parameters: nil}}},
+		"resolve_topic", 0.1,
+	)
+	if err == nil {
+		t.Fatal("expected error when reasoning consumed budget")
+	}
+	if !strings.Contains(err.Error(), "reasoning consumed entire max_tokens budget") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestKimiToolChoice_FunctionNameValidation(t *testing.T) {
+	attempt := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		w.Header().Set("Content-Type", "application/json")
+		if attempt == 1 {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"choices": []map[string]interface{}{{
+					"message": map[string]interface{}{
+						"tool_calls": []map[string]interface{}{{
+							"function": map[string]interface{}{
+								"name":      "wrong_function",
+								"arguments": `{"topic":"test"}`,
+							},
+						}},
+					},
+				}},
+				"usage": map[string]interface{}{"total_tokens": 50},
+			})
+		} else {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"choices": []map[string]interface{}{{
+					"message": map[string]interface{}{
+						"tool_calls": []map[string]interface{}{
+							{
+								"function": map[string]interface{}{
+									"name":      "wrong_function",
+									"arguments": `{"topic":"wrong"}`,
+								},
+							},
+							{
+								"function": map[string]interface{}{
+									"name":      "resolve_topic",
+									"arguments": `{"topic":"test"}`,
+								},
+							},
+						},
+					},
+				}},
+				"usage": map[string]interface{}{"total_tokens": 80},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	result, _, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "analyze"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic", Description: "test", Parameters: nil}}},
+		"resolve_topic", 0.1,
+	)
+
+	if attempt != 2 {
+		t.Errorf("expected 2 attempts (retry), got %d", attempt)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, `"topic":"test"`) {
+		t.Errorf("expected resolve_topic args, got %s", result)
+	}
+}
+
+func TestNonKimiModel_ForcedToolChoice(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"resolve_topic","arguments":"{\"topic\":\"test\"}"}}]}}],"usage":{"total_tokens":100}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "qwen3.6-flash", 30, 4096, false, 30)
+	_, _, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "analyze"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic", Description: "test", Parameters: nil}}},
+		"resolve_topic", 0.1,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	json.Unmarshal(capturedBody, &parsed)
+
+	tc, ok := parsed["tool_choice"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tool_choice to be object for non-kimi model, got %T", parsed["tool_choice"])
+	}
+	if tc["type"] != "function" {
+		t.Errorf("expected tool_choice.type=function, got %v", tc["type"])
+	}
+	fn := tc["function"].(map[string]interface{})
+	if fn["name"] != "resolve_topic" {
+		t.Errorf("expected tool_choice.function.name=resolve_topic, got %v", fn["name"])
+	}
+}
+
+func TestKimiToolChoice_AllRetriesFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"tool_calls":[]}}],"usage":{"total_tokens":10}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	_, _, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "analyze"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic", Description: "test", Parameters: nil}}},
+		"resolve_topic", 0.1,
+	)
+	if err == nil {
+		t.Fatal("expected error when all retries fail")
+	}
+}
+
+func TestCallWithTools_ReasoningFieldGatewayProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"tool_calls":[],"reasoning":"long reasoning via gateway proxy..."}}],"usage":{"total_tokens":100}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	_, _, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "analyze"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic", Description: "test", Parameters: nil}}},
+		"resolve_topic", 0.1,
+	)
+	if err == nil {
+		t.Fatal("expected error when reasoning field (gateway proxy variant) consumed budget")
+	}
+	if !strings.Contains(err.Error(), "reasoning consumed entire max_tokens budget") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestCallMap_PropagatesReasoningBudgetError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"content":"","reasoning_content":"very long reasoning..."}}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	_, _, err := client.CallMap(
+		context.Background(),
+		"[1] user1: hello\n[2] user2: world",
+		"test-source", 0, 2,
+		"2024-01-01 00:00", "2024-01-01 23:59",
+		"test topic", "testuser",
+	)
+	if err == nil {
+		t.Fatal("expected error to propagate for reasoning budget exhaustion")
+	}
+	if !strings.Contains(err.Error(), "reasoning budget exhausted") {
+		t.Errorf("expected reasoning budget error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "Kimi") || strings.Contains(err.Error(), "kimi") {
+		t.Errorf("error message should not contain model name, got: %v", err)
+	}
+}
+
+func TestCallMap_PropagatesTokenLimitError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[{"message":{"content":""},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	_, _, err := client.CallMap(
+		context.Background(),
+		"[1] user1: hello",
+		"test-source", 0, 1,
+		"2024-01-01 00:00", "2024-01-01 23:59",
+		"test topic", "testuser",
+	)
+	if err == nil {
+		t.Fatal("expected error to propagate for token limit exhaustion")
+	}
+	if !strings.Contains(err.Error(), "reasoning budget exhausted") {
+		t.Errorf("expected reasoning budget exhausted error, got: %v", err)
+	}
+}
+
+func TestCallMap_TransientErrorFallsBackToMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`internal server error`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "tencent/kimi-k2.6", 5, 4096, false, 5)
+	result, _, err := client.CallMap(
+		context.Background(),
+		"[1] user1: hello",
+		"test-source", 3, 1,
+		"2024-01-01 00:00", "2024-01-01 23:59",
+		"test topic", "testuser",
+	)
+	if err != nil {
+		t.Fatalf("transient errors should fall back to marker, got error: %v", err)
+	}
+	if !strings.Contains(result, MapFailedMarker) {
+		t.Errorf("expected marker string in result, got: %s", result)
+	}
+}

--- a/internal/service/llm_test.go
+++ b/internal/service/llm_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 )
 
@@ -15,9 +14,9 @@ func TestChatTemplateKwargs_QwenWithThinkingDisabled(t *testing.T) {
 		Temperature: 0.3,
 		MaxTokens:   client.maxTokens,
 	}
-	if !client.enableThinking && (strings.Contains(client.model, "qwen3.6") || strings.Contains(client.model, "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := client.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -29,11 +28,11 @@ func TestChatTemplateKwargs_QwenWithThinkingDisabled(t *testing.T) {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 
-	kwargs, ok := parsed["chat_template_kwargs"]
+	kwargs2, ok := parsed["chat_template_kwargs"]
 	if !ok {
 		t.Fatal("expected chat_template_kwargs in request body for qwen model")
 	}
-	kwargsMap, ok := kwargs.(map[string]interface{})
+	kwargsMap, ok := kwargs2.(map[string]interface{})
 	if !ok {
 		t.Fatal("chat_template_kwargs is not a map")
 	}
@@ -51,9 +50,9 @@ func TestChatTemplateKwargs_DeepseekV4WithThinkingDisabled(t *testing.T) {
 		Temperature: 0.3,
 		MaxTokens:   client.maxTokens,
 	}
-	if !client.enableThinking && (strings.Contains(client.model, "qwen3.6") || strings.Contains(client.model, "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := client.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -65,11 +64,11 @@ func TestChatTemplateKwargs_DeepseekV4WithThinkingDisabled(t *testing.T) {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 
-	kwargs, ok := parsed["chat_template_kwargs"]
+	kwargs2, ok := parsed["chat_template_kwargs"]
 	if !ok {
 		t.Fatal("expected chat_template_kwargs in request body for deepseek-v4 model")
 	}
-	kwargsMap, ok := kwargs.(map[string]interface{})
+	kwargsMap, ok := kwargs2.(map[string]interface{})
 	if !ok {
 		t.Fatal("chat_template_kwargs is not a map")
 	}
@@ -87,9 +86,9 @@ func TestChatTemplateKwargs_DeepseekV4WithThinkingEnabled(t *testing.T) {
 		Temperature: 0.3,
 		MaxTokens:   client.maxTokens,
 	}
-	if !client.enableThinking && (strings.Contains(client.model, "qwen3.6") || strings.Contains(client.model, "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := client.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -115,9 +114,9 @@ func TestChatTemplateKwargs_ClaudeModel(t *testing.T) {
 		Temperature: 0.3,
 		MaxTokens:   client.maxTokens,
 	}
-	if !client.enableThinking && (strings.Contains(client.model, "qwen3.6") || strings.Contains(client.model, "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := client.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -143,9 +142,9 @@ func TestChatTemplateKwargs_QwenWithThinkingEnabled(t *testing.T) {
 		Temperature: 0.3,
 		MaxTokens:   client.maxTokens,
 	}
-	if !client.enableThinking && (strings.Contains(client.model, "qwen3.6") || strings.Contains(client.model, "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kwargs := client.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
@@ -173,9 +172,9 @@ func TestChatTemplateKwargs_CallWithTools_Qwen(t *testing.T) {
 		Tools:       []Tool{{Type: "function", Function: ToolFunction{Name: "test", Description: "test", Parameters: nil}}},
 		ToolChoice:  ToolChoice{Type: "function", Function: ToolChoiceFunction{Name: "test"}},
 	}
-	if !client.enableThinking && (strings.Contains(client.model, "qwen3.6") || strings.Contains(client.model, "deepseek-v4")) {
-		reqBody.ChatTemplateKwargs = map[string]interface{}{"enable_thinking": false}
-	}
+	thinking, kw := client.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kw
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -383,6 +383,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		summary string
 		tokens  int
 		failed  bool
+		fatal   bool
 	}
 
 	concurrency := p.cfg.WorkerMapConcurrency
@@ -421,7 +422,8 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 			)
 			if err != nil {
 				log.Printf("[personal-worker] Map chunk %d failed: %v", idx, err)
-				results[idx] = chunkResult{failed: true}
+				isFatal := strings.Contains(err.Error(), "reasoning budget exhausted")
+				results[idx] = chunkResult{failed: true, fatal: isFatal}
 			} else {
 				results[idx] = chunkResult{summary: summary, tokens: tokens}
 			}
@@ -433,6 +435,17 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 
 	if ctx.Err() != nil {
 		return "", nil, 0, 0, "", fmt.Errorf("map phase cancelled: %w", ctx.Err())
+	}
+
+	var fatalChunks []int
+	for i, r := range results {
+		if r.fatal {
+			fatalChunks = append(fatalChunks, i)
+		}
+	}
+	if len(fatalChunks) > 0 {
+		return "", nil, 0, 0, "", fmt.Errorf(
+			"Map phase aborted: reasoning budget exhausted on chunk(s) %v", fatalChunks)
 	}
 
 	var chunkSummaries []string


### PR DESCRIPTION
## Summary

Add support for Kimi K2.6 model with thinking/reasoning mode handling.

## Changes

- **Thinking disabled**: Send `thinking: {type: "disabled"}` for Kimi models to prevent reasoning tokens from consuming the completion budget
- **Temperature constraint**: Kimi K2.6 only accepts `temperature=0.6`; override caller-specified values automatically
- **Tool calling**: Use `tool_choice: "auto"` instead of forced function call (Kimi API limitation) with function name validation + retry
- **Empty content detection**: Return explicit error when reasoning consumes entire `max_tokens` budget (instead of misleading fallback text)
- **Model detection**: Add `IsKimiModel()` / `IsQwenOrDeepSeekModel()` helpers in `model_detect.go`
- **Config**: Add `kimi-k2` to `modelMaxTokensDefaults` (150K) and CJK chars-per-token=2 fallback
- **Refactor**: Extract `buildThinkingConfig()` to unify thinking parameter handling across Kimi/Qwen/DeepSeek

## Testing

- Added `llm_kimi_test.go` with Kimi-specific tests covering thinking config, temperature override, tool choice, empty content detection
- Updated existing `llm_test.go` and `config_test.go`
- All tests pass, build clean

Closes #2