### PR TITLE
feat(ci): refine CI + add stale and PR labeler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,18 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
 
 permissions:
   contents: read
@@ -18,6 +27,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +39,7 @@ jobs:
         run: CGO_ENABLED=0 go build -v ./...
 
   test:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Test
     runs-on: ubuntu-latest
     needs: build
@@ -41,6 +52,7 @@ jobs:
         run: go test -race -count=1 -timeout 5m ./...
 
   vet:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Vet
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +64,7 @@ jobs:
         run: go vet ./...
 
   lint:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-labeler.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+    permissions:
+      issues: write
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,15 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  # pull_request_target runs in the context of the base repo and retains write
+  # access even for fork PRs — required because the reusable labeler calls the
+  # GitHub REST API to set labels and post comments (both need write tokens).
+  #
+  # Security: this workflow does NOT check out or execute any code from the PR
+  # branch; it only passes the PR number / owner / repo name to a reusable
+  # workflow that performs only API calls against the base repo. This matches
+  # the pattern used by auto-add-to-project.yml and octo-pr-feed.yml.
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
     types: [opened, synchronize, reopened]
 
 permissions: {}
@@ -16,4 +24,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    secrets: inherit
+    # secrets: intentionally omitted — reusable-pr-labeler.yml uses only the
+    # inherited GITHUB_TOKEN granted via the job-level permissions above.
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
## Changes

- **ci.yml**: draft PRs are now skipped; docs/markdown-only changes no longer trigger full CI
- **stale.yml**: four-lane stale management (unassigned/assigned × issues/PRs) via shared reusable workflow
- **labeler.yml**: auto size labels (XS/S/M/L/XL) + dependency-changed detection + maintainer checklist comment

## Dependencies

Requires `Mininglamp-OSS/.github#feat/automation-p0-shared-workflows` (PR #25) to be merged first — the reusable workflows `reusable-stale.yml` and `reusable-pr-labeler.yml` must be on `main` for stale and labeler to be functional.

## Part of P0 automation rollout

Modeled after openclaw best practices.