### PR TITLE
feat: add filter param (followed/recent) to chat candidates API

### DIFF
--- a/internal/api/handler/candidates.go
+++ b/internal/api/handler/candidates.go
@@ -108,10 +108,16 @@ type imDirect struct {
 // Query params:
 //   - keyword:   optional search keyword
 //   - chat_type: "group" | "direct" | "" (empty = all)
+//   - filter:    "followed" | "recent" | "" (empty = all, backward compatible)
 //
 // Groups are fetched from the `group` table.
 // Direct chats are fetched from `conversation_extra` (channel_type=1), filtered to
 // human peers only (32-char hex uid, not in robot table, robot flag = 0).
+//
+// When filter=followed, only groups where group_setting.save=1 for the current user
+// are returned (plus their threads). Direct chats are excluded.
+// When filter=recent, conversations are fetched from conversation_extra ordered by
+// updated_at DESC, returning recently active groups and directs.
 func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 	if h.imDB == nil {
 		c.JSON(http.StatusOK, gin.H{"code": 0, "data": []interface{}{}})
@@ -120,6 +126,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 
 	keyword := c.Query("keyword")
 	chatType := c.Query("chat_type") // "group", "direct", or "" = all
+	filter := c.Query("filter")     // "followed", "recent", or "" = all
 
 	// Resolve current user from context (set by AuthMiddleware).
 	currentUID, _ := c.Get("user_id")
@@ -134,13 +141,78 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		spaceIDStr, _ = v.(string)
 	}
 
+	// --- Build followed group_no set (used by filter=followed and for is_followed enrichment) ---
+	followedGroupNos := map[string]bool{}
+	if currentUIDStr != "" {
+		type followedGroup struct {
+			GroupNo string `gorm:"column:group_no"`
+		}
+		var fgs []followedGroup
+		h.imDB.Table("group_setting").
+			Select("group_no").
+			Where("uid = ? AND save = 1", currentUIDStr).
+			Find(&fgs)
+		for _, fg := range fgs {
+			followedGroupNos[fg.GroupNo] = true
+		}
+	}
+
+	// --- Build recent channel map (used by filter=recent and for last_active_at enrichment) ---
+	recentChannels := map[string]string{} // channelID -> updated_at ISO string
+	if currentUIDStr != "" {
+		type recentConv struct {
+			ChannelID   string `gorm:"column:channel_id"`
+			ChannelType int    `gorm:"column:channel_type"`
+			UpdatedAt   string `gorm:"column:updated_at"`
+		}
+		var rcs []recentConv
+		h.imDB.Table("conversation_extra").
+			Select("channel_id, channel_type, updated_at").
+			Where("uid = ?", currentUIDStr).
+			Order("updated_at DESC").
+			Limit(50).
+			Find(&rcs)
+		for _, rc := range rcs {
+			recentChannels[rc.ChannelID] = rc.UpdatedAt
+		}
+	}
+
+	// --- Determine which sections to include based on filter ---
+	includeGroups := chatType == "" || chatType == "all" || chatType == "group"
+	includeThreads := chatType == "" || chatType == "all" || chatType == "thread"
+	includeDirects := chatType == "" || chatType == "all" || chatType == "direct"
+
+	if filter == "followed" {
+		// Followed is group-centric: only groups + their threads, no directs.
+		includeDirects = false
+	} else if filter == "recent" {
+		// Recent includes both groups and directs that appear in conversation_extra.
+	}
+
 	// --- Groups ---
-	if chatType == "" || chatType == "all" || chatType == "group" {
+	if includeGroups {
 		var groups []imGroup
 		q := h.imDB.Table("`group` g").Select("g.group_no, g.name")
 		if currentUIDStr != "" {
 			q = q.Joins("INNER JOIN group_member gm ON gm.group_no = g.group_no").
 				Where("gm.uid = ? AND gm.is_deleted = 0", currentUIDStr)
+		}
+		if filter == "followed" && currentUIDStr != "" {
+			q = q.Joins("INNER JOIN group_setting gs ON gs.group_no = g.group_no").
+				Where("gs.uid = ? AND gs.save = 1", currentUIDStr)
+		} else if filter == "recent" {
+			// Only include groups that appear in the recent conversation list.
+			recentGroupNos := make([]string, 0)
+			for chID := range recentChannels {
+				recentGroupNos = append(recentGroupNos, chID)
+			}
+			if len(recentGroupNos) > 0 {
+				q = q.Where("g.group_no IN ?", recentGroupNos)
+			} else {
+				// No recent conversations — skip group query entirely.
+				groups = nil
+				goto groupsDone
+			}
 		}
 		if spaceIDStr != "" {
 			q = q.Where("g.space_id = ?", spaceIDStr)
@@ -149,18 +221,22 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			q = q.Where("g.name LIKE ?", "%"+keyword+"%")
 		}
 		h.applyLimit(q).Find(&groups)
+	groupsDone:
 		for _, g := range groups {
-			list = append(list, gin.H{
-				"chat_id":      g.GroupNo,
-				"chat_type":    "group",
-				"name":         g.Name,
-				"member_count": nil,
-			})
+			entry := gin.H{
+				"chat_id":        g.GroupNo,
+				"chat_type":      "group",
+				"name":           g.Name,
+				"member_count":   nil,
+				"is_followed":    followedGroupNos[g.GroupNo],
+				"last_active_at": recentChannels[g.GroupNo],
+			}
+			list = append(list, entry)
 		}
 	}
 
 	// --- Threads (子区, channelType=5) ---
-	if chatType == "" || chatType == "all" || chatType == "thread" {
+	if includeThreads {
 		type imThread struct {
 			ShortID string `gorm:"column:short_id"`
 			Name    string `gorm:"column:name"`
@@ -177,6 +253,23 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			q = q.Joins("INNER JOIN group_member gm ON gm.group_no" + h.collate + " = t.group_no").
 				Where("gm.uid = ? AND gm.is_deleted = 0", currentUIDStr)
 		}
+		if filter == "followed" && currentUIDStr != "" {
+			// Only threads under followed groups.
+			q = q.Joins("INNER JOIN group_setting gs2 ON gs2.group_no" + h.collate + " = t.group_no").
+				Where("gs2.uid = ? AND gs2.save = 1", currentUIDStr)
+		} else if filter == "recent" {
+			// Only threads under groups that appear in recent conversations.
+			recentGroupNos := make([]string, 0)
+			for chID := range recentChannels {
+				recentGroupNos = append(recentGroupNos, chID)
+			}
+			if len(recentGroupNos) > 0 {
+				q = q.Where("t.group_no IN ?", recentGroupNos)
+			} else {
+				threads = nil
+				goto threadsDone
+			}
+		}
 		if spaceIDStr != "" {
 			q = q.Where("g.space_id = ?", spaceIDStr)
 		}
@@ -184,6 +277,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			q = q.Where("t.name LIKE ? OR g.name LIKE ?", "%"+keyword+"%", "%"+keyword+"%")
 		}
 		h.applyLimit(q).Find(&threads)
+	threadsDone:
 		for _, t := range threads {
 			list = append(list, gin.H{
 				"chat_id":         t.GroupNo + "____" + t.ShortID,
@@ -191,6 +285,8 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"name":            t.Name,
 				"member_count":    nil,
 				"parent_group_no": t.GroupNo,
+				"is_followed":     followedGroupNos[t.GroupNo],
+				"last_active_at":  recentChannels[t.GroupNo],
 			})
 		}
 	}
@@ -201,7 +297,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 	// Filter: only 32-char hex uids (excludes system accounts like fileHelper/botfather),
 	//         not a robot (robot table + robot flag).
 	// Requires authentication; skipped silently if unauthenticated.
-	if (chatType == "" || chatType == "all" || chatType == "direct") && currentUIDStr != "" {
+	if includeDirects && currentUIDStr != "" {
 		var directs []imDirect
 		q := h.imDB.Table("conversation_extra ce").
 			Select("ce.channel_id, u.name, u.robot").
@@ -232,12 +328,19 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			if name == "" {
 				name = d.ChannelID
 			}
+			// For filter=recent, skip directs not in the recent conversations list.
+			if filter == "recent" {
+				if _, ok := recentChannels[d.ChannelID]; !ok {
+					continue
+				}
+			}
 			list = append(list, gin.H{
-				"chat_id":      d.ChannelID,
-				"chat_type":    "direct",
-				"name":         name,
-				"member_count": nil,
-				"is_bot":       d.Robot == 1,
+				"chat_id":        d.ChannelID,
+				"chat_type":      "direct",
+				"name":           name,
+				"member_count":   nil,
+				"is_bot":         d.Robot == 1,
+				"last_active_at": recentChannels[d.ChannelID],
 			})
 		}
 	}

--- a/internal/api/handler/candidates.go
+++ b/internal/api/handler/candidates.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -343,6 +344,21 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"last_active_at": recentChannels[d.ChannelID],
 			})
 		}
+	}
+
+	// --- Sort by recency when filter=recent ---
+	if filter == "recent" && len(list) > 1 {
+		sort.SliceStable(list, func(i, j int) bool {
+			ai, _ := list[i]["last_active_at"].(string)
+			aj, _ := list[j]["last_active_at"].(string)
+			if ai == "" {
+				return false
+			}
+			if aj == "" {
+				return true
+			}
+			return ai > aj // DESC: newer first
+		})
 	}
 
 	c.JSON(http.StatusOK, gin.H{"code": 0, "data": list})

--- a/internal/api/handler/candidates.go
+++ b/internal/api/handler/candidates.go
@@ -158,8 +158,13 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		}
 	}
 
-	// --- Build recent channel map (used by filter=recent and for last_active_at enrichment) ---
-	recentChannels := map[string]string{} // channelID -> updated_at ISO string
+	// --- Build recent channel maps (used by filter=recent and for last_active_at enrichment) ---
+	// conversation_extra mixes channel types under one channel_id column, so split by
+	// channel_type to avoid cross-type collisions. Thread channel_ids use the composite
+	// format 'group_no____short_id' (4 underscores), distinct from a bare group_no.
+	recentGroups := map[string]string{}  // channel_type=2: group_no       -> updated_at
+	recentThreads := map[string]string{} // channel_type=5: group_no____short_id -> updated_at
+	recentDirects := map[string]string{} // channel_type=1: peer uid       -> updated_at
 	if currentUIDStr != "" {
 		type recentConv struct {
 			ChannelID   string `gorm:"column:channel_id"`
@@ -174,7 +179,14 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			Limit(50).
 			Find(&rcs)
 		for _, rc := range rcs {
-			recentChannels[rc.ChannelID] = rc.UpdatedAt
+			switch rc.ChannelType {
+			case 1:
+				recentDirects[rc.ChannelID] = rc.UpdatedAt
+			case 5:
+				recentThreads[rc.ChannelID] = rc.UpdatedAt
+			default: // channel_type=2 (group)
+				recentGroups[rc.ChannelID] = rc.UpdatedAt
+			}
 		}
 	}
 
@@ -203,8 +215,8 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				Where("gs.uid = ? AND gs.save = 1", currentUIDStr)
 		} else if filter == "recent" {
 			// Only include groups that appear in the recent conversation list.
-			recentGroupNos := make([]string, 0)
-			for chID := range recentChannels {
+			recentGroupNos := make([]string, 0, len(recentGroups))
+			for chID := range recentGroups {
 				recentGroupNos = append(recentGroupNos, chID)
 			}
 			if len(recentGroupNos) > 0 {
@@ -230,7 +242,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"name":           g.Name,
 				"member_count":   nil,
 				"is_followed":    followedGroupNos[g.GroupNo],
-				"last_active_at": recentChannels[g.GroupNo],
+				"last_active_at": recentGroups[g.GroupNo],
 			}
 			list = append(list, entry)
 		}
@@ -259,14 +271,13 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			q = q.Joins("INNER JOIN group_setting gs2 ON gs2.group_no" + h.collate + " = t.group_no").
 				Where("gs2.uid = ? AND gs2.save = 1", currentUIDStr)
 		} else if filter == "recent" {
-			// Only threads under groups that appear in recent conversations.
-			recentGroupNos := make([]string, 0)
-			for chID := range recentChannels {
-				recentGroupNos = append(recentGroupNos, chID)
-			}
-			if len(recentGroupNos) > 0 {
-				q = q.Where("t.group_no IN ?", recentGroupNos)
-			} else {
+			// Recent threads are matched by their full composite channel id
+			// ('group_no____short_id') against recentThreads, NOT by parent group_no —
+			// a recently active parent group does not make all its threads recent, and a
+			// recently active thread may live under a group that itself is not recent.
+			// The composite id is not a SQL column, so the match is applied in the loop
+			// below. If there are no recent threads at all, skip the query entirely.
+			if len(recentThreads) == 0 {
 				threads = nil
 				goto threadsDone
 			}
@@ -280,14 +291,22 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		h.applyLimit(q).Find(&threads)
 	threadsDone:
 		for _, t := range threads {
+			compositeID := t.GroupNo + "____" + t.ShortID
+			// For filter=recent, only surface threads whose own composite channel id
+			// appears in the recent conversation list.
+			if filter == "recent" {
+				if _, ok := recentThreads[compositeID]; !ok {
+					continue
+				}
+			}
 			list = append(list, gin.H{
-				"chat_id":         t.GroupNo + "____" + t.ShortID,
+				"chat_id":         compositeID,
 				"chat_type":       "thread",
 				"name":            t.Name,
 				"member_count":    nil,
 				"parent_group_no": t.GroupNo,
 				"is_followed":     followedGroupNos[t.GroupNo],
-				"last_active_at":  recentChannels[t.GroupNo],
+				"last_active_at":  recentThreads[compositeID],
 			})
 		}
 	}
@@ -331,7 +350,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			}
 			// For filter=recent, skip directs not in the recent conversations list.
 			if filter == "recent" {
-				if _, ok := recentChannels[d.ChannelID]; !ok {
+				if _, ok := recentDirects[d.ChannelID]; !ok {
 					continue
 				}
 			}
@@ -341,7 +360,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"name":           name,
 				"member_count":   nil,
 				"is_bot":         d.Robot == 1,
-				"last_active_at": recentChannels[d.ChannelID],
+				"last_active_at": recentDirects[d.ChannelID],
 			})
 		}
 	}

--- a/internal/api/handler/candidates.go
+++ b/internal/api/handler/candidates.go
@@ -127,7 +127,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 
 	keyword := c.Query("keyword")
 	chatType := c.Query("chat_type") // "group", "direct", or "" = all
-	filter := c.Query("filter")     // "followed", "recent", or "" = all
+	filter := c.Query("filter")      // "followed", "recent", or "" = all
 
 	// Resolve current user from context (set by AuthMiddleware).
 	currentUID, _ := c.Get("user_id")
@@ -182,10 +182,12 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			switch rc.ChannelType {
 			case 1:
 				recentDirects[rc.ChannelID] = rc.UpdatedAt
+			case 2:
+				recentGroups[rc.ChannelID] = rc.UpdatedAt
 			case 5:
 				recentThreads[rc.ChannelID] = rc.UpdatedAt
-			default: // channel_type=2 (group)
-				recentGroups[rc.ChannelID] = rc.UpdatedAt
+			default:
+				// Ignore unknown channel types.
 			}
 		}
 	}
@@ -198,8 +200,6 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 	if filter == "followed" {
 		// Followed is group-centric: only groups + their threads, no directs.
 		includeDirects = false
-	} else if filter == "recent" {
-		// Recent includes both groups and directs that appear in conversation_extra.
 	}
 
 	// --- Groups ---
@@ -263,12 +263,12 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		if currentUIDStr != "" {
 			// Use group_member instead of thread_member so that all threads in the
 			// user's groups are returned, not just threads the user has posted in.
-			q = q.Joins("INNER JOIN group_member gm ON gm.group_no" + h.collate + " = t.group_no").
+			q = q.Joins("INNER JOIN group_member gm ON gm.group_no"+h.collate+" = t.group_no").
 				Where("gm.uid = ? AND gm.is_deleted = 0", currentUIDStr)
 		}
 		if filter == "followed" && currentUIDStr != "" {
 			// Only threads under followed groups.
-			q = q.Joins("INNER JOIN group_setting gs2 ON gs2.group_no" + h.collate + " = t.group_no").
+			q = q.Joins("INNER JOIN group_setting gs2 ON gs2.group_no"+h.collate+" = t.group_no").
 				Where("gs2.uid = ? AND gs2.save = 1", currentUIDStr)
 		} else if filter == "recent" {
 			// Recent threads are matched by their full composite channel id
@@ -288,7 +288,15 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		if keyword != "" {
 			q = q.Where("t.name LIKE ? OR g.name LIKE ?", "%"+keyword+"%", "%"+keyword+"%")
 		}
-		h.applyLimit(q).Find(&threads)
+		// For filter=recent the recency match happens in the loop below against the
+		// composite channel id, which is not a SQL column. Applying LIMIT here would
+		// truncate the result set before that filter runs and drop valid recent
+		// threads, so skip the limit in that case.
+		if filter == "recent" {
+			q.Find(&threads)
+		} else {
+			h.applyLimit(q).Find(&threads)
+		}
 	threadsDone:
 		for _, t := range threads {
 			compositeID := t.GroupNo + "____" + t.ShortID
@@ -342,7 +350,21 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		if keyword != "" {
 			q = q.Where("u.name LIKE ?", "%"+keyword+"%")
 		}
+		// For filter=recent, constrain to the recent direct peers in SQL so that LIMIT
+		// truncates the already-filtered set rather than dropping recent peers before
+		// the in-loop recency check runs.
+		if filter == "recent" {
+			recentDirectIDs := make([]string, 0, len(recentDirects))
+			for chID := range recentDirects {
+				recentDirectIDs = append(recentDirectIDs, chID)
+			}
+			if len(recentDirectIDs) == 0 {
+				goto directsDone
+			}
+			q = q.Where("ce.channel_id IN ?", recentDirectIDs)
+		}
 		h.applyLimit(q.Order("ce.updated_at DESC")).Find(&directs)
+	directsDone:
 		for _, d := range directs {
 			name := d.Name
 			if name == "" {
@@ -360,6 +382,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"name":           name,
 				"member_count":   nil,
 				"is_bot":         d.Robot == 1,
+				"is_followed":    false,
 				"last_active_at": recentDirects[d.ChannelID],
 			})
 		}

--- a/internal/api/handler/candidates_test.go
+++ b/internal/api/handler/candidates_test.go
@@ -23,6 +23,10 @@ func setupCandidateImDB(t *testing.T) *gorm.DB {
 	imDB.Exec(`CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0)`)
 	imDB.Exec(`CREATE TABLE group_setting (group_no TEXT NOT NULL, uid TEXT NOT NULL, save INTEGER DEFAULT 0, top INTEGER DEFAULT 0, mute INTEGER DEFAULT 0)`)
 	imDB.Exec(`CREATE TABLE conversation_extra (uid TEXT NOT NULL, channel_id TEXT NOT NULL, channel_type INTEGER DEFAULT 2, updated_at TEXT)`)
+	imDB.Exec(`CREATE TABLE user (uid TEXT NOT NULL, name TEXT, robot INTEGER DEFAULT 0)`)
+	imDB.Exec(`CREATE TABLE robot (robot_id TEXT, creator_uid TEXT, status INTEGER DEFAULT 1)`)
+	imDB.Exec(`CREATE TABLE space_member (uid TEXT, space_id TEXT, status INTEGER DEFAULT 1)`)
+	imDB.Exec(`CREATE TABLE friend (uid TEXT, to_uid TEXT, is_deleted INTEGER DEFAULT 0)`)
 	return imDB
 }
 
@@ -326,5 +330,130 @@ func TestSearchChatCandidates_FilterEmptyIsBackwardCompatible(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if len(resp.Data) != 2 {
 		t.Fatalf("expected 2 groups with empty filter, got %d", len(resp.Data))
+	}
+}
+
+func TestSearchChatCandidates_FilterRecentThread(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+
+	// One group with two threads. The parent group is NOT recently active, and only
+	// one thread (th001 -> 'grp1____th001') appears in conversation_extra as recent.
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'ParentGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (1, 'th001', 'Recent Thread', 'grp1', 1, 5)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (2, 'th002', 'Stale Thread', 'grp1', 1, 7)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+	// channel_type=5 thread conversation, keyed by composite 'group_no____short_id'.
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type, updated_at) VALUES ('user1', 'grp1____th001', 5, '2026-06-06T12:00:00Z')`)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestFilter(r, "user1", "thread", "", "recent")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	// Only the thread whose composite channel id is recent should surface.
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 recent thread, got %d: %v", len(resp.Data), resp.Data)
+	}
+	got := resp.Data[0]
+	if got["name"] != "Recent Thread" {
+		t.Errorf("expected 'Recent Thread', got %v", got["name"])
+	}
+	if got["chat_id"] != "grp1____th001" {
+		t.Errorf("expected chat_id=grp1____th001, got %v", got["chat_id"])
+	}
+	// last_active_at must be the thread's own activity, not the parent group's.
+	if got["last_active_at"] != "2026-06-06T12:00:00Z" {
+		t.Errorf("expected thread last_active_at=2026-06-06T12:00:00Z, got %v", got["last_active_at"])
+	}
+}
+
+func TestSearchChatCandidates_FilterRecentGroupNotLeakingThreads(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+
+	// Parent group IS recently active (channel_type=2), but its threads are NOT.
+	// The recent group must surface; none of its threads should leak in as recent.
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'RecentGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (1, 'th001', 'Thread A', 'grp1', 1, 5)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type, updated_at) VALUES ('user1', 'grp1', 2, '2026-06-06T10:00:00Z')`)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestFilter(r, "user1", "", "", "recent")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 item (group only), got %d: %v", len(resp.Data), resp.Data)
+	}
+	if resp.Data[0]["chat_type"] != "group" || resp.Data[0]["name"] != "RecentGroup" {
+		t.Errorf("expected RecentGroup, got %v", resp.Data[0])
+	}
+}
+
+func TestSearchChatCandidates_FilterRecentMixedGroupDirectOrdering(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+
+	// A recent group and a recent direct chat with distinct activity times.
+	// The direct is more recent, so it must sort ahead of the group.
+	const peerUID = "abcdef0123456789abcdef0123456789" // 32-char hex
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'RecentGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO user (uid, name, robot) VALUES (?, 'Peer Person', 0)`, peerUID)
+	imDB.Exec(`INSERT INTO space_member (uid, space_id, status) VALUES (?, 'space1', 1)`, peerUID)
+
+	// Group active earlier, direct active later.
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type, updated_at) VALUES ('user1', 'grp1', 2, '2026-06-06T09:00:00Z')`)
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type, updated_at) VALUES (?, ?, 1, '2026-06-06T11:00:00Z')`, "user1", peerUID)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestFilter(r, "user1", "", "", "recent")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 items (group + direct), got %d: %v", len(resp.Data), resp.Data)
+	}
+	// Most recent first: the direct (11:00) before the group (09:00).
+	if resp.Data[0]["chat_type"] != "direct" {
+		t.Errorf("expected direct first (most recent), got %v", resp.Data[0])
+	}
+	if resp.Data[0]["name"] != "Peer Person" {
+		t.Errorf("expected 'Peer Person' first, got %v", resp.Data[0]["name"])
+	}
+	if resp.Data[1]["chat_type"] != "group" {
+		t.Errorf("expected group second, got %v", resp.Data[1])
+	}
+	if resp.Data[1]["last_active_at"] != "2026-06-06T09:00:00Z" {
+		t.Errorf("expected group last_active_at=2026-06-06T09:00:00Z, got %v", resp.Data[1]["last_active_at"])
 	}
 }

--- a/internal/api/handler/candidates_test.go
+++ b/internal/api/handler/candidates_test.go
@@ -21,6 +21,8 @@ func setupCandidateImDB(t *testing.T) *gorm.DB {
 	imDB.Exec(`CREATE TABLE "group" (group_no TEXT NOT NULL, name TEXT, space_id TEXT, status INTEGER DEFAULT 1)`)
 	imDB.Exec(`CREATE TABLE thread (id INTEGER PRIMARY KEY, short_id TEXT, name TEXT, group_no TEXT, status INTEGER DEFAULT 1, message_count INTEGER DEFAULT 0)`)
 	imDB.Exec(`CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0)`)
+	imDB.Exec(`CREATE TABLE group_setting (group_no TEXT NOT NULL, uid TEXT NOT NULL, save INTEGER DEFAULT 0, top INTEGER DEFAULT 0, mute INTEGER DEFAULT 0)`)
+	imDB.Exec(`CREATE TABLE conversation_extra (uid TEXT NOT NULL, channel_id TEXT NOT NULL, channel_type INTEGER DEFAULT 2, updated_at TEXT)`)
 	return imDB
 }
 
@@ -33,10 +35,17 @@ func setupCandidateRouter(h *CandidateHandler) *gin.Engine {
 }
 
 func doCandidateRequest(r *gin.Engine, userID, chatType, keyword string) *httptest.ResponseRecorder {
+	return doCandidateRequestFilter(r, userID, chatType, keyword, "")
+}
+
+func doCandidateRequestFilter(r *gin.Engine, userID, chatType, keyword, filter string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	path := "/api/v1/summary-chat-candidates?chat_type=" + chatType
 	if keyword != "" {
 		path += "&keyword=" + keyword
+	}
+	if filter != "" {
+		path += "&filter=" + filter
 	}
 	req := httptest.NewRequest("GET", path, nil)
 	if userID != "" {
@@ -197,5 +206,125 @@ func TestSearchChatCandidates_ThreadExcludesEmptyMessageCount(t *testing.T) {
 	}
 	if resp.Data[0]["name"] != "Active Thread" {
 		t.Errorf("expected 'Active Thread', got %v", resp.Data[0]["name"])
+	}
+}
+
+func TestSearchChatCandidates_FilterFollowed(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+
+	// Two groups: user follows grp1 but not grp2
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'FollowedGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp2', 'UnfollowedGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp2', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO group_setting (group_no, uid, save) VALUES ('grp1', 'user1', 1)`)
+	imDB.Exec(`INSERT INTO group_setting (group_no, uid, save) VALUES ('grp2', 'user1', 0)`)
+
+	// Thread under followed group
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (1, 'th001', 'Thread In Followed', 'grp1', 1, 5)`)
+	// Thread under unfollowed group
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (2, 'th002', 'Thread In Unfollowed', 'grp2', 1, 3)`)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestFilter(r, "user1", "", "", "followed")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	// Should get: FollowedGroup + Thread In Followed = 2 items
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 items (1 group + 1 thread), got %d: %v", len(resp.Data), resp.Data)
+	}
+
+	names := map[string]bool{}
+	for _, item := range resp.Data {
+		names[item["name"].(string)] = true
+		// All items should have is_followed=true
+		if item["is_followed"] != true {
+			t.Errorf("expected is_followed=true for %v, got %v", item["name"], item["is_followed"])
+		}
+	}
+	if !names["FollowedGroup"] {
+		t.Errorf("expected FollowedGroup in results, got %v", names)
+	}
+	if !names["Thread In Followed"] {
+		t.Errorf("expected Thread In Followed in results, got %v", names)
+	}
+	if names["UnfollowedGroup"] || names["Thread In Unfollowed"] {
+		t.Errorf("unfollowed items should not appear, got %v", names)
+	}
+}
+
+func TestSearchChatCandidates_FilterRecent(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+
+	// Two groups, only grp1 has recent conversation activity
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'RecentGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp2', 'InactiveGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp2', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type, updated_at) VALUES ('user1', 'grp1', 2, '2026-06-06T10:00:00Z')`)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestFilter(r, "user1", "", "", "recent")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	// Should get only RecentGroup (grp1 has conversation_extra entry)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 item, got %d: %v", len(resp.Data), resp.Data)
+	}
+	if resp.Data[0]["name"] != "RecentGroup" {
+		t.Errorf("expected RecentGroup, got %v", resp.Data[0]["name"])
+	}
+	if resp.Data[0]["last_active_at"] != "2026-06-06T10:00:00Z" {
+		t.Errorf("expected last_active_at=2026-06-06T10:00:00Z, got %v", resp.Data[0]["last_active_at"])
+	}
+}
+
+func TestSearchChatCandidates_FilterEmptyIsBackwardCompatible(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'Group1', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp2', 'Group2', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp2', 'user1', 0)`)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	// No filter = returns all groups (backward compatible)
+	w := doCandidateRequestFilter(r, "user1", "group", "", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 groups with empty filter, got %d", len(resp.Data))
 	}
 }


### PR DESCRIPTION
## Summary

`SearchChatCandidates` 新增 `filter` query 参数，支持按「关注」和「最近」过滤群选择列表。

## Changes

**`internal/api/handler/candidates.go`**
- 新增 `filter` query param（`followed` / `recent` / 空=全部）
- `filter=followed`：查 `group_setting.save=1` 返回用户关注的群及其子区
- `filter=recent`：查 `conversation_extra` 按 `updated_at DESC` 返回最近活跃对话
- 每个 candidate 追加 `is_followed`（bool）和 `last_active_at`（string）字段
- 向后兼容：filter 为空时行为不变

**`internal/api/handler/candidates_test.go`**
- 新增 `group_setting` 和 `conversation_extra` 表到测试 fixture
- 新增 `doCandidateRequestFilter` helper
- 新增 3 个测试：`FilterFollowed`、`FilterRecent`、`FilterEmptyIsBackwardCompatible`
- **All 8 tests pass** ✅（已通过 CC 本地验证）

## Test Results

```
=== RUN   TestSearchChatCandidates_FilterFollowed        ✅
=== RUN   TestSearchChatCandidates_FilterRecent           ✅
=== RUN   TestSearchChatCandidates_FilterEmptyIsBackwardCompatible ✅
ok  github.com/Mininglamp-OSS/octo-smart-summary/internal/api/handler
```

## Related

- Closes #66
- Frontend counterpart: Mininglamp-OSS/octo-web#297