### PR TITLE
feat(ci): add release drafter and gated release publish

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+# Release Drafter config — https://github.com/release-drafter/release-drafter
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+categories:
+  - title: "Features"
+    labels: [enhancement, feature]
+  - title: "Bug Fixes"
+    labels: [bug, fix]
+  - title: "CI and Infrastructure"
+    labels: [ci, infra, dependencies-changed]
+  - title: "Documentation"
+    labels: [documentation, docs]
+exclude-labels: [skip-changelog]
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  draft:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-drafter.yml@main
+    permissions:
+      contents: write
+      pull-requests: read

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,31 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.4.0)"
+        required: true
+        type: string
+      validate_run_id:
+        description: "Required: successful CI run ID from the tagged commit as release evidence"
+        required: true
+        type: string
+      draft:
+        description: "Keep as draft instead of publishing"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  publish:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-publish.yml@main
+    with:
+      tag: ${{ inputs.tag }}
+      validate_run_id: ${{ inputs.validate_run_id }}
+      draft: ${{ inputs.draft }}
+    permissions:
+      contents: write
+      actions: read


### PR DESCRIPTION
## Changes

### `release-drafter.yml` (new)
Automatically maintains a GitHub Release draft as PRs merge to main.
- Triggers on every push to main + manual dispatch
- Delegates to shared reusable workflow in .github repo
- Uses per-repo `.github/release-drafter.yml` config

### `release-publish.yml` (new)
Gate-controlled manual release publisher via workflow_dispatch.
Inputs: tag (required), validate_run_id (optional CI gate), draft flag.

### `.github/release-drafter.yml` (new)
Release drafter category config (Features / Bug Fixes / CI & Infrastructure / Documentation).

## Merge order
Requires Mininglamp-OSS/.github PR #27 merged first.

## Part of P1 automation rollout