### PR TITLE
ci: add OSV-Scanner vulnerability scanning

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,34 @@
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 4 * * 1" # Weekly Monday 04:30 UTC (12:30 CST)
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-scheduled:
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        -r
+        ./
+
+  scan-pr:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        -r
+        ./

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -30,3 +30,7 @@ jobs:
       scan-args: |-
         -r
         ./
+      # Fork PRs have read-only GITHUB_TOKEN; skip SARIF upload to avoid
+      # security-events:write permission failure. Scan still runs and
+      # results are visible in the workflow output.
+      upload-sarif: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -3,8 +3,6 @@ name: OSV-Scanner
 on:
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   push:
     branches: [main]
   schedule:
@@ -26,7 +24,7 @@ jobs:
         ./
 
   scan-pr:
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       scan-args: |-


### PR DESCRIPTION
## What
Add [OSV-Scanner](https://google.github.io/osv-scanner/) dependency vulnerability scanning.

## How
Uses Google's official reusable workflows (`v2.3.8`, SHA-pinned to `9a498708...`):
- **PR scan** (`osv-scanner-reusable-pr.yml`): incremental — only reports new vulns introduced by PR
- **Scheduled/push scan** (`osv-scanner-reusable.yml`): full scan on push to main, weekly Monday 04:30 UTC, and manual dispatch

Results uploaded as SARIF to GitHub Security > Code Scanning tab.

## Permissions
Minimal: `actions: read`, `contents: read`, `security-events: write`.

Ref: Workflow optimization task T10