### PR TITLE
fix(schedule): preserve real source_name for scheduled summaries (#89)

### DIFF
--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -83,7 +83,7 @@ func main() {
 	go proc.Run()
 
 	// Start scheduler (cron jobs)
-	cronSched := worker.StartScheduler(summaryDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays)
+	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays)
 
 	// Start internal HTTP server for worker-trigger
 	hub := ws.NewHub(summaryDB)

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -121,6 +121,7 @@ type timeRange struct {
 type sourceReq struct {
 	SourceType int    `json:"source_type"`
 	SourceID   string `json:"source_id"`
+	SourceName string `json:"source_name"`
 }
 
 type participantReq struct {

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -25,8 +25,8 @@ type scheduleParticipantConfig struct {
 	UserName string `json:"user_name"`
 }
 
-func syncScheduledTaskConfig(tx *gorm.DB, sched model.SummarySchedule, task model.SummaryTask, now time.Time) error {
-	if err := syncScheduledTaskSources(tx, task.ID, sched.SourceConfig); err != nil {
+func syncScheduledTaskConfig(tx *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, task model.SummaryTask, now time.Time) error {
+	if err := syncScheduledTaskSources(tx, imDB, task.ID, sched.SourceConfig); err != nil {
 		return err
 	}
 	if err := syncScheduledTaskParticipants(tx, task, sched.ParticipantConfig, now); err != nil {
@@ -41,8 +41,8 @@ func syncScheduledTaskConfig(tx *gorm.DB, sched model.SummarySchedule, task mode
 // rebuilt from the schedule config (the source of truth). This is the same shape
 // as syncScheduledTaskConfig but assumes no pre-existing children (no deletes) and
 // always materializes the creator participant even when ParticipantConfig is empty.
-func buildScheduledTaskChildren(tx *gorm.DB, sched model.SummarySchedule, task model.SummaryTask, now time.Time) error {
-	if err := buildScheduledTaskSources(tx, task.ID, sched.SourceConfig); err != nil {
+func buildScheduledTaskChildren(tx *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, task model.SummaryTask, now time.Time) error {
+	if err := buildScheduledTaskSources(tx, imDB, task.ID, sched.SourceConfig); err != nil {
 		return err
 	}
 	if err := buildScheduledTaskParticipants(tx, task, sched.ParticipantConfig, now); err != nil {
@@ -51,7 +51,7 @@ func buildScheduledTaskChildren(tx *gorm.DB, sched model.SummarySchedule, task m
 	return nil
 }
 
-func buildScheduledTaskSources(tx *gorm.DB, taskID int64, raw model.JSON) error {
+func buildScheduledTaskSources(tx *gorm.DB, imDB *gorm.DB, taskID int64, raw model.JSON) error {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -65,7 +65,7 @@ func buildScheduledTaskSources(tx *gorm.DB, taskID int64, raw model.JSON) error 
 		}
 		sourceName := src.SourceName
 		if sourceName == "" {
-			sourceName = service.ResolveSourceNameWithType(src.SourceID, src.SourceType, nil)
+			sourceName = service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
 		}
 		if err := tx.Create(&model.SummarySource{
 			TaskID:     taskID,
@@ -140,7 +140,7 @@ func buildScheduledTaskParticipants(tx *gorm.DB, task model.SummaryTask, raw mod
 	return nil
 }
 
-func syncScheduledTaskSources(tx *gorm.DB, taskID int64, raw model.JSON) error {
+func syncScheduledTaskSources(tx *gorm.DB, imDB *gorm.DB, taskID int64, raw model.JSON) error {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -158,7 +158,7 @@ func syncScheduledTaskSources(tx *gorm.DB, taskID int64, raw model.JSON) error {
 		}
 		sourceName := src.SourceName
 		if sourceName == "" {
-			sourceName = service.ResolveSourceNameWithType(src.SourceID, src.SourceType, nil)
+			sourceName = service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
 		}
 		if err := tx.Create(&model.SummarySource{
 			TaskID:     taskID,

--- a/internal/worker/scheduled_replace_test.go
+++ b/internal/worker/scheduled_replace_test.go
@@ -166,3 +166,55 @@ func TestSyncScheduledTaskParticipants_AlwaysIncludesCreatorAndDedups(t *testing
 		t.Errorf("participant = %+v, want creator/accepted", parts[0])
 	}
 }
+
+// buildScheduledTaskSources must persist the source_name carried in the
+// schedule config verbatim (the fix for the dropped-name bug). It must NOT
+// degrade a config-provided real name into the fallback placeholder.
+func TestBuildScheduledTaskSources_UsesConfigSourceName(t *testing.T) {
+	db := newReplaceTestDB(t)
+	if err := db.AutoMigrate(&model.SummarySource{}); err != nil {
+		t.Fatalf("migrate source: %v", err)
+	}
+	taskID := seedProcessingTask(t, db)
+
+	// Config carries the real group name -> it must be stored as-is.
+	raw := model.JSON(`[{"source_type":1,"source_id":"group-abcdef123456","source_name":"真实群名(群聊)"}]`)
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		// imDB=nil on purpose: with a config name present the resolver must
+		// never be consulted, so nil is irrelevant here.
+		return buildScheduledTaskSources(tx, nil, taskID, raw)
+	}); err != nil {
+		t.Fatalf("build sources: %v", err)
+	}
+
+	var src model.SummarySource
+	db.Where("task_id = ?", taskID).First(&src)
+	if src.SourceName != "真实群名(群聊)" {
+		t.Errorf("source_name = %q, want config name %q", src.SourceName, "真实群名(群聊)")
+	}
+}
+
+// When the config has no source_name and no IM DB is available, the function
+// falls back to the placeholder name (documents the legacy degradation path so
+// the fallback contract is locked in).
+func TestBuildScheduledTaskSources_FallbackWhenNoNameAndNoIMDB(t *testing.T) {
+	db := newReplaceTestDB(t)
+	if err := db.AutoMigrate(&model.SummarySource{}); err != nil {
+		t.Fatalf("migrate source: %v", err)
+	}
+	taskID := seedProcessingTask(t, db)
+
+	raw := model.JSON(`[{"source_type":1,"source_id":"group-abcdef123456"}]`)
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return buildScheduledTaskSources(tx, nil, taskID, raw)
+	}); err != nil {
+		t.Fatalf("build sources: %v", err)
+	}
+
+	var src model.SummarySource
+	db.Where("task_id = ?", taskID).First(&src)
+	want := "来源-group-ab(群聊)"
+	if src.SourceName != want {
+		t.Errorf("source_name = %q, want fallback %q", src.SourceName, want)
+	}
+}

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -19,10 +19,10 @@ import (
 var schedulerHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 // StartScheduler starts the 4 cron scan jobs (every 60s).
-func StartScheduler(db *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int) *cron.Cron {
+func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int) *cron.Cron {
 	c := cron.New()
 
-	c.AddFunc("@every 60s", func() { scanPendingSchedules(db, maxWindowDays) })
+	c.AddFunc("@every 60s", func() { scanPendingSchedules(db, imDB, maxWindowDays) })
 	c.AddFunc("@every 60s", func() { scanConfirmTimeouts(db) })
 	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry) })
 	c.AddFunc("@every 60s", func() { scanStuckPersonalTasks(db, workerTriggerURL) })
@@ -33,7 +33,7 @@ func StartScheduler(db *gorm.DB, maxRetry int, workerTriggerURL string, maxWindo
 }
 
 // scanPendingSchedules requeues bound tasks from due schedules.
-func scanPendingSchedules(db *gorm.DB, maxWindowDays int) {
+func scanPendingSchedules(db *gorm.DB, imDB *gorm.DB, maxWindowDays int) {
 	now := timezone.Now()
 	var schedules []model.SummarySchedule
 	err := db.Where("is_active = 1 AND next_run_at <= ? AND deleted_at IS NULL", now).Find(&schedules).Error
@@ -43,7 +43,7 @@ func scanPendingSchedules(db *gorm.DB, maxWindowDays int) {
 	}
 
 	for _, sched := range schedules {
-		taskID, claimed, err := claimAndCreateScheduledTask(db, sched, now, maxWindowDays)
+		taskID, claimed, err := claimAndCreateScheduledTask(db, imDB, sched, now, maxWindowDays)
 		if err != nil {
 			log.Printf("[scheduler] create task for schedule %d: %v", sched.ID, err)
 			continue
@@ -58,7 +58,7 @@ func scanPendingSchedules(db *gorm.DB, maxWindowDays int) {
 	}
 }
 
-func claimAndCreateScheduledTask(db *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int) (int64, bool, error) {
+func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int) (int64, bool, error) {
 	if sched.NextRunAt == nil {
 		return 0, false, nil
 	}
@@ -216,7 +216,7 @@ func claimAndCreateScheduledTask(db *gorm.DB, sched model.SummarySchedule, now t
 
 		// Rebuild the three subtables (source / participant / personal_result) from
 		// the schedule config -- the new task_id starts with no children.
-		if err := buildScheduledTaskChildren(tx, lockedSched, newTask, now); err != nil {
+		if err := buildScheduledTaskChildren(tx, imDB, lockedSched, newTask, now); err != nil {
 			return err
 		}
 

--- a/internal/worker/scheduler_lastrun_test.go
+++ b/internal/worker/scheduler_lastrun_test.go
@@ -91,7 +91,7 @@ func TestClaim_RequeueAdvancesLastRunAt(t *testing.T) {
 	seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
 
 	now := time.Now().UTC()
-	taskID, claimed, err := claimAndCreateScheduledTask(db, sched, now, 30)
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestClaim_OverlapSkipPreservesLastRunAt(t *testing.T) {
 	seedBoundTask(t, db, sched.ID, model.StatusProcessing, 1)
 
 	now := time.Now().UTC()
-	taskID, claimed, err := claimAndCreateScheduledTask(db, sched, now, 30)
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestClaim_NoPriorTaskCreatesFirstTask(t *testing.T) {
 	// no prior task seeded
 
 	now := time.Now().UTC()
-	taskID, claimed, err := claimAndCreateScheduledTask(db, sched, now, 30)
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestClaim_MultiPersonConfigDisablesSchedule(t *testing.T) {
 	seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
 
 	now := time.Now().UTC()
-	_, claimed, err := claimAndCreateScheduledTask(db, sched, now, 30)
+	_, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #89.

Scheduled summaries were writing the fallback placeholder name `来源-<id前8位>(群聊)` into `summary_source.source_name` instead of the chat's real name. Manual tasks were unaffected. Two combined defects were responsible:

- **Defect A (root cause)** — `sourceReq` in `internal/api/handler/task.go` lacked a `SourceName` field, so the frontend-provided `source_name` was silently dropped during deserialization and never persisted into `summary_schedule.source_config`.
- **Defect B (defense-in-depth)** — the scheduled worker resolved names with a hardcoded `nil` imDB, so `ResolveSourceNameWithType` returned the fallback placeholder immediately without ever querying the IM `group` table.

## Changes

1. **Add `SourceName` to `sourceReq`** (`internal/api/handler/task.go`) — the frontend `source_name` is now correctly persisted into `source_config`.
2. **Thread the real `imDB` down the scheduled source-build chain** — `StartScheduler → scanPendingSchedules → claimAndCreateScheduledTask → buildScheduledTaskChildren → buildScheduledTaskSources` (and the parallel `syncScheduledTask*` path), passing the real `imDB` to `ResolveSourceNameWithType` instead of `nil`. This lets legacy configs without a stored name still resolve the real group name from `im.group`.
3. **Unit tests** for `buildScheduledTaskSources` covering both the config-name path (name stored verbatim, no degradation) and the fallback path (no name + no imDB → placeholder).
4. Updated one existing test affected by the `claimAndCreateScheduledTask` signature change.

## Verification

- `go build ./...` — pass
- `go vet ./internal/worker/... ./internal/api/handler/...` — clean
- `go test ./internal/worker/... ./internal/api/handler/...` — all pass (incl. 2 new tests)

## Notes

Existing degraded rows (`来源-xxx(群聊)`) in `summary_source` / `source_config` are **not** auto-backfilled by this code fix; a one-off migration script would be needed if historical correction is desired.

- Change 1 is backward compatible and does not affect the manual task-creation path.
- Change 2 only affects the scheduled path; the manual path already passes `h.imDB`.
