### PR TITLE
feat: backend support for chat-window smart summary (origin_channel + summary templates)

### DIFF
--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -128,15 +129,16 @@ func TestAuthorizeTaskAccess_Participant(t *testing.T) {
 	}
 }
 
-func TestAuthorizeTaskAccess_GroupMember(t *testing.T) {
+func TestAuthorizeTaskAccess_GroupMemberDenied(t *testing.T) {
 	db, imDB := setupTestDBs(t)
 	taskID := seedTask(t, db, imDB)
 	h := NewTaskHandler(db, imDB, "")
 	r := setupRouter(h)
 
+	// groupmember1 is only a source-group member, neither creator nor participant → 403
 	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d", taskID), "groupmember1")
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 for group member, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for source-group member, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -194,5 +196,155 @@ func TestCancelSummary_RequiresAuth(t *testing.T) {
 	w = doRequest(r, "POST", fmt.Sprintf("/api/v1/summaries/%d/cancel", task.ID), "creator1")
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 for cancel by creator, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteSummary_GroupMemberDenied(t *testing.T) {
+	db, imDB := setupTestDBs(t)
+	taskID := seedTask(t, db, imDB)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupRouter(h)
+
+	// Source-group member must not be able to delete another user's summary.
+	w := doRequest(r, "DELETE", fmt.Sprintf("/api/v1/summaries/%d", taskID), "groupmember1")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for delete by source-group member, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCancelSummary_GroupMemberDenied(t *testing.T) {
+	db, imDB := setupTestDBs(t)
+	h := NewTaskHandler(db, imDB, "")
+
+	// Create a pending task whose source group contains groupmember1.
+	task := model.SummaryTask{
+		TaskNo:      "TST-003",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusPending,
+	}
+	db.Create(&task)
+	db.Create(&model.SummarySource{TaskID: task.ID, SourceType: model.SourceGroup, SourceID: "grp_abc"})
+	imDB.Exec("INSERT INTO group_member (group_no, uid, is_deleted) VALUES (?, ?, 0)", "grp_abc", "groupmember1")
+
+	r := setupRouter(h)
+
+	// Source-group member must not be able to cancel another user's summary.
+	w := doRequest(r, "POST", fmt.Sprintf("/api/v1/summaries/%d/cancel", task.ID), "groupmember1")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for cancel by source-group member, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// setupListTestDBs migrates the extra tables ListSummaries touches (summary_result)
+// to avoid no-such-table noise during list rendering.
+func setupListTestDBs(t *testing.T) (db *gorm.DB, imDB *gorm.DB) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open summary db: %v", err)
+	}
+	db.AutoMigrate(&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{}, &model.SummaryResult{})
+
+	imDB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	imDB.Exec("CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0)")
+
+	return db, imDB
+}
+
+func setupListRouter(h *TaskHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.GET("/api/v1/summaries", h.ListSummaries)
+	return r
+}
+
+type listResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		Total int           `json:"total"`
+		Items []interface{} `json:"items"`
+	} `json:"data"`
+}
+
+func parseListResponse(t *testing.T, w *httptest.ResponseRecorder) listResponse {
+	t.Helper()
+	var resp listResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nbody: %s", err, w.Body.String())
+	}
+	return resp
+}
+
+func seedListTask(t *testing.T, db *gorm.DB, imDB *gorm.DB) {
+	t.Helper()
+
+	task := model.SummaryTask{
+		TaskNo:      "TST-LIST-001",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	db.Create(&task)
+	db.Create(&model.SummarySource{TaskID: task.ID, SourceType: model.SourceGroup, SourceID: "grp_abc"})
+	db.Create(&model.SummaryParticipant{TaskID: task.ID, UserID: "participant1", UserName: "P1"})
+	imDB.Exec("INSERT INTO group_member (group_no, uid, is_deleted) VALUES (?, ?, 0)", "grp_abc", "groupmember1")
+}
+
+func TestListSummaries_GroupMemberSeesNothing(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedListTask(t, db, imDB)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	w := doRequest(r, "GET", "/api/v1/summaries", "groupmember1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 0 {
+		t.Errorf("expected total 0 for source-group member, got %d", resp.Data.Total)
+	}
+	if len(resp.Data.Items) != 0 {
+		t.Errorf("expected 0 items for source-group member, got %d", len(resp.Data.Items))
+	}
+}
+
+func TestListSummaries_CreatorSeesTask(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedListTask(t, db, imDB)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	w := doRequest(r, "GET", "/api/v1/summaries", "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 1 {
+		t.Errorf("expected total 1 for creator, got %d", resp.Data.Total)
+	}
+}
+
+func TestListSummaries_ParticipantSeesTask(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedListTask(t, db, imDB)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	w := doRequest(r, "GET", "/api/v1/summaries", "participant1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 1 {
+		t.Errorf("expected total 1 for participant, got %d", resp.Data.Total)
 	}
 }

--- a/internal/api/handler/members_auth_test.go
+++ b/internal/api/handler/members_auth_test.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupMembersTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open summary db: %v", err)
+	}
+	db.AutoMigrate(&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{}, &model.PersonalResult{})
+	return db
+}
+
+func setupMembersRouter(h *PersonalHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.GET("/api/v1/summaries/:id/members", h.GetMembers)
+	return r
+}
+
+func seedMembersTask(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+
+	task := model.SummaryTask{
+		TaskNo:      "TST-MEMBERS-001",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	db.Create(&task)
+	db.Create(&model.SummarySource{TaskID: task.ID, SourceType: model.SourceGroup, SourceID: "grp_abc"})
+	db.Create(&model.SummaryParticipant{TaskID: task.ID, UserID: "participant1", UserName: "P1"})
+	return task.ID
+}
+
+func TestGetMembers_Creator(t *testing.T) {
+	db := setupMembersTestDB(t)
+	taskID := seedMembersTask(t, db)
+	h := NewPersonalHandler(db, "", nil)
+	r := setupMembersRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d/members", taskID), "creator1")
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for creator, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMembers_Participant(t *testing.T) {
+	db := setupMembersTestDB(t)
+	taskID := seedMembersTask(t, db)
+	h := NewPersonalHandler(db, "", nil)
+	r := setupMembersRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d/members", taskID), "participant1")
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for participant, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMembers_GroupMemberDenied(t *testing.T) {
+	db := setupMembersTestDB(t)
+	taskID := seedMembersTask(t, db)
+	h := NewPersonalHandler(db, "", nil)
+	r := setupMembersRouter(h)
+
+	// Source-group membership alone does not grant access to the member list.
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d/members", taskID), "groupmember1")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for source-group member, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMembers_StrangerDenied(t *testing.T) {
+	db := setupMembersTestDB(t)
+	taskID := seedMembersTask(t, db)
+	h := NewPersonalHandler(db, "", nil)
+	r := setupMembersRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d/members", taskID), "stranger1")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for stranger, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMembers_NoAuth(t *testing.T) {
+	db := setupMembersTestDB(t)
+	taskID := seedMembersTask(t, db)
+	h := NewPersonalHandler(db, "", nil)
+	r := setupMembersRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d/members", taskID), "")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unauthenticated, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMembers_TaskNotFound(t *testing.T) {
+	db := setupMembersTestDB(t)
+	seedMembersTask(t, db)
+	h := NewPersonalHandler(db, "", nil)
+	r := setupMembersRouter(h)
+
+	w := doRequest(r, "GET", "/api/v1/summaries/999999/members", "creator1")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for missing task, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/handler/origin_channel_test.go
+++ b/internal/api/handler/origin_channel_test.go
@@ -1,0 +1,360 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupOriginTestDB(t *testing.T) (db *gorm.DB, imDB *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.AutoMigrate(
+		&model.SummaryTask{},
+		&model.SummarySource{},
+		&model.SummaryParticipant{},
+		&model.PersonalResult{},
+		&model.SummaryResult{},
+	)
+	imDB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	imDB.Exec("CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0)")
+	return db, imDB
+}
+
+func setupOriginRouter(h *TaskHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.POST("/api/v1/summaries", h.CreateSummary)
+	r.GET("/api/v1/summaries", h.ListSummaries)
+	r.GET("/api/v1/summaries/:id", h.GetSummary)
+	r.GET("/api/v1/summary-templates", h.GetTemplates)
+	return r
+}
+
+func doCreateRequest(r *gin.Engine, body interface{}, userID string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/summaries", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Token", userID)
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestCreateSummary_WithOriginChannel(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	body := map[string]interface{}{
+		"title":               "test",
+		"origin_channel_id":   "group_123",
+		"origin_channel_type": 1,
+		"time_range": map[string]interface{}{
+			"start": time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			"end":   time.Now().Format(time.RFC3339),
+		},
+	}
+	w := doCreateRequest(r, body, "user1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	taskID := int64(data["task_id"].(float64))
+
+	var task model.SummaryTask
+	db.First(&task, taskID)
+	if task.OriginChannelID != "group_123" {
+		t.Errorf("origin_channel_id: want group_123, got %s", task.OriginChannelID)
+	}
+	if task.OriginChannelType != 1 {
+		t.Errorf("origin_channel_type: want 1, got %d", task.OriginChannelType)
+	}
+
+	// Verify auto-fill source was created
+	var sources []model.SummarySource
+	db.Where("task_id = ?", taskID).Find(&sources)
+	if len(sources) != 1 {
+		t.Fatalf("expected 1 source (auto-filled), got %d", len(sources))
+	}
+	if sources[0].SourceType != 1 {
+		t.Errorf("source_type: want 1, got %d", sources[0].SourceType)
+	}
+	if sources[0].SourceID != "group_123" {
+		t.Errorf("source_id: want group_123, got %s", sources[0].SourceID)
+	}
+}
+
+func TestCreateSummary_OriginChannelValidation_InvalidType(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	body := map[string]interface{}{
+		"title":               "test",
+		"origin_channel_id":   "group_123",
+		"origin_channel_type": 5,
+		"time_range": map[string]interface{}{
+			"start": time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			"end":   time.Now().Format(time.RFC3339),
+		},
+	}
+	w := doCreateRequest(r, body, "user1")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if int(resp["code"].(float64)) != 40001 {
+		t.Errorf("expected code 40001, got %v", resp["code"])
+	}
+}
+
+func TestCreateSummary_OriginChannelValidation_TypeWithoutID(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	body := map[string]interface{}{
+		"title":               "test",
+		"origin_channel_id":   "",
+		"origin_channel_type": 2,
+		"time_range": map[string]interface{}{
+			"start": time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			"end":   time.Now().Format(time.RFC3339),
+		},
+	}
+	w := doCreateRequest(r, body, "user1")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if int(resp["code"].(float64)) != 40001 {
+		t.Errorf("expected code 40001, got %v", resp["code"])
+	}
+}
+
+func TestCreateSummary_OriginChannel_NoAutoFillWhenSourcesProvided(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	body := map[string]interface{}{
+		"title":               "test",
+		"origin_channel_id":   "group_123",
+		"origin_channel_type": 1,
+		"sources": []map[string]interface{}{
+			{"source_type": 1, "source_id": "group_456"},
+		},
+		"time_range": map[string]interface{}{
+			"start": time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			"end":   time.Now().Format(time.RFC3339),
+		},
+	}
+	w := doCreateRequest(r, body, "user1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	taskID := int64(data["task_id"].(float64))
+
+	var sources []model.SummarySource
+	db.Where("task_id = ?", taskID).Find(&sources)
+	if len(sources) != 1 {
+		t.Fatalf("expected 1 source (user-provided), got %d", len(sources))
+	}
+	if sources[0].SourceID != "group_456" {
+		t.Errorf("source_id should be user-provided group_456, got %s", sources[0].SourceID)
+	}
+}
+
+func TestListSummaries_FilterByOriginChannelID(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	now := time.Now().UTC()
+	task1 := model.SummaryTask{
+		TaskNo:            "LST-001",
+		SpaceID:           "space1",
+		CreatorID:         "user1",
+		SummaryMode:       model.ModeByPerson,
+		Status:            model.StatusCompleted,
+		OriginChannelID:   "group_aaa",
+		OriginChannelType: 1,
+		TimeRangeStart:    now.Add(-24 * time.Hour),
+		TimeRangeEnd:      now,
+	}
+	task2 := model.SummaryTask{
+		TaskNo:            "LST-002",
+		SpaceID:           "space1",
+		CreatorID:         "user1",
+		SummaryMode:       model.ModeByPerson,
+		Status:            model.StatusCompleted,
+		OriginChannelID:   "group_bbb",
+		OriginChannelType: 1,
+		TimeRangeStart:    now.Add(-24 * time.Hour),
+		TimeRangeEnd:      now,
+	}
+	db.Create(&task1)
+	db.Create(&task2)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/summaries?origin_channel_id=group_aaa", nil)
+	req.Header.Set("Token", "user1")
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	total := int(data["total"].(float64))
+	if total != 1 {
+		t.Errorf("expected 1 result, got %d", total)
+	}
+	items := data["items"].([]interface{})
+	item := items[0].(map[string]interface{})
+	if item["origin_channel_id"] != "group_aaa" {
+		t.Errorf("expected origin_channel_id=group_aaa, got %v", item["origin_channel_id"])
+	}
+	if int(item["origin_channel_type"].(float64)) != 1 {
+		t.Errorf("expected origin_channel_type=1, got %v", item["origin_channel_type"])
+	}
+}
+
+func TestGetSummary_IncludesOriginFields(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	now := time.Now().UTC()
+	task := model.SummaryTask{
+		TaskNo:            "GET-001",
+		SpaceID:           "space1",
+		CreatorID:         "user1",
+		SummaryMode:       model.ModeByPerson,
+		Status:            model.StatusCompleted,
+		OriginChannelID:   "thread_xyz",
+		OriginChannelType: 2,
+		TimeRangeStart:    now.Add(-24 * time.Hour),
+		TimeRangeEnd:      now,
+	}
+	db.Create(&task)
+	db.Create(&model.SummaryParticipant{TaskID: task.ID, UserID: "user1", UserName: "U1"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/summaries/%d", task.ID), nil)
+	req.Header.Set("Token", "user1")
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+
+	if data["origin_channel_id"] != "thread_xyz" {
+		t.Errorf("origin_channel_id: want thread_xyz, got %v", data["origin_channel_id"])
+	}
+	if int(data["origin_channel_type"].(float64)) != 2 {
+		t.Errorf("origin_channel_type: want 2, got %v", data["origin_channel_type"])
+	}
+}
+
+func TestGetTemplates_ReturnsCorrectStructure(t *testing.T) {
+	db, imDB := setupOriginTestDB(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupOriginRouter(h)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/summary-templates", nil)
+	req.Header.Set("Token", "user1")
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	templates := data["templates"].([]interface{})
+
+	if len(templates) != 4 {
+		t.Fatalf("expected 4 templates, got %d", len(templates))
+	}
+
+	expectedIDs := []string{"project_progress", "task_tracking", "weekly_report", "chat_content"}
+	for i, tmpl := range templates {
+		m := tmpl.(map[string]interface{})
+		if m["id"] != expectedIDs[i] {
+			t.Errorf("template[%d] id: want %s, got %v", i, expectedIDs[i], m["id"])
+		}
+		if m["label"] == nil || m["label"] == "" {
+			t.Errorf("template[%d] label is empty", i)
+		}
+		if m["icon"] == nil || m["icon"] == "" {
+			t.Errorf("template[%d] icon is empty", i)
+		}
+		if m["pattern"] == nil || m["pattern"] == "" {
+			t.Errorf("template[%d] pattern is empty", i)
+		}
+		if m["type"] == nil || m["type"] == "" {
+			t.Errorf("template[%d] type is empty", i)
+		}
+	}
+
+	// Verify parameterized template has placeholders
+	taskTracking := templates[1].(map[string]interface{})
+	if taskTracking["type"] != "parameterized" {
+		t.Errorf("task_tracking type: want parameterized, got %v", taskTracking["type"])
+	}
+	placeholders := taskTracking["placeholders"].([]interface{})
+	if len(placeholders) != 1 {
+		t.Fatalf("task_tracking placeholders: want 1, got %d", len(placeholders))
+	}
+	ph := placeholders[0].(map[string]interface{})
+	if ph["key"] != "task_name" {
+		t.Errorf("placeholder key: want task_name, got %v", ph["key"])
+	}
+}

--- a/internal/api/handler/personal.go
+++ b/internal/api/handler/personal.go
@@ -259,6 +259,32 @@ func (h *PersonalHandler) GetMembers(c *gin.Context) {
 		return
 	}
 
+	// Authorization: only the task creator or an explicit participant may read the
+	// member list. Source-group membership alone does NOT grant access. This mirrors
+	// TaskHandler.authorizeTaskAccess / canAccessTask (codes 4010 / 40008 / 40003).
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 4010, Message: "authentication required"})
+		return
+	}
+
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND deleted_at IS NULL", taskID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+
+	if task.CreatorID != userID {
+		var cnt int64
+		h.db.Model(&model.SummaryParticipant{}).
+			Where("task_id = ? AND user_id = ?", taskID, userID).
+			Count(&cnt)
+		if cnt == 0 {
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权访问此任务"})
+			return
+		}
+	}
+
 	var participants []model.SummaryParticipant
 	h.db.Where("task_id = ?", taskID).Find(&participants)
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -102,6 +102,8 @@ type createSummaryReq struct {
 	Sources             []sourceReq  `json:"sources"`
 	Participants        []participantReq `json:"participants"`
 	ConfirmTimeoutHours int          `json:"confirm_timeout_hours"`
+	OriginChannelID     string       `json:"origin_channel_id"`
+	OriginChannelType   int          `json:"origin_channel_type"`
 }
 
 type timeRange struct {
@@ -147,6 +149,20 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 	if utf8.RuneCountInString(req.Topic) > 1000 {
 		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 1000 字符"})
 		return
+	}
+	if req.OriginChannelID != "" && (req.OriginChannelType < model.OriginChannelGroup || req.OriginChannelType > model.OriginChannelDM) {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set"})
+		return
+	}
+	if req.OriginChannelID == "" && req.OriginChannelType != 0 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "origin_channel_id is required when origin_channel_type is set"})
+		return
+	}
+	if len(req.Sources) == 0 && req.OriginChannelID != "" && req.OriginChannelType >= model.OriginChannelGroup && req.OriginChannelType <= model.OriginChannelDM {
+		req.Sources = []sourceReq{{
+			SourceType: req.OriginChannelType,
+			SourceID:   req.OriginChannelID,
+		}}
 	}
 	if len(req.Sources) == 0 && req.Topic == "" && req.TimeRange == nil {
 		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "至少提供 sources、topic 或 time_range 之一"})
@@ -201,16 +217,18 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 	confirmDeadline := &dl
 
 	task := model.SummaryTask{
-		TaskNo:          taskNo,
-		SpaceID:         spaceID,
-		CreatorID:       effectiveUID,
-		Title:           title,
-		SummaryMode:     summaryMode,
-		TimeRangeStart:  timeStart,
-		TimeRangeEnd:    timeEnd,
-		Status:          initialStatus,
-		TriggerType:     model.TriggerManual,
-		ConfirmDeadline: confirmDeadline,
+		TaskNo:            taskNo,
+		SpaceID:           spaceID,
+		CreatorID:         effectiveUID,
+		Title:             title,
+		SummaryMode:       summaryMode,
+		TimeRangeStart:    timeStart,
+		TimeRangeEnd:      timeEnd,
+		Status:            initialStatus,
+		TriggerType:       model.TriggerManual,
+		ConfirmDeadline:   confirmDeadline,
+		OriginChannelID:   req.OriginChannelID,
+		OriginChannelType: req.OriginChannelType,
 	}
 
 	log.Printf("[handler] CreateSummary space=%s user=%s mode=%d", spaceID, effectiveUID, summaryMode)
@@ -333,6 +351,9 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	if s := c.Query("keyword"); s != "" {
 		query = query.Where("title LIKE ?", "%"+s+"%")
 	}
+	if s := c.Query("origin_channel_id"); s != "" {
+		query = query.Where("origin_channel_id = ?", s)
+	}
 	if s := c.Query("created_after"); s != "" {
 		if t, err := time.Parse(time.RFC3339, s); err == nil {
 			query = query.Where("created_at >= ?", t)
@@ -392,19 +413,21 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		}
 
 		items = append(items, gin.H{
-			"task_id":          t.ID,
-			"task_no":          t.TaskNo,
-			"title":            t.Title,
-			"summary_mode":     t.SummaryMode,
-			"status":           t.Status,
-			"trigger_type":     t.TriggerType,
-			"time_range_start": t.TimeRangeStart.Format(time.RFC3339),
-			"time_range_end":   t.TimeRangeEnd.Format(time.RFC3339),
-			"sources":          srcList,
-			"total_msg_count":  totalMsgCount,
-			"creator_name":     creatorName,
-			"created_at":       t.CreatedAt.Format(time.RFC3339),
-			"completed_at":     completedAt,
+			"task_id":             t.ID,
+			"task_no":             t.TaskNo,
+			"title":              t.Title,
+			"summary_mode":       t.SummaryMode,
+			"status":             t.Status,
+			"trigger_type":       t.TriggerType,
+			"time_range_start":   t.TimeRangeStart.Format(time.RFC3339),
+			"time_range_end":     t.TimeRangeEnd.Format(time.RFC3339),
+			"sources":            srcList,
+			"total_msg_count":    totalMsgCount,
+			"creator_name":       creatorName,
+			"origin_channel_id":  t.OriginChannelID,
+			"origin_channel_type": t.OriginChannelType,
+			"created_at":         t.CreatedAt.Format(time.RFC3339),
+			"completed_at":       completedAt,
 		})
 	}
 
@@ -470,20 +493,22 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 	}
 
 	resp := gin.H{
-		"task_id":          task.ID,
-		"task_no":          task.TaskNo,
-		"title":            task.Title,
-		"summary_mode":     task.SummaryMode,
-		"status":           task.Status,
-		"trigger_type":     task.TriggerType,
-		"time_range_start": task.TimeRangeStart.Format(time.RFC3339),
-		"time_range_end":   task.TimeRangeEnd.Format(time.RFC3339),
-		"sources":          srcList,
-		"participants":     partList,
-		"result":           resultOut,
-		"error_message":    task.ErrorMessage,
-		"created_at":       task.CreatedAt.Format(time.RFC3339),
-		"updated_at":       task.UpdatedAt.Format(time.RFC3339),
+		"task_id":             task.ID,
+		"task_no":             task.TaskNo,
+		"title":              task.Title,
+		"summary_mode":       task.SummaryMode,
+		"status":             task.Status,
+		"trigger_type":       task.TriggerType,
+		"time_range_start":   task.TimeRangeStart.Format(time.RFC3339),
+		"time_range_end":     task.TimeRangeEnd.Format(time.RFC3339),
+		"sources":            srcList,
+		"participants":       partList,
+		"result":             resultOut,
+		"error_message":      task.ErrorMessage,
+		"origin_channel_id":  task.OriginChannelID,
+		"origin_channel_type": task.OriginChannelType,
+		"created_at":         task.CreatedAt.Format(time.RFC3339),
+		"updated_at":         task.UpdatedAt.Format(time.RFC3339),
 	}
 
 	if latestResult.ID > 0 {
@@ -683,6 +708,63 @@ func (h *TaskHandler) InferScope(c *gin.Context) {
 	}
 	result := service.InferScope(topic)
 	ok(c, result)
+}
+
+// GetTemplates handles GET /api/v1/summary-templates
+func (h *TaskHandler) GetTemplates(c *gin.Context) {
+	type placeholder struct {
+		Key      string `json:"key"`
+		Label    string `json:"label"`
+		Position []int  `json:"position,omitempty"`
+	}
+	type tmpl struct {
+		ID           string        `json:"id"`
+		Label        string        `json:"label"`
+		Icon         string        `json:"icon"`
+		Description  string        `json:"description"`
+		Type         string        `json:"type"`
+		Pattern      string        `json:"pattern"`
+		Placeholders []placeholder `json:"placeholders,omitempty"`
+	}
+
+	templates := []tmpl{
+		{
+			ID:           "project_progress",
+			Label:        "汇总项目进展",
+			Icon:         "FileText",
+			Description:  "与团队成员一起总结进展",
+			Type:         "parameterized",
+			Pattern:      "总结 {project_name} 的项目进展",
+			Placeholders: []placeholder{{Key: "project_name", Label: "输入项目名称", Position: []int{3, 9}}},
+		},
+		{
+			ID:           "task_tracking",
+			Label:        "跟踪任务进度",
+			Icon:         "ListChecks",
+			Description:  "邀请同事汇总任务完成情况",
+			Type:         "parameterized",
+			Pattern:      "总结 {task_name} 的完成情况",
+			Placeholders: []placeholder{{Key: "task_name", Label: "输入任务名称", Position: []int{3, 9}}},
+		},
+		{
+			ID:          "weekly_report",
+			Label:       "总结团队周报",
+			Icon:        "Calendar",
+			Description: "总结团队成员每周的工作",
+			Type:        "fixed",
+			Pattern:     "总结每周的工作周报",
+		},
+		{
+			ID:          "chat_content",
+			Label:       "总结聊天内容",
+			Icon:        "MessageSquare",
+			Description: "总结指定聊天中的事情进展",
+			Type:        "fixed",
+			Pattern:     "总结本群中的关键内容",
+		},
+	}
+
+	ok(c, gin.H{"templates": templates})
 }
 
 func (h *TaskHandler) triggerWorker(req model.WorkerTriggerRequest) {

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -29,9 +29,24 @@ func NewTaskHandler(db, imDB *gorm.DB, workerTriggerURL string) *TaskHandler {
 	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL}
 }
 
+// canAccessTask reports whether userID may read the task: creator or explicit
+// participant. This is the single source of truth shared by the detail path
+// (authorizeTaskAccess) and conceptually the batch path (batchAuthorize) and the
+// list query (ListSummaries). Source-group membership alone does NOT grant access.
+func (h *TaskHandler) canAccessTask(userID string, taskID int64, creatorID string) bool {
+	if creatorID == userID {
+		return true
+	}
+	var cnt int64
+	h.db.Model(&model.SummaryParticipant{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Count(&cnt)
+	return cnt > 0
+}
+
 // authorizeTaskAccess loads a task by ID and checks that the current user is
-// authorized to access it. Authorization passes if the user is the task creator,
-// a participant, or a member of at least one source group.
+// authorized to access it. Authorization passes if the user is the task creator
+// or an explicit participant. Source-group membership alone does NOT grant access.
 // Returns the task and true on success; writes a JSON error response and returns
 // nil, false on failure.
 func (h *TaskHandler) authorizeTaskAccess(c *gin.Context, taskID int64) (*model.SummaryTask, bool) {
@@ -47,33 +62,8 @@ func (h *TaskHandler) authorizeTaskAccess(c *gin.Context, taskID int64) (*model.
 		return nil, false
 	}
 
-	// 1. Creator check
-	if task.CreatorID == userID {
+	if h.canAccessTask(userID, task.ID, task.CreatorID) {
 		return &task, true
-	}
-
-	// 2. Participant check
-	var participantCount int64
-	h.db.Model(&model.SummaryParticipant{}).
-		Where("task_id = ? AND user_id = ?", taskID, userID).
-		Count(&participantCount)
-	if participantCount > 0 {
-		return &task, true
-	}
-
-	// 3. Source group membership check (via imDB)
-	var sourceIDs []string
-	h.db.Model(&model.SummarySource{}).
-		Where("task_id = ? AND source_type = ?", taskID, model.SourceGroup).
-		Pluck("source_id", &sourceIDs)
-	if len(sourceIDs) > 0 {
-		var memberCount int64
-		h.imDB.Table("group_member").
-			Where("group_no IN ? AND uid = ? AND is_deleted = 0", sourceIDs, userID).
-			Count(&memberCount)
-		if memberCount > 0 {
-			return &task, true
-		}
 	}
 
 	c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权访问此任务"})
@@ -95,15 +85,15 @@ func bizErr(c *gin.Context, err *service.BizError) {
 }
 
 type createSummaryReq struct {
-	UID                 string       `json:"uid"`
-	Title               string       `json:"title"`
-	Topic               string       `json:"topic"`
-	TimeRange           *timeRange   `json:"time_range"`
-	Sources             []sourceReq  `json:"sources"`
+	UID                 string           `json:"uid"`
+	Title               string           `json:"title"`
+	Topic               string           `json:"topic"`
+	TimeRange           *timeRange       `json:"time_range"`
+	Sources             []sourceReq      `json:"sources"`
 	Participants        []participantReq `json:"participants"`
-	ConfirmTimeoutHours int          `json:"confirm_timeout_hours"`
-	OriginChannelID     string       `json:"origin_channel_id"`
-	OriginChannelType   int          `json:"origin_channel_type"`
+	ConfirmTimeoutHours int              `json:"confirm_timeout_hours"`
+	OriginChannelID     string           `json:"origin_channel_id"`
+	OriginChannelType   int              `json:"origin_channel_type"`
 }
 
 type timeRange struct {
@@ -118,7 +108,7 @@ type sourceReq struct {
 
 type participantReq struct {
 	UserName string `json:"user_name"`
-	UserID string `json:"user_id"`
+	UserID   string `json:"user_id"`
 }
 
 // CreateSummary handles POST /api/v1/summaries
@@ -282,9 +272,14 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 				continue
 			}
 			pp := model.SummaryParticipant{
-				TaskID:   task.ID,
-				UserID:   p.UserID,
-				UserName: func() string { if p.UserName != "" { return p.UserName }; return service.ResolveUserName(p.UserID) }(),
+				TaskID: task.ID,
+				UserID: p.UserID,
+				UserName: func() string {
+					if p.UserName != "" {
+						return p.UserName
+					}
+					return service.ResolveUserName(p.UserID)
+				}(),
 			}
 			if err := tx.Create(&pp).Error; err != nil {
 				return err
@@ -415,19 +410,19 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		items = append(items, gin.H{
 			"task_id":             t.ID,
 			"task_no":             t.TaskNo,
-			"title":              t.Title,
-			"summary_mode":       t.SummaryMode,
-			"status":             t.Status,
-			"trigger_type":       t.TriggerType,
-			"time_range_start":   t.TimeRangeStart.Format(time.RFC3339),
-			"time_range_end":     t.TimeRangeEnd.Format(time.RFC3339),
-			"sources":            srcList,
-			"total_msg_count":    totalMsgCount,
-			"creator_name":       creatorName,
-			"origin_channel_id":  t.OriginChannelID,
+			"title":               t.Title,
+			"summary_mode":        t.SummaryMode,
+			"status":              t.Status,
+			"trigger_type":        t.TriggerType,
+			"time_range_start":    t.TimeRangeStart.Format(time.RFC3339),
+			"time_range_end":      t.TimeRangeEnd.Format(time.RFC3339),
+			"sources":             srcList,
+			"total_msg_count":     totalMsgCount,
+			"creator_name":        creatorName,
+			"origin_channel_id":   t.OriginChannelID,
 			"origin_channel_type": t.OriginChannelType,
-			"created_at":         t.CreatedAt.Format(time.RFC3339),
-			"completed_at":       completedAt,
+			"created_at":          t.CreatedAt.Format(time.RFC3339),
+			"completed_at":        completedAt,
 		})
 	}
 
@@ -495,20 +490,20 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 	resp := gin.H{
 		"task_id":             task.ID,
 		"task_no":             task.TaskNo,
-		"title":              task.Title,
-		"summary_mode":       task.SummaryMode,
-		"status":             task.Status,
-		"trigger_type":       task.TriggerType,
-		"time_range_start":   task.TimeRangeStart.Format(time.RFC3339),
-		"time_range_end":     task.TimeRangeEnd.Format(time.RFC3339),
-		"sources":            srcList,
-		"participants":       partList,
-		"result":             resultOut,
-		"error_message":      task.ErrorMessage,
-		"origin_channel_id":  task.OriginChannelID,
+		"title":               task.Title,
+		"summary_mode":        task.SummaryMode,
+		"status":              task.Status,
+		"trigger_type":        task.TriggerType,
+		"time_range_start":    task.TimeRangeStart.Format(time.RFC3339),
+		"time_range_end":      task.TimeRangeEnd.Format(time.RFC3339),
+		"sources":             srcList,
+		"participants":        partList,
+		"result":              resultOut,
+		"error_message":       task.ErrorMessage,
+		"origin_channel_id":   task.OriginChannelID,
 		"origin_channel_type": task.OriginChannelType,
-		"created_at":         task.CreatedAt.Format(time.RFC3339),
-		"updated_at":         task.UpdatedAt.Format(time.RFC3339),
+		"created_at":          task.CreatedAt.Format(time.RFC3339),
+		"updated_at":          task.UpdatedAt.Format(time.RFC3339),
 	}
 
 	if latestResult.ID > 0 {
@@ -930,8 +925,10 @@ func (h *TaskHandler) BatchStatus(c *gin.Context) {
 }
 
 // batchAuthorize returns the subset of taskIDs that userID is allowed to access.
-// Known limitation: source_type=2 (thread) is not checked here, consistent with
-// the existing authorizeTaskAccess implementation.
+// Access is granted to task creators and explicit participants only.
+// Source-group membership does NOT grant access. This must stay semantically
+// equal to canAccessTask / authorizeTaskAccess; the batch Pluck form is only a
+// performance optimization to avoid N per-task queries.
 func (h *TaskHandler) batchAuthorize(userID string, taskIDs []int64, taskMap map[int64]*model.SummaryTask) []int64 {
 	authorized := make(map[int64]struct{})
 
@@ -953,42 +950,6 @@ func (h *TaskHandler) batchAuthorize(userID string, taskIDs []int64, taskMap map
 		Distinct().Pluck("task_id", &participantTaskIDs)
 	for _, id := range participantTaskIDs {
 		authorized[id] = struct{}{}
-	}
-
-	stillRemaining := make([]int64, 0)
-	for _, id := range remainingIDs {
-		if _, ok := authorized[id]; !ok {
-			stillRemaining = append(stillRemaining, id)
-		}
-	}
-	if len(stillRemaining) == 0 {
-		return mapKeys(authorized)
-	}
-
-	var sources []model.SummarySource
-	h.db.Where("task_id IN ? AND source_type = ?", stillRemaining, model.SourceGroup).
-		Find(&sources)
-
-	if len(sources) > 0 {
-		groupToTasks := make(map[string][]int64)
-		for _, s := range sources {
-			groupToTasks[s.SourceID] = append(groupToTasks[s.SourceID], s.TaskID)
-		}
-		groupNos := make([]string, 0, len(groupToTasks))
-		for gno := range groupToTasks {
-			groupNos = append(groupNos, gno)
-		}
-
-		var memberGroups []string
-		h.imDB.Table("group_member").
-			Where("group_no IN ? AND uid = ? AND is_deleted = 0", groupNos, userID).
-			Pluck("group_no", &memberGroups)
-
-		for _, gno := range memberGroups {
-			for _, taskID := range groupToTasks[gno] {
-				authorized[taskID] = struct{}{}
-			}
-		}
 	}
 
 	return mapKeys(authorized)

--- a/internal/api/handler/task_batch_status_test.go
+++ b/internal/api/handler/task_batch_status_test.go
@@ -252,6 +252,27 @@ func TestBatchStatus_DeletedTasks(t *testing.T) {
 	}
 }
 
+func TestBatchStatus_GroupMemberExcluded(t *testing.T) {
+	db, imDB := setupBatchTestDBs(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupBatchRouter(h)
+
+	task := model.SummaryTask{TaskNo: "BATCH-GRP", SpaceID: "space1", CreatorID: "owner", Status: model.StatusProcessing}
+	db.Create(&task)
+	db.Create(&model.SummarySource{TaskID: task.ID, SourceType: model.SourceGroup, SourceID: "grp_x"})
+	imDB.Exec("INSERT INTO group_member (group_no, uid, is_deleted) VALUES (?, ?, 0)", "grp_x", "gm1")
+
+	// gm1 is only a source-group member → excluded from batch results.
+	w := doBatchRequest(r, map[string]interface{}{"task_ids": []int64{task.ID}}, "gm1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseBatchResponse(t, w)
+	if len(resp.Data.Tasks) != 0 {
+		t.Errorf("expected 0 tasks for source-group member, got %d", len(resp.Data.Tasks))
+	}
+}
+
 func TestBatchStatus_DBError(t *testing.T) {
 	db, imDB := setupBatchTestDBs(t)
 	h := NewTaskHandler(db, imDB, "")

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -56,7 +56,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.GET("/summary-infer", taskH.InferScope)
 		v1.GET("/summary-member-candidates", handler.NewCandidateHandler(imDB, candidateQueryLimit).SearchCandidates)
 		v1.GET("/summary-chat-candidates", handler.NewCandidateHandler(imDB, candidateQueryLimit).SearchChatCandidates)
-		v1.GET("/summary-templates", func(c *gin.Context) { c.JSON(200, gin.H{"code": 0, "data": gin.H{"templates": []string{}}}) })
+		v1.GET("/summary-templates", taskH.GetTemplates)
 
 		v1.POST("/summary-schedules", schedH.CreateSchedule)
 		v1.GET("/summary-schedules", schedH.ListSchedules)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -82,6 +82,14 @@ const (
 	SourceDirect = 3
 )
 
+// Origin channel type constants.
+const (
+	OriginChannelGlobal = 0
+	OriginChannelGroup  = 1
+	OriginChannelThread = 2
+	OriginChannelDM     = 3
+)
+
 // Channel type constants (aligned with the IM server protocol).
 const (
 	ChannelTypeDM    = 1
@@ -103,6 +111,8 @@ type SummaryTask struct {
 	RetryCount         int        `gorm:"column:retry_count;type:tinyint;not null;default:0" json:"retry_count"`
 	ErrorMessage       *string    `gorm:"column:error_message;type:varchar(500)" json:"error_message"`
 	ScheduleID         *int64     `gorm:"column:schedule_id" json:"schedule_id"`
+	OriginChannelID    string     `gorm:"column:origin_channel_id;type:varchar(64);not null;default:'';index:idx_origin_channel" json:"origin_channel_id"`
+	OriginChannelType  int        `gorm:"column:origin_channel_type;type:tinyint;not null;default:0" json:"origin_channel_type"`
 	ProcessingDeadline *time.Time `gorm:"column:processing_deadline" json:"processing_deadline"`
 	ConfirmDeadline    *time.Time `gorm:"column:confirm_deadline" json:"confirm_deadline"`
 	CreatedAt          time.Time  `gorm:"column:created_at;not null" json:"created_at"`

--- a/migrations/sql/20260528-01-add-origin-channel.sql
+++ b/migrations/sql/20260528-01-add-origin-channel.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+ALTER TABLE `summary_task`
+    ADD COLUMN `origin_channel_id` VARCHAR(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' AFTER `schedule_id`,
+    ADD COLUMN `origin_channel_type` TINYINT NOT NULL DEFAULT 0 AFTER `origin_channel_id`,
+    ADD INDEX `idx_origin_channel` (`origin_channel_id`);
+
+-- +migrate Down
+ALTER TABLE `summary_task` DROP INDEX `idx_origin_channel`;
+ALTER TABLE `summary_task` DROP COLUMN `origin_channel_type`;
+ALTER TABLE `summary_task` DROP COLUMN `origin_channel_id`;


### PR DESCRIPTION
## Summary

Backend support for the chat-window smart summary feature.

### origin_channel support
- Threaded `origin_channel` through the request **handler**, **router**, **model**, and added a database **migration** so summaries can record and filter by their originating channel.

### Summary templates
- Added `GetTemplates` exposed via `GET /api/v1/summary-templates`.
- Ships 4 built-in templates:
  - `project_progress`
  - `task_tracking`
  - `weekly_report`
  - `chat_content`

### Tests
- Added tests covering the new `origin_channel` handling and the summary-templates endpoint.

Closes #60