### PR TITLE
ci: add auto-add-to-project workflow

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,19 @@
+name: Auto-add to Octo Board
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+# GITHUB_TOKEN not used; PROJECT_TOKEN (PAT) is used instead
+permissions: {}
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
+        with:
+          project-url: https://github.com/orgs/Mininglamp-OSS/projects/2
+          github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Add `auto-add-to-project.yml` workflow: automatically adds new issues and PRs to [Octo Board (Project #2)](https://github.com/orgs/Mininglamp-OSS/projects/2) when they are opened.

## Why

Previously this was only handled for the `.github` repo itself. This extends coverage to all org repositories.

## Details

- Trigger: `issues: [opened]` + `pull_request_target: [opened]`
- Action: `actions/add-to-project@v1.0.2` (pinned commit hash)
- Requires: `PROJECT_TOKEN` org secret (already configured)
- `permissions: {}` — GITHUB_TOKEN not used