### PR TITLE
chore(ci): standardize reusable workflow refs to @main

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -11,6 +11,6 @@ permissions: {}
 
 jobs:
   add-to-project:
-    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@v1
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -8,4 +8,4 @@ jobs:
   welcome:
     permissions:
       issues: write
-    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@v1
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@main

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@v1
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@main
     with:
       repo_name: ${{ github.event.workflow_run.repository.name }}
       workflow_name: ${{ github.event.workflow_run.name }}

--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@v2
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
     with:
       repo_name: ${{ github.event.repository.name }}
       issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -8,7 +8,7 @@ permissions: {}  # GITHUB_TOKEN not used; lock down to minimum
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@v1
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@main
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

All reusable workflow references in this repo previously pointed to `@v1`, `@v2`, or a raw commit SHA for centrally-maintained workflows from `Mininglamp-OSS/.github`. This PR standardizes them all to `@main`.

## Why @main?

- **Zero tag maintenance** — no need to manually bump @v1/@v2 after every .github update
- **Consistency** — newer workflows (reusable-stale, reusable-codeql, reusable-pr-labeler, etc.) already use `@main`
- **Safe** — `Mininglamp-OSS/.github` main is always reviewed before merge; breaking changes are caught by Workflow Sanity CI

## Changed files

All `.github/workflows/*.yml` that reference `Mininglamp-OSS/.github` reusable workflows.