### PR TITLE
chore: enable enforce-freshness for check-sprint

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -20,5 +20,6 @@ jobs:
     with:
       pr-number: ${{ github.event.pull_request.number }}
       repo-name: ${{ github.repository }}
+      enforce-freshness: true
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
Enable `enforce-freshness: true` to prevent merging PRs with stale Sprint check results after a sprint rollover. Part of Issue-first check-sprint rollout (B-4).