### PR TITLE
ci: add -shuffle=on to go test for order-dependency detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Test
-        run: go test -race -count=1 -timeout 5m ./...
+        run: go test -race -shuffle=on -count=1 -timeout 5m ./...
 
   vet:
     needs: [changes]


### PR DESCRIPTION
## What

Add `-shuffle=on` flag to all `go test` invocations in CI.

## Why

`-shuffle=on` randomizes test execution order, exposing implicit ordering dependencies that cause flaky tests. This is a zero-cost quality improvement — any test that fails with shuffle enabled has a latent bug.

## Changes

Added `-shuffle=on` to `go test` commands in `.github/workflows/ci.yml`.

## Risk

None. If tests fail after this change, it reveals pre-existing hidden ordering dependencies that should be fixed.