### PR TITLE
ci: build and publish multi-arch Docker images to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,278 @@
+name: Docker Publish
+
+# Publishes the api + worker images as a pair to Docker Hub on every v* tag
+# push. Both images come out of the same source revision, so they share one
+# run, one approval gate, and one concurrency lock.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish. Must match Docker tag grammar ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$, must NOT look like a semver alias (1, 1.2, v1.2.3, ...), and from non-default branches must be prefixed with "test-".'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize ALL publishes to this repo's images so two close-together v*
+  # tags can't race on the shared mutable tags (:latest, :MAJOR,
+  # :MAJOR.MINOR). One group covers both api and worker because a single
+  # tag push releases them together.
+  #
+  # KNOWN TRADEOFF: GitHub Actions concurrency holds at most ONE pending run
+  # per group; a newer pending run replaces the older one even with
+  # `cancel-in-progress: false`. So if you push v1.0.0 (running), v1.0.1
+  # (queued), v1.0.2 (queued) in quick succession, v1.0.1 will be canceled
+  # by v1.0.2 and never publish. Workaround: wait for each release to finish
+  # publishing before pushing the next tag.
+  #
+  # NOTE: workflow-level concurrency.group only accepts github/inputs/vars
+  # contexts (not env), so the prefix is hard-coded here.
+  group: docker-publish-mininglamposs-octo-smart-summary
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    # No-secret preflight: rejects bad inputs/refs BEFORE any job that holds
+    # Docker Hub credentials runs. Catches command-injection attempts,
+    # invalid Docker tag grammar, semver-alias clobbering, and manual
+    # publishes from unreviewed refs — all before any registry write.
+    name: Validate inputs and ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag push ref
+        if: github.event_name == 'push'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          # Require strict semver per semver.org §9 (with mandatory leading 'v')
+          # so metadata-action's type=semver actually matches. A loose regex
+          # would let near-semver refs (e.g. 'vfoo', 'v01.2.3', 'v1.2.3-01',
+          # 'v1.2.3-..', 'v1.2.3+build..meta') reach the secret-bearing build
+          # job and push orphan digests before metadata-action quietly emits
+          # no tags — defeating the no-secret preflight intent.
+          #
+          # The regex below is the official semver.org regex (BRE/ERE form),
+          # prefixed with a literal 'v'. It rejects:
+          #   - leading zeros in numeric identifiers (v01.2.3, v1.2.3-01)
+          #   - empty dot-separated identifiers (v1.2.3-.. , v1.2.3+a..b)
+          #   - characters outside [0-9A-Za-z.+-]
+          tag="${REF#refs/tags/}"
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          if ! printf '%s' "$tag" | grep -Eq "$semver"; then
+            echo "::error::tag '$tag' is not strict semver per semver.org (vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]); refusing to publish"
+            exit 1
+          fi
+          echo "OK: $REF"
+
+      - name: Validate workflow_dispatch input and ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # Docker image tag grammar (also blocks shell metacharacters as a
+          # side effect — only [A-Za-z0-9_.-] are allowed and length <= 128).
+          if ! printf '%s' "$INPUT_TAG" | grep -Eq '^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$'; then
+            echo "::error::tag '$INPUT_TAG' violates Docker tag grammar ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$"
+            exit 1
+          fi
+
+          # Reserved auto-managed names — manual dispatch must not clobber them.
+          case "$INPUT_TAG" in
+            latest|main|master)
+              echo "::error::tag '$INPUT_TAG' is reserved/auto-managed; pick a different name"
+              exit 1
+              ;;
+          esac
+
+          # Semver-alias shapes (e.g. 1, 1.2, 1.2.3, v1.2.3) are reserved for
+          # the auto-managed major / major.minor / major.minor.patch / version
+          # aliases populated by tag-push events. A manual dispatch with
+          # these shapes would race with / overwrite the next real release.
+          if printf '%s' "$INPUT_TAG" | grep -Eq '^v?[0-9]+(\.[0-9]+){0,2}([+-].+)?$'; then
+            echo "::error::tag '$INPUT_TAG' looks like a semver alias; manual publishes must use a non-semver name (or prefix with 'test-')"
+            exit 1
+          fi
+
+          # Restrict manual publishes from non-default branches to the
+          # 'test-' namespace so feature-branch experimentation cannot land
+          # in the official release tag space. Read the default branch from
+          # repository metadata so a future rename doesn't silently weaken
+          # this guard.
+          DEFAULT_REF="refs/heads/${DEFAULT_BRANCH}"
+          if [ "$REF" != "$DEFAULT_REF" ]; then
+            case "$INPUT_TAG" in
+              test-*) echo "OK: non-default ref '$REF' with test- prefix" ;;
+              *)
+                echo "::error::manual publishes from '$REF' must use a 'test-*' tag (got '$INPUT_TAG'); merge to ${DEFAULT_BRANCH} for official tags"
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "OK: dispatch from $REF with tag '$INPUT_TAG'"
+
+  build:
+    # Matrix dimension: 2 images × 2 architectures = 4 parallel build jobs.
+    # Each emits a single-arch digest-only image to Docker Hub; the merge
+    # job assembles the multi-arch manifest per image.
+    name: Build ${{ matrix.image }} ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    needs: validate
+    # `docker-hub-publish` environment gates the Docker Hub credentials:
+    #   - required reviewers (Mininglamp-OSS/maintainers team)
+    #   - deployment ref allowlist: refs/heads/main, refs/tags/v*
+    # No DOCKERHUB_* secret reaches a runner until a maintainer approves
+    # the run in the Actions UI.
+    environment: docker-hub-publish
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - { name: octo-smart-summary-api,    dockerfile: Dockerfile.api }
+          - { name: octo-smart-summary-worker, dockerfile: Dockerfile.worker }
+        platform:
+          - { id: linux/amd64, runner: ubuntu-latest,     arch: amd64 }
+          - { id: linux/arm64, runner: ubuntu-24.04-arm,  arch: arm64 }
+    env:
+      IMAGE_REF: mininglamposs/${{ matrix.image.name }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform.id }}
+          outputs: type=image,name=${{ env.IMAGE_REF }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docker-publish-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=docker-publish-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          # Disable provenance attestation so the final manifest list doesn't
+          # carry an extra "unknown/unknown" platform entry that confuses some
+          # registry UIs and scanners.
+          provenance: false
+
+      - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${BUILD_DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # One merge job per image; both run after all 4 build jobs finish.
+    name: Merge multi-arch manifest for ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build
+    # Same gate as `build` — manifest creation also needs Docker Hub creds.
+    # The single approval at the start of the run covers all jobs.
+    environment: docker-hub-publish
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - octo-smart-summary-api
+          - octo-smart-summary-worker
+    env:
+      IMAGE_REF: mininglamposs/${{ matrix.image }}
+    steps:
+      - name: Download digests for this image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE_REF }}
+          # `flavor: latest=auto` is the metadata-action default, set explicitly
+          # so the prerelease-skipping behavior is visible without consulting
+          # action docs. With latest=auto + a {{version}} semver tag entry,
+          # `:latest` is published for stable releases (v1.2.3) and skipped
+          # for prereleases (v1.2.3-rc1).
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ env.IMAGE_REF }}
+          METADATA: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          # Build "-t TAG" args as an array — never interpolate tags into the
+          # shell command line, which would be a command-injection vector
+          # if metadata-action ever emitted a tag containing shell syntax.
+          tags=()
+          while IFS= read -r tag; do
+            tags+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$METADATA")
+
+          if [ ${#tags[@]} -eq 0 ]; then
+            echo "::error::metadata-action produced no tags; refusing to publish manifest"
+            exit 1
+          fi
+
+          # Digest filenames in /tmp/digests are SHA-256 hex strings (validated
+          # by upload-artifact's if-no-files-found:error and the controlled
+          # filename derived from build.outputs.digest), safe to feed in.
+          sources=()
+          for f in *; do
+            sources+=("${IMAGE}@sha256:${f}")
+          done
+
+          docker buildx imagetools create "${tags[@]}" "${sources[@]}"
+
+      - name: Inspect image
+        env:
+          IMAGE: ${{ env.IMAGE_REF }}
+          PRIMARY_TAG: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE}:${PRIMARY_TAG}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,19 +53,28 @@ jobs:
           # Require strict semver per semver.org §9 (with mandatory leading 'v')
           # so metadata-action's type=semver actually matches. A loose regex
           # would let near-semver refs (e.g. 'vfoo', 'v01.2.3', 'v1.2.3-01',
-          # 'v1.2.3-..', 'v1.2.3+build..meta') reach the secret-bearing build
-          # job and push orphan digests before metadata-action quietly emits
-          # no tags — defeating the no-secret preflight intent.
+          # 'v1.2.3-..') reach the secret-bearing build job and push orphan
+          # digests before metadata-action quietly emits no tags — defeating
+          # the no-secret preflight intent.
           #
           # The regex below is the official semver.org regex (BRE/ERE form),
-          # prefixed with a literal 'v'. It rejects:
+          # prefixed with a literal 'v' and WITHOUT the optional +BUILD
+          # metadata suffix. Build metadata is rejected because
+          # metadata-action's {{version}}/{{major}}/{{major}}.{{minor}}
+          # patterns strip the +BUILD portion when computing Docker tag
+          # names, so v1.2.3 and v1.2.3+build.1 would both publish to
+          # :1.2.3 / :1.2 / :1 / :latest — two distinct git tags clobbering
+          # the same release aliases, breaking the no-clobber invariant.
+          #
+          # Rejects:
           #   - leading zeros in numeric identifiers (v01.2.3, v1.2.3-01)
-          #   - empty dot-separated identifiers (v1.2.3-.. , v1.2.3+a..b)
-          #   - characters outside [0-9A-Za-z.+-]
+          #   - empty dot-separated identifiers (v1.2.3-..)
+          #   - any +BUILD metadata (v1.2.3+build.1)
+          #   - characters outside [0-9A-Za-z.-]
           tag="${REF#refs/tags/}"
-          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?$'
           if ! printf '%s' "$tag" | grep -Eq "$semver"; then
-            echo "::error::tag '$tag' is not strict semver per semver.org (vMAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]); refusing to publish"
+            echo "::error::tag '$tag' is not strict semver per semver.org without +BUILD metadata (vMAJOR.MINOR.PATCH[-PRERELEASE]); refusing to publish"
             exit 1
           fi
           echo "OK: $REF"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -125,8 +125,14 @@ jobs:
     # Matrix dimension: 2 images × 2 architectures = 4 parallel build jobs.
     # Each emits a single-arch digest-only image to Docker Hub; the merge
     # job assembles the multi-arch manifest per image.
-    name: Build ${{ matrix.image }} ${{ matrix.platform }}
-    runs-on: ${{ matrix.runner }}
+    #
+    # SHAPE CONTRACT: `matrix.image` is an OBJECT here (with .name + .dockerfile)
+    # to keep the dockerfile path adjacent to the image name. The merge job
+    # below uses a SCALAR image matrix (just the name). Both shapes
+    # independently produce the same image-name string at the artifact /
+    # cache-scope boundary — keep them in sync if you ever rename keys here.
+    name: Build ${{ matrix.image.name }} ${{ matrix.platform.id }}
+    runs-on: ${{ matrix.platform.runner }}
     needs: validate
     # `docker-hub-publish` environment gates the Docker Hub credentials:
     #   - required reviewers (Mininglamp-OSS/maintainers team)


### PR DESCRIPTION
## Summary

Add a hardened `docker-publish.yml` workflow that publishes both `api` and `worker` images as a pair to Docker Hub on every `v*` tag push. Same security model and defenses as the workflows in [`octo-server#72`](https://github.com/Mininglamp-OSS/octo-server/pull/72) and [`octo-matter#18`](https://github.com/Mininglamp-OSS/octo-matter/pull/18), adapted for this repo's two-image layout.

## Images published

- `mininglamposs/octo-smart-summary-api` (from `Dockerfile.api`)
- `mininglamposs/octo-smart-summary-worker` (from `Dockerfile.worker`)

Both are multi-arch (`linux/amd64` + `linux/arm64`), produced from the same source revision in a single workflow run.

## Architecture

- **2 × 2 build matrix** (images × archs) on native runners (`ubuntu-latest` + `ubuntu-24.04-arm`) — no QEMU
- **Push-by-digest** per arch → **per-image merge** into multi-arch manifest list
- 4 parallel build jobs → 2 merge jobs

## Hardening (same baseline as sibling repos)

- All third-party actions pinned to commit SHAs
- **No-secret `validate` job** runs first; `build` and `merge` declare `needs: validate`
  - Tag push: strict semver per semver.org §9 (with leading `v`)
  - `workflow_dispatch`: Docker tag grammar + reserved-name + semver-alias-shape + non-default-branch `test-*` namespace
- **Command-injection-safe shell**: every external input via `env:`, `imagetools` args built as bash arrays
- **`docker-hub-publish` GitHub Environment** gate (already configured in repo settings):
  - Required reviewer: `Mininglamp-OSS/maintainers` team
  - Deployment ref allowlist: `main` branch + `v*` tags
- **Per-image per-arch GHA cache scope** (`docker-publish-IMAGE-ARCH`)
- `provenance: false` (no `unknown/unknown` manifest entries)
- Concurrency block documents the GitHub 1-pending-run queue-depth tradeoff

## Decisions made

- **Docker Hub only**, not GHCR — matches the OSS publishing strategy in sibling repos
- **Single workflow with matrix**, not two separate workflows — same source, same release, shared approval gate
- **One concurrency group** covers both images — they release together, no need for independent locks

## Prerequisites

- Org-level secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (already provisioned for `Mininglamp-OSS`)
- Repo environment `docker-hub-publish` with required-reviewers + ref allowlist (configured)

## Test plan (run after merge to main)

> Testing on this PR branch is intentionally blocked by the environment policy. All scenarios must run from `main` after merge.

- [ ] **Env gate** — From `main`, dispatch with `tag=test-env-gate-$(date +%s)`. Run pauses at `build` jobs with "Waiting for review"; proceeds after a maintainer approves.
- [ ] **Both images published** — Inspect both `mininglamposs/octo-smart-summary-api:<tag>` and `mininglamposs/octo-smart-summary-worker:<tag>`; each shows both `linux/amd64` and `linux/arm64`, no `unknown/unknown`.
- [ ] **Semver preflight rejects junk** — temporarily push `vfoo` (or `v01.2.3`); validate fails before any Docker Hub login. Delete tag after.
- [ ] **Prerelease skip-:latest** — push `v0.0.1-rc1`; confirm only `:0.0.1-rc1` on both images (no `:latest`/`:0`/`:0.0`).
- [ ] **Branch dispatch rejected** — try to dispatch from any non-main branch; environment policy should block.
- [ ] **Reserved-name guard** — dispatch input `latest` (or `1.2`); validate should fail.