### PR TITLE
fix(schedule): preserve source names

### DIFF
--- a/internal/api/handler/schedule_behavior_test.go
+++ b/internal/api/handler/schedule_behavior_test.go
@@ -168,6 +168,80 @@ func TestCreateSchedule_BindsUnscheduledTask(t *testing.T) {
 	}
 }
 
+func TestCreateSchedule_PreservesSourceNameInConfig(t *testing.T) {
+	db := newScheduleTestDB(t)
+	r := newScheduleTestRouter(db)
+	taskID := seedScheduleTask(t, db, "T1", "s1", "u1")
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID, "interval_days": 1, "run_time": "09:00",
+		"sources": []map[string]interface{}{
+			{"source_type": model.SourceGroup, "source_id": "grp1____s1", "source_name": "研发群(群聊)"},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 creating schedule, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var task model.SummaryTask
+	if err := db.First(&task, taskID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if task.ScheduleID == nil {
+		t.Fatal("task should be bound to a schedule after create")
+	}
+	assertScheduleSourceName(t, db, *task.ScheduleID, "研发群(群聊)")
+}
+
+func TestUpdateSchedule_PreservesSourceNameInConfig(t *testing.T) {
+	db := newScheduleTestDB(t)
+	r := newScheduleTestRouter(db)
+	taskID := seedScheduleTask(t, db, "T1", "s1", "u1")
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID, "interval_days": 1, "run_time": "09:00",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create schedule: %d %s", w.Code, w.Body.String())
+	}
+	var task model.SummaryTask
+	if err := db.First(&task, taskID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if task.ScheduleID == nil {
+		t.Fatal("task should be bound to a schedule after create")
+	}
+
+	w = scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(*task.ScheduleID), map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"sources": []map[string]interface{}{
+			{"source_type": model.SourceGroup, "source_id": "grp2____s1", "source_name": "产品群(群聊)"},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("update schedule: %d %s", w.Code, w.Body.String())
+	}
+	assertScheduleSourceName(t, db, *task.ScheduleID, "产品群(群聊)")
+}
+
+func assertScheduleSourceName(t *testing.T, db *gorm.DB, scheduleID int64, want string) {
+	t.Helper()
+	var sched model.SummarySchedule
+	if err := db.First(&sched, scheduleID).Error; err != nil {
+		t.Fatal(err)
+	}
+	var sources []sourceReq
+	if err := json.Unmarshal(sched.SourceConfig, &sources); err != nil {
+		t.Fatalf("unmarshal source_config: %v", err)
+	}
+	if len(sources) != 1 {
+		t.Fatalf("source_config entries = %d, want 1", len(sources))
+	}
+	if sources[0].SourceName != want {
+		t.Fatalf("source_name = %q, want %q; raw config: %s", sources[0].SourceName, want, string(sched.SourceConfig))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Single-person invariant: scheduled summary rejects multi-person tasks.
 // ---------------------------------------------------------------------------

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -121,6 +121,7 @@ type timeRange struct {
 type sourceReq struct {
 	SourceType int    `json:"source_type"`
 	SourceID   string `json:"source_id"`
+	SourceName string `json:"source_name"`
 }
 
 type participantReq struct {

--- a/internal/worker/scheduled_replace_test.go
+++ b/internal/worker/scheduled_replace_test.go
@@ -20,6 +20,7 @@ func newReplaceTestDB(t *testing.T) *gorm.DB {
 		&model.SummaryResult{},
 		&model.SummaryChunk{},
 		&model.SummaryParticipant{},
+		&model.SummarySource{},
 		&model.PersonalResult{},
 	); err != nil {
 		t.Fatalf("migrate: %v", err)
@@ -119,6 +120,28 @@ func TestSaveLatestResult_ScheduledKeepsHandEditedResult(t *testing.T) {
 	db.Model(&model.SummaryResult{}).Where("task_id = ? AND edited_at IS NOT NULL", taskID).Count(&editedCount)
 	if editedCount != 1 {
 		t.Errorf("hand-edited result count = %d, want 1", editedCount)
+	}
+}
+
+func TestBuildScheduledTaskSources_PreservesConfiguredSourceName(t *testing.T) {
+	db := newReplaceTestDB(t)
+	raw := model.JSON(`[{"source_type":1,"source_id":"grp1____space1","source_name":"研发群(群聊)"}]`)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return buildScheduledTaskSources(tx, 42, raw)
+	}); err != nil {
+		t.Fatalf("build scheduled sources: %v", err)
+	}
+
+	var source model.SummarySource
+	if err := db.Where("task_id = ?", 42).First(&source).Error; err != nil {
+		t.Fatal(err)
+	}
+	if source.SourceName != "研发群(群聊)" {
+		t.Fatalf("source_name = %q, want %q", source.SourceName, "研发群(群聊)")
+	}
+	if source.SourceID != "grp1____space1" || source.SourceType != model.SourceGroup {
+		t.Fatalf("source = %+v, want group source grp1____space1", source)
 	}
 }
 


### PR DESCRIPTION
Fixes #89

## Summary
- preserve `source_name` when create/update schedule requests store `source_config`
- add regression coverage for schedule create/update persistence and scheduled source materialization

## Root cause
Schedule create/update requests reused `sourceReq`, but that struct did not include `source_name`. JSON binding therefore dropped the frontend-provided name before `source_config` was saved. Scheduled runs then rebuilt task sources from config without the real name and fell back to the placeholder resolver.

## Validation
- `go test -race -count=1 -run "Test(CreateSchedule_PreservesSourceNameInConfig|UpdateSchedule_PreservesSourceNameInConfig)$" ./internal/api/handler`
- `go test -race -count=1 -run TestBuildScheduledTaskSources_PreservesConfiguredSourceName ./internal/worker`
- `go build -v ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `go test -race -count=1 -timeout 5m ./internal/api/handler ./internal/worker`
- `git diff --check`
- `go test -race -shuffle=on -count=1 -timeout 5m ./...`
