### PR TITLE
ci: improve GitHub Actions workflows for octo-smart-summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.21'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build
+        run: CGO_ENABLED=0 go build -v ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Test
+        run: go test -race -count=1 -timeout 5m ./...
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Vet
+        run: go vet ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.5
+          args: --timeout=5m

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -17,6 +17,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
+
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch


### PR DESCRIPTION
## Changes

### A4: Add CI workflow for Go 1.21 project

Added `.github/workflows/ci.yml` with build, test, vet, and lint jobs:
- Triggers on push/PR to `main`
- Go version: 1.21
- `build`: `CGO_ENABLED=0 go build -v ./...`
- `test` (after build): `go test -race -count=1 -timeout 5m ./...`
- `vet`: `go vet ./...`
- `lint`: golangci-lint v1.64.5 with `--timeout=5m`

### D: Add `permissions: {}` to `pr-merged-done.yml`

Adds explicit `permissions: {}` block between `on:` and `jobs:` to clarify that `GITHUB_TOKEN` is not used; only `PROJECT_TOKEN` is passed explicitly.