### PR TITLE
fix(ci): use issues: write permission for PR welcome comments

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -16,4 +16,4 @@ jobs:
   welcome:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
     permissions:
-      pull-requests: write
+      issues: write

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -17,3 +17,4 @@ jobs:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
     permissions:
       issues: write
+      pull-requests: write


### PR DESCRIPTION
## Problem

The `pr-contributor-welcome.yml` caller that landed in a previous PR declared `permissions: pull-requests: write`, but PR comments are created via the GitHub Issues API (`issues.createComment`) which requires `issues: write`.

Caught by Jerry-Xin in Mininglamp-OSS/octo-adapters#53. Reusable workflow fix: Mininglamp-OSS/.github#33.

## Fix

`pull-requests: write` → `issues: write` in the caller job permissions.