### PR TITLE
fix(pipeline): ExtractText 支持 RichText=14 避免摘要丢字 (Phase 1)

### DIFF
--- a/internal/pipeline/payload.go
+++ b/internal/pipeline/payload.go
@@ -3,15 +3,106 @@ package pipeline
 import (
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 )
 
+// richTextImagePlaceholder is injected for image blocks when assembling the
+// plain text of a RichText (type=14) message. Mirrors octo-lib's
+// common.RichTextImagePlaceholder so summaries read consistently across repos.
+const richTextImagePlaceholder = "[图片]"
+
+// richTextBlock is a single element of a RichText (type=14) content array.
+// Schema mirrors octo-lib common.RichTextBlock: a text block carries Text, an
+// image block is rendered as a placeholder in plain text.
+type richTextBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// payloadData is the decoded message payload.
+//
+// Content is kept as json.RawMessage so a RichText (type=14) payload — whose
+// content may be either an ordered block array or (for backward compatibility)
+// a plain string — can be decoded for every message type without breaking the
+// existing type==1 string path. Plain is the top-level redundant plain text the
+// server generates for RichText messages.
 type payloadData struct {
-	Type    int    `json:"type"`
-	Content string `json:"content"`
+	Type    int             `json:"type"`
+	Content json.RawMessage `json:"content"`
+	Plain   string          `json:"plain"`
+}
+
+// contentString returns the content interpreted as a JSON string. ok is false
+// when content is absent or not a JSON string (e.g. a RichText block array).
+func (d payloadData) contentString() (string, bool) {
+	if len(d.Content) == 0 {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(d.Content, &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// richTextPlain assembles the display/summary text for a RichText (type=14)
+// payload: prefer the server-generated top-level plain; otherwise traverse the
+// content block array (text blocks contribute their text, image blocks inject
+// the [图片] placeholder); finally fall back to a string content for backward
+// compatibility with the legacy string-content path.
+func (d payloadData) richTextPlain() string {
+	if strings.TrimSpace(d.Plain) != "" {
+		return d.Plain
+	}
+	if len(d.Content) > 0 {
+		var blocks []richTextBlock
+		if err := json.Unmarshal(d.Content, &blocks); err == nil {
+			var b strings.Builder
+			for _, blk := range blocks {
+				switch blk.Type {
+				case "image":
+					b.WriteString(richTextImagePlaceholder)
+				default:
+					// text block, or unknown type carrying text (forward-compatible).
+					b.WriteString(blk.Text)
+				}
+			}
+			if b.Len() > 0 {
+				return b.String()
+			}
+		}
+	}
+	// Backward compatibility: legacy RichText with string content.
+	if s, ok := d.contentString(); ok {
+		return s
+	}
+	return ""
+}
+
+// extractFromData pulls the summary text out of a decoded payload.
+//   - type==1 (text): return the string content;
+//   - type==14 (RichText / 图文混排): return the assembled plain text;
+//   - otherwise: ("", false).
+func extractFromData(data payloadData) (string, bool) {
+	switch data.Type {
+	case 1:
+		if s, ok := data.contentString(); ok && s != "" {
+			return s, true
+		}
+		return "", false
+	case 14:
+		if text := data.richTextPlain(); text != "" {
+			return text, true
+		}
+		return "", false
+	default:
+		return "", false
+	}
 }
 
 // ExtractText decodes a message payload (raw JSON or base64-encoded JSON).
-// Returns the text content if type == 1, otherwise returns ("", false).
+// Returns the text content for type==1 (plain text) and type==14 (RichText /
+// 图文混排); otherwise returns ("", false).
 func ExtractText(payload []byte) (string, bool) {
 	if len(payload) == 0 {
 		return "", false
@@ -20,10 +111,7 @@ func ExtractText(payload []byte) (string, bool) {
 	// Try raw JSON first
 	var data payloadData
 	if err := json.Unmarshal(payload, &data); err == nil {
-		if data.Type == 1 && data.Content != "" {
-			return data.Content, true
-		}
-		return "", false
+		return extractFromData(data)
 	}
 
 	// Try base64 decode then JSON
@@ -43,8 +131,5 @@ func ExtractText(payload []byte) (string, bool) {
 	if err := json.Unmarshal(decoded, &data); err != nil {
 		return "", false
 	}
-	if data.Type == 1 && data.Content != "" {
-		return data.Content, true
-	}
-	return "", false
+	return extractFromData(data)
 }

--- a/internal/pipeline/payload_test.go
+++ b/internal/pipeline/payload_test.go
@@ -80,3 +80,85 @@ func TestExtractText_EmptyContent(t *testing.T) {
 		t.Errorf("got %q, want empty", text)
 	}
 }
+
+// --- RichText (type=14) ---
+
+func TestExtractText_RichTextPlainOnly(t *testing.T) {
+	payload := []byte(`{"type":14,"plain":"看这张图 [图片] 不错"}`)
+	text, ok := ExtractText(payload)
+	if !ok {
+		t.Fatal("expected ok=true for type=14 with plain")
+	}
+	if text != "看这张图 [图片] 不错" {
+		t.Errorf("got %q, want %q", text, "看这张图 [图片] 不错")
+	}
+}
+
+func TestExtractText_RichTextBlocksOnly(t *testing.T) {
+	payload := []byte(`{"type":14,"content":[{"type":"text","text":"看这张图 "},{"type":"image","url":"https://x/a.png","width":10,"height":10},{"type":"text","text":" 不错"}]}`)
+	text, ok := ExtractText(payload)
+	if !ok {
+		t.Fatal("expected ok=true for type=14 with blocks")
+	}
+	if text != "看这张图 [图片] 不错" {
+		t.Errorf("got %q, want %q", text, "看这张图 [图片] 不错")
+	}
+}
+
+func TestExtractText_RichTextPlainAndBlocks(t *testing.T) {
+	// plain takes precedence over re-traversing blocks.
+	payload := []byte(`{"type":14,"plain":"权威纯文本","content":[{"type":"text","text":"忽略我"},{"type":"image","url":"https://x/a.png","width":10,"height":10}]}`)
+	text, ok := ExtractText(payload)
+	if !ok {
+		t.Fatal("expected ok=true for type=14 with plain+blocks")
+	}
+	if text != "权威纯文本" {
+		t.Errorf("got %q, want %q", text, "权威纯文本")
+	}
+}
+
+func TestExtractText_RichTextLegacyStringContent(t *testing.T) {
+	// Backward compatibility: legacy RichText whose content is a plain string.
+	payload := []byte(`{"type":14,"content":"老版本字符串内容"}`)
+	text, ok := ExtractText(payload)
+	if !ok {
+		t.Fatal("expected ok=true for type=14 with legacy string content")
+	}
+	if text != "老版本字符串内容" {
+		t.Errorf("got %q, want %q", text, "老版本字符串内容")
+	}
+}
+
+func TestExtractText_RichTextImageOnly(t *testing.T) {
+	payload := []byte(`{"type":14,"content":[{"type":"image","url":"https://x/a.png","width":10,"height":10}]}`)
+	text, ok := ExtractText(payload)
+	if !ok {
+		t.Fatal("expected ok=true for type=14 image-only block")
+	}
+	if text != "[图片]" {
+		t.Errorf("got %q, want %q", text, "[图片]")
+	}
+}
+
+func TestExtractText_RichTextEmpty(t *testing.T) {
+	payload := []byte(`{"type":14,"content":[]}`)
+	text, ok := ExtractText(payload)
+	if ok {
+		t.Fatal("expected ok=false for type=14 with empty content and no plain")
+	}
+	if text != "" {
+		t.Errorf("got %q, want empty", text)
+	}
+}
+
+func TestExtractText_RichTextBase64(t *testing.T) {
+	raw := `{"type":14,"content":[{"type":"text","text":"base64 富文本"},{"type":"image","url":"https://x/a.png","width":10,"height":10}]}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(raw))
+	text, ok := ExtractText([]byte(encoded))
+	if !ok {
+		t.Fatal("expected ok=true for base64 type=14")
+	}
+	if text != "base64 富文本[图片]" {
+		t.Errorf("got %q, want %q", text, "base64 富文本[图片]")
+	}
+}


### PR DESCRIPTION
## Summary
`internal/pipeline/payload.go ExtractText` only handled `type==1`, so RichText (`type==14`, 图文混排) messages returned `ok=false` and were dropped by `fetch.go`'s `if !ok { continue }` — their text never reached the LLM summary list.

## Changes
- `payloadData`: `content` is now `json.RawMessage` (so it can be either a block array or a legacy string) and a top-level `plain` field is added.
- `ExtractText`: new `type==14` branch — prefer the server-generated top-level `plain`; otherwise traverse the `content` block array (`{type:text}` blocks append their text, `{type:image}` blocks inject the `[图片]` placeholder); falls back to a legacy string `content` for backward compatibility.
- Block schema (`text`/`image`, `[图片]` placeholder) mirrors octo-lib `common.RichTextBlock` / `BuildRichTextPlain` (octo-lib is not a dependency here, so the traversal is implemented minimally in-repo).
- `type==1` and the legacy string-content path are unchanged.

## Tests
Added `type=14` unit tests: plain-only / blocks-only / both (plain wins) / legacy string content / image-only / empty / base64.

## Verification
- `go build ./...` ✅
- `go vet ./internal/pipeline/` ✅
- `go test ./...` ✅ (all packages green)

## Review status
- Scope: 1 source file + tests (+178/-11), no auth/schema changes
- /review: PASS ✅ (self-review on diff; backward-compatible, no trust-boundary or SQL changes)
- /codex: independent codex-review dispatched separately per dispatch (ReviewBot)

Fixes #51
