### PR TITLE
fix: use pull_request_target for fork secret access

### DIFF
--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -4,9 +4,11 @@ on:
   pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
 
+permissions: {}  # GITHUB_TOKEN not used; lock down to minimum
+
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@c6c51348fccac99161166dce1b52dec1063aeea2
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,7 +1,7 @@
 name: Octo PR Feed
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, closed, reopened, ready_for_review, review_requested]
 
 jobs:


### PR DESCRIPTION
## Fix: `octo-pr-feed` fork secret access (Codex Review P2)

### Problem
Workflows triggered by `pull_request` from **forked repositories** do not receive repository secrets. This means `OCTO_BOT_TOKEN` is unavailable, and every external contributor's PR triggers a failed workflow run.

### Fix
Changed trigger from `pull_request` → `pull_request_target`.

This is safe because:
- The workflow only reads event payload metadata (PR title, author, URL)
- No PR code is checked out
- `pull_request_target` runs in the context of the base branch, giving access to secrets

Applied to all 8 repos.