### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -75,6 +76,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -89,6 +91,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [changes]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -105,6 +108,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Vet
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -120,6 +124,7 @@ jobs:
       needs.changes.outputs.code == 'true'
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5


### PR DESCRIPTION
## What

Add `timeout-minutes` to every CI job that is missing one.

**Timeout values:**
- `changes` (path detection): **5 min**
- `build` / `vet` / `lint` / custom lint jobs: **15 min**
- `test` / `build-and-test` / `npm-test`: **30 min**

## Why

Without explicit timeouts, a stuck test or build will run until GitHub's
6-hour default kills it — wasting runner capacity and delaying feedback.

Ref: Mininglamp-OSS workflow optimization T04.
