### PR TITLE
fix: support archived threads in smart summary when explicitly selected (#78)

### DIFF
--- a/internal/api/handler/candidates.go
+++ b/internal/api/handler/candidates.go
@@ -120,6 +120,9 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 
 	keyword := c.Query("keyword")
 	chatType := c.Query("chat_type") // "group", "direct", or "" = all
+	// include_archived: when true, threads with status=2 (Archived) are also
+	// returned. Defaults to false. Deleted threads (status=3) are NEVER returned.
+	includeArchived := c.Query("include_archived") == "true" || c.Query("include_archived") == "1"
 
 	// Resolve current user from context (set by AuthMiddleware).
 	currentUID, _ := c.Get("user_id")
@@ -155,6 +158,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"chat_type":    "group",
 				"name":         g.Name,
 				"member_count": nil,
+				"is_archived":  false,
 			})
 		}
 	}
@@ -165,12 +169,21 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 			ShortID string `gorm:"column:short_id"`
 			Name    string `gorm:"column:name"`
 			GroupNo string `gorm:"column:group_no"`
+			Status  int    `gorm:"column:status"`
 		}
 		var threads []imThread
 		q := h.imDB.Table("thread t").
-			Select("DISTINCT t.short_id, t.name, t.group_no").
-			Joins("INNER JOIN `group` g ON g.group_no" + h.collate + " = t.group_no").
-			Where("t.status = 1 AND g.status = 1 AND t.message_count > 0")
+			Select("DISTINCT t.short_id, t.name, t.group_no, t.status").
+			Joins("INNER JOIN `group` g ON g.group_no" + h.collate + " = t.group_no")
+		// Default: only Active threads (status=1). When include_archived is set,
+		// also return Archived threads (status=2). Deleted (status=3) is never
+		// included. Parent group must be active (g.status=1) and the thread must
+		// have messages.
+		if includeArchived {
+			q = q.Where("t.status IN (1, 2) AND g.status = 1 AND t.message_count > 0")
+		} else {
+			q = q.Where("t.status = 1 AND g.status = 1 AND t.message_count > 0")
+		}
 		if currentUIDStr != "" {
 			// Use group_member instead of thread_member so that all threads in the
 			// user's groups are returned, not just threads the user has posted in.
@@ -191,6 +204,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"name":            t.Name,
 				"member_count":    nil,
 				"parent_group_no": t.GroupNo,
+				"is_archived":     t.Status == 2,
 			})
 		}
 	}
@@ -238,6 +252,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 				"name":         name,
 				"member_count": nil,
 				"is_bot":       d.Robot == 1,
+				"is_archived":  false,
 			})
 		}
 	}

--- a/internal/api/handler/candidates_test.go
+++ b/internal/api/handler/candidates_test.go
@@ -47,6 +47,19 @@ func doCandidateRequest(r *gin.Engine, userID, chatType, keyword string) *httpte
 	return w
 }
 
+// doCandidateRequestRaw issues a request with a verbatim query string, allowing
+// arbitrary params such as include_archived.
+func doCandidateRequestRaw(r *gin.Engine, userID, query string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/summary-chat-candidates?"+query, nil)
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
 func TestSearchChatCandidates_ThreadUsesGroupMember(t *testing.T) {
 	imDB := setupCandidateImDB(t)
 
@@ -197,5 +210,149 @@ func TestSearchChatCandidates_ThreadExcludesEmptyMessageCount(t *testing.T) {
 	}
 	if resp.Data[0]["name"] != "Active Thread" {
 		t.Errorf("expected 'Active Thread', got %v", resp.Data[0]["name"])
+	}
+}
+
+// seedArchiveScenario seeds one group with three threads: Active (1), Archived
+// (2) and Deleted (3), each with messages, and makes user1 a member.
+func seedArchiveScenario(imDB *gorm.DB) {
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'TestGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (1, 'th001', 'Active Thread', 'grp1', 1, 5)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (2, 'th002', 'Archived Thread', 'grp1', 2, 4)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count) VALUES (3, 'th003', 'Deleted Thread', 'grp1', 3, 9)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+}
+
+func threadNameSet(data []map[string]any) map[string]bool {
+	names := map[string]bool{}
+	for _, item := range data {
+		if name, ok := item["name"].(string); ok {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+func TestSearchChatCandidates_DefaultExcludesArchivedAndDeleted(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	seedArchiveScenario(imDB)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	// No include_archived param -> default false: only Active (status=1).
+	w := doCandidateRequest(r, "user1", "thread", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 thread (only active), got %d: %v", len(resp.Data), resp.Data)
+	}
+	if resp.Data[0]["name"] != "Active Thread" {
+		t.Errorf("expected 'Active Thread', got %v", resp.Data[0]["name"])
+	}
+	if resp.Data[0]["is_archived"] != false {
+		t.Errorf("active thread is_archived should be false, got %v", resp.Data[0]["is_archived"])
+	}
+}
+
+func TestSearchChatCandidates_IncludeArchivedFalseExplicit(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	seedArchiveScenario(imDB)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestRaw(r, "user1", "chat_type=thread&include_archived=false")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 thread for include_archived=false, got %d: %v", len(resp.Data), resp.Data)
+	}
+	if resp.Data[0]["name"] != "Active Thread" {
+		t.Errorf("expected 'Active Thread', got %v", resp.Data[0]["name"])
+	}
+}
+
+func TestSearchChatCandidates_IncludeArchivedTrue(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	seedArchiveScenario(imDB)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequestRaw(r, "user1", "chat_type=thread&include_archived=true")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	// Active + Archived, but NEVER Deleted.
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 threads (active+archived), got %d: %v", len(resp.Data), resp.Data)
+	}
+	names := threadNameSet(resp.Data)
+	if !names["Active Thread"] || !names["Archived Thread"] {
+		t.Errorf("expected Active + Archived threads, got %v", names)
+	}
+	if names["Deleted Thread"] {
+		t.Errorf("Deleted thread must never be returned, got %v", names)
+	}
+
+	// is_archived must be true only for the archived thread.
+	for _, item := range resp.Data {
+		want := item["name"] == "Archived Thread"
+		if item["is_archived"] != want {
+			t.Errorf("thread %v: is_archived = %v, want %v", item["name"], item["is_archived"], want)
+		}
+	}
+}
+
+func TestSearchChatCandidates_GroupAndDirectHaveIsArchivedFalse(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status) VALUES ('grp1', 'TestGroup', 'space1', 1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1', 'user1', 0)`)
+
+	h := NewCandidateHandler(imDB, -1)
+	h.collate = ""
+	r := setupCandidateRouter(h)
+
+	w := doCandidateRequest(r, "user1", "group", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int              `json:"code"`
+		Data []map[string]any `json:"data"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 group, got %d: %v", len(resp.Data), resp.Data)
+	}
+	v, ok := resp.Data[0]["is_archived"]
+	if !ok {
+		t.Fatalf("group candidate missing is_archived field: %v", resp.Data[0])
+	}
+	if v != false {
+		t.Errorf("group is_archived should be false, got %v", v)
 	}
 }

--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -41,7 +41,14 @@ type Message struct {
 type LLMCallFn func(ctx context.Context, prompt string) (string, error)
 
 // GetUserChannels discovers all channels (group + DM) for a user. (Layer 1)
-func GetUserChannels(ctx context.Context, uid string, imDB *gorm.DB) ([]ChannelInfo, error) {
+//
+// selectedThreadIDs scopes the archived-thread relaxation: only threads whose
+// channel id (group_no____short_id) appears here are allowed when their status
+// is Archived (2). When the slice is empty, only Active (status=1) threads are
+// discovered. Deleted threads (status=3) are never returned. This keeps
+// auto/background summaries (no explicit sources) free of archived threads
+// while letting an explicitly-selected archived thread survive discovery.
+func GetUserChannels(ctx context.Context, uid string, imDB *gorm.DB, selectedThreadIDs ...string) ([]ChannelInfo, error) {
 	if imDB == nil {
 		return nil, fmt.Errorf("IM database not available")
 	}
@@ -115,19 +122,30 @@ func GetUserChannels(ctx context.Context, uid string, imDB *gorm.DB) ([]ChannelI
 		SpaceID     string `gorm:"column:space_id"`
 	}
 	var threadChannels []threadRow
-	err = imDB.WithContext(ctx).Raw(`
+	// Active threads (status=1) are always discovered. Archived threads
+	// (status=2) are only discovered when explicitly selected by the caller,
+	// scoped via selectedThreadIDs. Deleted threads (status=3) are never
+	// returned (always excluded by enumerating allowed statuses).
+	threadStatusCond := "t.status = 1"
+	threadArgs := []interface{}{uid}
+	if len(selectedThreadIDs) > 0 {
+		threadStatusCond = "(t.status = 1 OR (t.status = 2 AND CONCAT(t.group_no, '____', t.short_id) IN ?))"
+		threadArgs = append(threadArgs, selectedThreadIDs)
+	}
+	threadQuery := `
 		SELECT CONCAT(t.group_no, '____', t.short_id) AS channel_id,
 		       5 AS channel_type,
 		       CONCAT(t.name, ' · ', g.name) AS channel_name,
 		       COALESCE(g.space_id, '') AS space_id
 		FROM thread t
-		INNER JOIN `+"`group`"+` g ON g.group_no COLLATE utf8mb4_unicode_ci = t.group_no
+		INNER JOIN ` + "`group`" + ` g ON g.group_no COLLATE utf8mb4_unicode_ci = t.group_no
 		INNER JOIN thread_member tm ON tm.thread_id = t.id
 		WHERE tm.uid = ?
-		  AND t.status = 1
+		  AND ` + threadStatusCond + `
 		  AND g.status = 1
 		ORDER BY t.updated_at DESC
-	`, uid).Scan(&threadChannels).Error
+	`
+	err = imDB.WithContext(ctx).Raw(threadQuery, threadArgs...).Scan(&threadChannels).Error
 	if err != nil {
 		log.Printf("[pipeline] query thread channels error: %v", err)
 	}
@@ -204,6 +222,36 @@ func mapFrontendSourceType(frontendType int) int {
 	default:
 		return frontendType
 	}
+}
+
+// sourceType extracts the integer source_type from a specifiedSources entry,
+// handling both int and float64 (JSON-decoded) representations.
+func sourceType(s map[string]interface{}) int {
+	if st, ok := s["source_type"].(int); ok {
+		return st
+	}
+	if st, ok := s["source_type"].(float64); ok {
+		return int(st)
+	}
+	return 0
+}
+
+// selectedThreadChannelIDs returns the channel ids of explicitly-selected thread
+// sources (frontend source_type=2). These scope the archived-thread relaxation in
+// GetUserChannels so that only threads the user actually picked can be archived;
+// auto/background summaries (no explicit sources) get an empty slice and never
+// surface archived threads.
+func selectedThreadChannelIDs(specifiedSources []map[string]interface{}) []string {
+	var ids []string
+	for _, s := range specifiedSources {
+		if mapFrontendSourceType(sourceType(s)) != 5 {
+			continue
+		}
+		if id, ok := s["source_id"].(string); ok && id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }
 
 // ApplySourceConstraints filters channels to only those specified. (Layer 2)
@@ -352,7 +400,12 @@ func FetchMessagesFromChannel(ctx context.Context, channelID string, channelType
 
 // IntersectParticipantChannels filters channels to only those where both
 // the creator and all participants are members. (Layer 1.5)
-func IntersectParticipantChannels(ctx context.Context, creatorChannels []ChannelInfo, participantUIDs []string, imDB *gorm.DB) ([]ChannelInfo, error) {
+//
+// selectedThreadIDs is threaded into each participant's GetUserChannels call with
+// the same scope as Layer 1, so an explicitly-selected archived thread that the
+// creator can see is not dropped just because the participant lookup defaulted to
+// status=1-only discovery.
+func IntersectParticipantChannels(ctx context.Context, creatorChannels []ChannelInfo, participantUIDs []string, imDB *gorm.DB, selectedThreadIDs ...string) ([]ChannelInfo, error) {
 	if len(participantUIDs) == 0 {
 		return creatorChannels, nil
 	}
@@ -365,7 +418,7 @@ func IntersectParticipantChannels(ctx context.Context, creatorChannels []Channel
 
 	// For each participant, get their channels and intersect
 	for _, uid := range participantUIDs {
-		pChannels, err := GetUserChannels(ctx, uid, imDB)
+		pChannels, err := GetUserChannels(ctx, uid, imDB, selectedThreadIDs...)
 		if err != nil {
 			return nil, fmt.Errorf("get channels for participant %s: %w", uid, err)
 		}
@@ -563,7 +616,11 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 
 	// Layer 1: channel discovery
 	l1Start := time.Now()
-	userChannels, err := GetUserChannels(ctx, creatorUID, imDB)
+	// Scope archived-thread discovery to explicitly-selected thread sources so
+	// an archived thread the user picked survives, while auto/background
+	// summaries (no explicit sources) keep status=1 and never leak archived.
+	selectedThreads := selectedThreadChannelIDs(specifiedSources)
+	userChannels, err := GetUserChannels(ctx, creatorUID, imDB, selectedThreads...)
 	if err != nil {
 		return nil, fmt.Errorf("channel discovery: %w", err)
 	}
@@ -572,7 +629,7 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 
 	// Layer 1.5: intersect with participant channels
 	l15Start := time.Now()
-	userChannels, err = IntersectParticipantChannels(ctx, userChannels, participantUIDs, imDB)
+	userChannels, err = IntersectParticipantChannels(ctx, userChannels, participantUIDs, imDB, selectedThreads...)
 	if err != nil {
 		return nil, fmt.Errorf("intersect participant channels: %w", err)
 	}
@@ -660,13 +717,7 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 	l45Start := time.Now()
 	onlyDMSources := len(specifiedSources) > 0
 	for _, s := range specifiedSources {
-		st := 0
-		if v, ok := s["source_type"].(int); ok {
-			st = v
-		} else if v, ok := s["source_type"].(float64); ok {
-			st = int(v)
-		}
-		if st != 3 { // not DM
+		if sourceType(s) != 3 { // not DM
 			onlyDMSources = false
 			break
 		}

--- a/internal/pipeline/fetch_archive_test.go
+++ b/internal/pipeline/fetch_archive_test.go
@@ -1,0 +1,330 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// archiveDriverOnce registers a sqlite3 driver variant that knows the MySQL
+// collation name (utf8mb4_unicode_ci) hardcoded into the pipeline's thread
+// queries, so those raw SQL joins run under SQLite in tests.
+var archiveDriverOnce sync.Once
+
+const archiveDriverName = "sqlite3_pipeline_collate"
+
+func registerArchiveDriver() {
+	archiveDriverOnce.Do(func() {
+		sql.Register(archiveDriverName, &sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				// Map the MySQL collation to a plain byte comparison.
+				return conn.RegisterCollation("utf8mb4_unicode_ci", func(a, b string) int {
+					switch {
+					case a < b:
+						return -1
+					case a > b:
+						return 1
+					default:
+						return 0
+					}
+				})
+			},
+		})
+	})
+}
+
+// setupPipelineImDB builds an in-memory IM schema sufficient for GetUserChannels
+// and the message-fetch path, with the MySQL collation registered.
+func setupPipelineImDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	registerArchiveDriver()
+	db, err := gorm.Open(sqlite.Dialector{DriverName: archiveDriverName, DSN: ":memory:"}, &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open pipeline im db: %v", err)
+	}
+	db.Exec(`CREATE TABLE "group" (group_no TEXT NOT NULL, name TEXT, space_id TEXT, status INTEGER DEFAULT 1, creator TEXT, updated_at INTEGER DEFAULT 0)`)
+	db.Exec(`CREATE TABLE thread (id INTEGER PRIMARY KEY, short_id TEXT, name TEXT, group_no TEXT, status INTEGER DEFAULT 1, message_count INTEGER DEFAULT 0, creator_uid TEXT, updated_at INTEGER DEFAULT 0)`)
+	db.Exec(`CREATE TABLE thread_member (thread_id INTEGER NOT NULL, uid TEXT NOT NULL)`)
+	db.Exec(`CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0, role INTEGER DEFAULT 0)`)
+	db.Exec(`CREATE TABLE conversation_extra (uid TEXT, channel_id TEXT, channel_type INTEGER, updated_at INTEGER DEFAULT 0)`)
+	// Single message shard ("message") is enough for tableCount=1.
+	db.Exec("CREATE TABLE message (message_seq INTEGER, from_uid TEXT, channel_id TEXT, channel_type INTEGER, timestamp INTEGER, payload BLOB, is_deleted INTEGER DEFAULT 0)")
+	return db
+}
+
+// seedThreadScenario seeds one active group with Active(1)/Archived(2)/Deleted(3)
+// threads, makes user1 a member of each, and inserts one text message per thread.
+func seedPipelineThreads(db *gorm.DB, ts int64) {
+	db.Exec(`INSERT INTO "group" (group_no, name, space_id, status, creator) VALUES ('grp1', 'TestGroup', 'space1', 1, 'user1')`)
+	db.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count, creator_uid) VALUES (1, 'thA', 'Active', 'grp1', 1, 5, 'user1')`)
+	db.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count, creator_uid) VALUES (2, 'thB', 'Archived', 'grp1', 2, 4, 'user1')`)
+	db.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count, creator_uid) VALUES (3, 'thC', 'Deleted', 'grp1', 3, 9, 'user1')`)
+	db.Exec(`INSERT INTO thread_member (thread_id, uid) VALUES (1, 'user1'), (2, 'user1'), (3, 'user1')`)
+	db.Exec(`INSERT INTO group_member (group_no, uid, is_deleted, role) VALUES ('grp1', 'user1', 0, 0)`)
+
+	payload := `{"type":1,"content":"hello"}`
+	db.Exec(`INSERT INTO message (message_seq, from_uid, channel_id, channel_type, timestamp, payload, is_deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		1, "user1", "grp1____thA", 5, ts, []byte(payload), 0)
+	db.Exec(`INSERT INTO message (message_seq, from_uid, channel_id, channel_type, timestamp, payload, is_deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		2, "user1", "grp1____thB", 5, ts, []byte(payload), 0)
+	db.Exec(`INSERT INTO message (message_seq, from_uid, channel_id, channel_type, timestamp, payload, is_deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		3, "user1", "grp1____thC", 5, ts, []byte(payload), 0)
+}
+
+func threadIDSet(channels []ChannelInfo) map[string]bool {
+	set := map[string]bool{}
+	for _, ch := range channels {
+		if ch.ChannelType == 5 {
+			set[ch.ChannelID] = true
+		}
+	}
+	return set
+}
+
+func TestGetUserChannels_NoSelection_ExcludesArchivedAndDeleted(t *testing.T) {
+	db := setupPipelineImDB(t)
+	seedPipelineThreads(db, time.Now().Unix())
+
+	channels, err := GetUserChannels(context.Background(), "user1", db)
+	if err != nil {
+		t.Fatalf("GetUserChannels: %v", err)
+	}
+	threads := threadIDSet(channels)
+	if !threads["grp1____thA"] {
+		t.Errorf("active thread should be discovered, got %v", threads)
+	}
+	if threads["grp1____thB"] {
+		t.Errorf("archived thread must NOT be auto-discovered, got %v", threads)
+	}
+	if threads["grp1____thC"] {
+		t.Errorf("deleted thread must never be discovered, got %v", threads)
+	}
+}
+
+func TestGetUserChannels_SelectedArchivedRetained(t *testing.T) {
+	db := setupPipelineImDB(t)
+	seedPipelineThreads(db, time.Now().Unix())
+
+	channels, err := GetUserChannels(context.Background(), "user1", db, "grp1____thB")
+	if err != nil {
+		t.Fatalf("GetUserChannels: %v", err)
+	}
+	threads := threadIDSet(channels)
+	if !threads["grp1____thA"] {
+		t.Errorf("active thread should still be discovered, got %v", threads)
+	}
+	if !threads["grp1____thB"] {
+		t.Errorf("explicitly-selected archived thread must be retained, got %v", threads)
+	}
+	// Even when an archived thread is selected, Deleted (3) must stay excluded.
+	if threads["grp1____thC"] {
+		t.Errorf("deleted thread must never be discovered even when selected siblings exist, got %v", threads)
+	}
+}
+
+func TestGetUserChannels_SelectedDeletedNeverRetained(t *testing.T) {
+	db := setupPipelineImDB(t)
+	seedPipelineThreads(db, time.Now().Unix())
+
+	// Even if a deleted thread id is passed as selected, it must not appear:
+	// the relaxation only admits status=2.
+	channels, err := GetUserChannels(context.Background(), "user1", db, "grp1____thC")
+	if err != nil {
+		t.Fatalf("GetUserChannels: %v", err)
+	}
+	threads := threadIDSet(channels)
+	if threads["grp1____thC"] {
+		t.Errorf("deleted thread must never be discovered, got %v", threads)
+	}
+}
+
+func TestResolveAndFetch_SelectedArchivedThread_ProducesMessages(t *testing.T) {
+	db := setupPipelineImDB(t)
+	ts := time.Now().Add(-time.Hour).Unix()
+	seedPipelineThreads(db, ts)
+
+	specifiedSources := []map[string]interface{}{
+		{"source_id": "grp1____thB", "source_type": 2}, // frontend thread type
+	}
+
+	start := time.Now().Add(-24 * time.Hour)
+	end := time.Now().Add(time.Hour)
+
+	msgs, err := ResolveAndFetchMessagesForPersonal(
+		context.Background(), "user1", nil, nil, specifiedSources, "",
+		start, end, db, nil, nil, 1, 0, 2, nil,
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatalf("expected non-empty summary input for selected archived thread, got 0 messages")
+	}
+	for _, m := range msgs {
+		if m.ChannelID != "grp1____thB" {
+			t.Errorf("unexpected message from %s, want only grp1____thB", m.ChannelID)
+		}
+	}
+}
+
+func TestResolveAndFetch_NoSources_ArchivedExcluded(t *testing.T) {
+	db := setupPipelineImDB(t)
+	ts := time.Now().Add(-time.Hour).Unix()
+	seedPipelineThreads(db, ts)
+
+	start := time.Now().Add(-24 * time.Hour)
+	end := time.Now().Add(time.Hour)
+
+	// No explicit sources -> auto discovery -> only the active thread's message.
+	msgs, err := ResolveAndFetchMessagesForPersonal(
+		context.Background(), "user1", nil, nil, nil, "",
+		start, end, db, nil, nil, 1, 0, 2, nil,
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
+	}
+	for _, m := range msgs {
+		if m.ChannelID == "grp1____thB" {
+			t.Errorf("archived thread message leaked into auto summary: %+v", m)
+		}
+		if m.ChannelID == "grp1____thC" {
+			t.Errorf("deleted thread message must never be fetched: %+v", m)
+		}
+	}
+	// The active thread should be present.
+	var sawActive bool
+	for _, m := range msgs {
+		if m.ChannelID == "grp1____thA" {
+			sawActive = true
+		}
+	}
+	if !sawActive {
+		t.Errorf("expected active thread message in auto summary, got %d messages", len(msgs))
+	}
+}
+
+func TestFilterByOwnership_ArchivedThreadCreatorRetained(t *testing.T) {
+	db := setupPipelineImDB(t)
+	seedPipelineThreads(db, time.Now().Unix())
+
+	// user1 is creator of both active (thA) and archived (thB) threads; the
+	// ownership resolver must keep the archived one when explicitly a candidate.
+	candidates := []ChannelInfo{
+		{ChannelID: "grp1____thA", ChannelType: 5, ChannelName: "Active"},
+		{ChannelID: "grp1____thB", ChannelType: 5, ChannelName: "Archived"},
+		{ChannelID: "grp1____thC", ChannelType: 5, ChannelName: "Deleted"},
+	}
+	result := filterByOwnership(context.Background(), candidates, "user1", []string{"creator"}, db)
+	got := threadIDSet(result)
+	if !got["grp1____thA"] {
+		t.Errorf("creator active thread should be retained, got %v", got)
+	}
+	if !got["grp1____thB"] {
+		t.Errorf("creator archived thread should be retained, got %v", got)
+	}
+	if got["grp1____thC"] {
+		t.Errorf("deleted thread must be excluded by ownership query, got %v", got)
+	}
+}
+
+func TestFilterByOwnership_ArchivedThreadMemberRetained(t *testing.T) {
+	db := setupPipelineImDB(t)
+	seedPipelineThreads(db, time.Now().Unix())
+	// Add a separate creator so user1 is a non-creator member of the threads.
+	db.Exec(`UPDATE thread SET creator_uid = 'owner_other' WHERE id IN (1,2,3)`)
+
+	candidates := []ChannelInfo{
+		{ChannelID: "grp1____thA", ChannelType: 5, ChannelName: "Active"},
+		{ChannelID: "grp1____thB", ChannelType: 5, ChannelName: "Archived"},
+		{ChannelID: "grp1____thC", ChannelType: 5, ChannelName: "Deleted"},
+	}
+	result := filterByOwnership(context.Background(), candidates, "user1", []string{"member"}, db)
+	got := threadIDSet(result)
+	if !got["grp1____thB"] {
+		t.Errorf("member archived thread should be retained, got %v", got)
+	}
+	if got["grp1____thC"] {
+		t.Errorf("deleted thread must be excluded by member ownership query, got %v", got)
+	}
+}
+
+// seedSharedArchivedThread seeds a group with both user1 and user2 as members of
+// an archived thread that carries one message from each, so a multi-person
+// summary (creator user1, participant user2) has mutual activity to retain.
+func seedSharedArchivedThread(db *gorm.DB, ts int64) {
+	db.Exec(`INSERT INTO "group" (group_no, name, space_id, status, creator) VALUES ('grp1', 'TestGroup', 'space1', 1, 'user1')`)
+	db.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count, creator_uid) VALUES (1, 'thA', 'Active', 'grp1', 1, 5, 'user1')`)
+	db.Exec(`INSERT INTO thread (id, short_id, name, group_no, status, message_count, creator_uid) VALUES (2, 'thB', 'Archived', 'grp1', 2, 4, 'user1')`)
+	// Both members belong to both threads.
+	db.Exec(`INSERT INTO thread_member (thread_id, uid) VALUES (1, 'user1'), (1, 'user2'), (2, 'user1'), (2, 'user2')`)
+	db.Exec(`INSERT INTO group_member (group_no, uid, is_deleted, role) VALUES ('grp1', 'user1', 0, 0), ('grp1', 'user2', 0, 0)`)
+
+	payload := `{"type":1,"content":"hello"}`
+	db.Exec(`INSERT INTO message (message_seq, from_uid, channel_id, channel_type, timestamp, payload, is_deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		1, "user1", "grp1____thB", 5, ts, []byte(payload), 0)
+	db.Exec(`INSERT INTO message (message_seq, from_uid, channel_id, channel_type, timestamp, payload, is_deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		2, "user2", "grp1____thB", 5, ts, []byte(payload), 0)
+}
+
+// TestResolveAndFetch_MultiPerson_SelectedArchivedThread_Retained is the
+// regression guard for the Layer 1.5 blocker: a participant channel lookup that
+// ignored the selected-thread scope removed the creator-side archived thread in
+// the intersect, yielding an empty summary. With the scope threaded through, the
+// shared archived thread survives and its messages are returned.
+func TestResolveAndFetch_MultiPerson_SelectedArchivedThread_Retained(t *testing.T) {
+	db := setupPipelineImDB(t)
+	ts := time.Now().Add(-time.Hour).Unix()
+	seedSharedArchivedThread(db, ts)
+
+	specifiedSources := []map[string]interface{}{
+		{"source_id": "grp1____thB", "source_type": 2}, // frontend thread type
+	}
+
+	start := time.Now().Add(-24 * time.Hour)
+	end := time.Now().Add(time.Hour)
+
+	msgs, err := ResolveAndFetchMessagesForPersonal(
+		context.Background(), "user1", []string{"user2"}, nil, specifiedSources, "",
+		start, end, db, nil, nil, 1, 0, 2, nil,
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatalf("expected non-empty multi-person summary for selected archived thread, got 0 messages")
+	}
+	for _, m := range msgs {
+		if m.ChannelID != "grp1____thB" {
+			t.Errorf("unexpected message from %s, want only grp1____thB", m.ChannelID)
+		}
+	}
+}
+
+// TestIntersectParticipantChannels_EmptySelection_NoArchived asserts that an
+// empty selected-thread slice keeps participant discovery on the status=1-only
+// query, so an archived thread shared by both members is not surfaced.
+func TestIntersectParticipantChannels_EmptySelection_NoArchived(t *testing.T) {
+	db := setupPipelineImDB(t)
+	seedSharedArchivedThread(db, time.Now().Unix())
+
+	// Creator can see the archived thread (it was explicitly selected for them),
+	// but with no selection threaded into the participant lookup, the intersect
+	// drops it because user2's status=1-only discovery never includes it.
+	creatorChannels, err := GetUserChannels(context.Background(), "user1", db, "grp1____thB")
+	if err != nil {
+		t.Fatalf("GetUserChannels: %v", err)
+	}
+	result, err := IntersectParticipantChannels(context.Background(), creatorChannels, []string{"user2"}, db)
+	if err != nil {
+		t.Fatalf("IntersectParticipantChannels: %v", err)
+	}
+	if threadIDSet(result)["grp1____thB"] {
+		t.Errorf("empty selection must keep participant discovery on status=1 (no archived), got %v", threadIDSet(result))
+	}
+}

--- a/internal/pipeline/resolve_channel.go
+++ b/internal/pipeline/resolve_channel.go
@@ -329,8 +329,15 @@ func filterByOwnership(ctx context.Context, candidates []ChannelInfo, creatorUID
 			}
 			if len(threadChannelIDs) > 0 {
 				var ids []string
+				// status IN (1, 2) relaxes the default status=1 to also admit
+				// archived threads. This is defense-in-depth: filterByOwnership only
+				// runs when no explicit sources are specified, and in that path Layer 1
+				// has already excluded archived threads, so this branch never actually
+				// sees an archived candidate today. It is kept so the ownership filter
+				// stays correct if archived threads ever reach it, and so the
+				// Deleted-exclusion guarantee (status=3 never matches) holds regardless.
 				if err := imDB.WithContext(ctx).Raw(
-					"SELECT CONCAT(group_no, '____', short_id) FROM thread WHERE creator_uid = ? AND CONCAT(group_no, '____', short_id) IN ? AND status = 1",
+					"SELECT CONCAT(group_no, '____', short_id) FROM thread WHERE creator_uid = ? AND CONCAT(group_no, '____', short_id) IN ? AND status IN (1, 2)",
 					creatorUID, threadChannelIDs,
 				).Pluck("CONCAT(group_no, '____', short_id)", &ids).Error; err != nil {
 					log.Printf("[pipeline] filterByOwnership: query creator thread error: %v", err)
@@ -375,10 +382,14 @@ func filterByOwnership(ctx context.Context, candidates []ChannelInfo, creatorUID
 			}
 			if len(threadChannelIDs) > 0 {
 				var ids []string
+				// status IN (1, 2) here is defense-in-depth for the same reason as the
+				// creator branch above: archived threads do not reach filterByOwnership
+				// in the real pipeline, but admitting status=2 keeps the filter correct
+				// if they ever do, while status=3 (Deleted) stays excluded.
 				if err := imDB.WithContext(ctx).Raw(
 					"SELECT CONCAT(t.group_no, '____', t.short_id) FROM thread t "+
 						"INNER JOIN thread_member tm ON tm.thread_id = t.id "+
-						"WHERE tm.uid = ? AND t.creator_uid != ? AND CONCAT(t.group_no, '____', t.short_id) IN ? AND t.status = 1",
+						"WHERE tm.uid = ? AND t.creator_uid != ? AND CONCAT(t.group_no, '____', t.short_id) IN ? AND t.status IN (1, 2)",
 					creatorUID, creatorUID, threadChannelIDs,
 				).Pluck("CONCAT(t.group_no, '____', t.short_id)", &ids).Error; err != nil {
 					log.Printf("[pipeline] filterByOwnership: query member thread error: %v", err)


### PR DESCRIPTION
Closes #78. Frontend counterpart: Mininglamp-OSS/octo-web#346.

## Summary

Archived threads (status=2) were hard-excluded from smart summary in two independent backend layers, and the candidate response never told the frontend whether a thread was archived. This change lets an explicitly-selected archived thread be summarized, while keeping auto/background summaries to active threads only and always excluding deleted (status=3).

## Changes

- `internal/api/handler/candidates.go`: parse `include_archived` query param (default false). Thread candidate query uses `t.status = 1` by default and `t.status IN (1,2)` when `include_archived=true` (keeps `g.status = 1`, `message_count > 0`; never status=3). Added `is_archived` to all candidate objects (threads: true iff status=2; groups/directs: always false).
- `internal/pipeline/fetch.go`: relax thread discovery to `status IN (1,2)` ONLY for explicitly-selected sources, threaded through `GetUserChannels` / `IntersectParticipantChannels` so auto/background summaries (no explicit sources) keep `status = 1` and never include archived threads.
- `internal/pipeline/resolve_channel.go`: relax thread ownership queries (creator/member) to `status IN (1,2)` for explicitly-selected ids; deleted always excluded (defense-in-depth, documented in comments).

## End-to-end contract (with octo-web#346)

- Request: `include_archived` (bool query param, default false).
- Response: `is_archived` (bool per candidate, default false).

## Tests

- `candidates_test.go`: seeds status 1/2/3; asserts default returns only active; `include_archived=true` returns active + archived, never deleted; `is_archived` correct per type.
- `fetch_archive_test.go`: archived excluded from auto-discovery; explicitly-selected archived retained through the full pipeline (single-person AND multi-person participant intersect) and produces non-empty messages; selected-deleted never retained; ownership resolver covers archived selected thread for creator/member roles.

`go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Coordination

Must ship together with octo-web#346 — relaxing the candidate listing without relaxing the fetch pipeline would let users select an archived thread and get an empty summary.