### PR TITLE
fix: align release-drafter labels with type:* naming convention

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,12 +9,12 @@ template: |
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
   - title: "Features"
-    labels: [enhancement, feature]
+    labels: [type:feature]
   - title: "Bug Fixes"
-    labels: [bug, fix]
+    labels: [type:bug]
   - title: "CI and Infrastructure"
-    labels: [ci, infra, dependencies-changed, dependencies]
+    labels: [type:chore, dependencies-changed]
   - title: "Documentation"
-    labels: [documentation, docs]
+    labels: [type:docs]
 exclude-labels: [skip-changelog]
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,12 +9,12 @@ template: |
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
   - title: "Features"
-    labels: [type:feature]
+    labels: ["type:feature"]
   - title: "Bug Fixes"
-    labels: [type:bug]
+    labels: ["type:bug"]
   - title: "CI and Infrastructure"
-    labels: [type:chore, dependencies-changed]
+    labels: ["type:chore", dependencies-changed, dependencies]
   - title: "Documentation"
-    labels: [type:docs]
+    labels: ["type:docs"]
 exclude-labels: [skip-changelog]
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"


### PR DESCRIPTION
## Problem

`release-drafter.yml` references bare labels (`enhancement`, `feature`, `bug`, `fix`, `documentation`, `docs`) that do not exist on this repo. The actual labels use the `type:` prefix (`type:feature`, `type:bug`, `type:docs`, `type:chore`).

Result: PRs with the correct `type:*` labels are not categorized in release notes.

## Fix

- `[enhancement, feature]` → `[type:feature]`
- `[bug, fix]` → `[type:bug]`
- `[documentation, docs]` → `[type:docs]`
- `[ci, infra, dependencies-changed, dependencies]` → `[type:chore, dependencies-changed]`

## Context

Part of org-wide label scheme alignment. Related PRs across other repos fix the same drift in issue templates and release-drafter configs.