### PR TITLE
chore: add CODEOWNERS with maintainers team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS — unified team ownership
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @Mininglamp-OSS/maintainers


### PR DESCRIPTION
## What

Add `.github/CODEOWNERS` referencing `@Mininglamp-OSS/maintainers` as the default code owner.

## Why

This repo has no CODEOWNERS file, which means the `require_code_owner_review` setting in branch protection rulesets has no effect. Adding CODEOWNERS enables enforced code owner review for all PRs.

This is part of an org-wide effort to unify CODEOWNERS across all Mininglamp-OSS repositories.

## How

Add a single default rule: `* @Mininglamp-OSS/maintainers`. The team has admin permission on this repo and includes: Jerry-Xin, yujiawei, an9xyz, lml2468.

## Checklist

- [x] Self-reviewed the full diff from a reviewer's perspective
- [x] Rebased onto latest `main`
- [x] Commit messages follow Conventional Commits

## Testing

N/A — configuration-only change. Verified `@Mininglamp-OSS/maintainers` team exists and has admin permission via GitHub API.

## Breaking Changes

N/A