### PR TITLE
fix(docker): add Asia/Shanghai timezone to api and worker images (#68)

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,7 +7,10 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /bin/summary-api ./cmd/summary-api
 
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates tzdata
+ENV TZ=Asia/Shanghai
+RUN apk add --no-cache ca-certificates tzdata \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone
 COPY --from=builder /bin/summary-api /bin/summary-api
 EXPOSE 8080 8081
 ENTRYPOINT ["/bin/summary-api"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -7,7 +7,10 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /bin/summary-worker ./cmd/summary-worker
 
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates tzdata
+ENV TZ=Asia/Shanghai
+RUN apk add --no-cache ca-certificates tzdata \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone
 COPY --from=builder /bin/summary-worker /bin/summary-worker
 EXPOSE 8082
 ENTRYPOINT ["/bin/summary-worker"]


### PR DESCRIPTION
Closes #68.

## Problem

The api and worker containers ran in UTC because their runtime stage only installed `tzdata` without configuring the actual timezone. As a result `time.Now()` in `internal/pipeline/narrow.go` returned UTC wall-clock time, while the LLM time-range extraction prompt hardcodes `+08:00`. This shifted `endTS` ~8 hours early and filtered out same-day messages, producing "在当前范围内未找到与主题相关的聊天记录" even when messages existed.

## Fix

Configure the timezone to `Asia/Shanghai` in the runtime stage of both `Dockerfile.api` and `Dockerfile.worker`, matching the pattern already used by octo-server and octo-speech:

```dockerfile
FROM alpine:3.19
ENV TZ=Asia/Shanghai
RUN apk add --no-cache ca-certificates tzdata \
    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
    && echo $TZ > /etc/timezone
```

Note: instead of `COPY --from=builder /usr/share/zoneinfo/Asia/Shanghai /etc/localtime` (as drafted in the issue), the symlink is built from the runtime stage's own `tzdata`. The `golang:1.25-alpine` builder image does not ship `/usr/share/zoneinfo/Asia/Shanghai` by default, so copying from the builder risks a build failure.

## Scope

Dockerfile-only change. No Go code modified — all logic that requires UTC already calls `.UTC()` explicitly, and the remaining bare `time.Now()` uses are duration measurements (`time.Since`) unaffected by the local timezone.

## Verification

- Both images build successfully.
- `date` inside both containers returns `CST +0800`; `/etc/timezone` is `Asia/Shanghai`.
- Deployed to the local stack and confirmed via running containers (`TZ=Asia/Shanghai`, `+0800`); worker query timestamps now use Beijing time.