### PR TITLE
fix(summary): correct thread source_name resolution & enforce backend-authoritative naming (#93)

### DIFF
--- a/internal/service/summary.go
+++ b/internal/service/summary.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"strings"
 
@@ -58,29 +59,50 @@ func ResolveSourceNameWithType(sourceID string, sourceType int, imDB *gorm.DB) s
 			return name + "(群聊)"
 		}
 	case 2: // thread
-		// Thread source_id format: {group_no}____{short_id}
-		// Note: For thread, ____ separates group_no and short_id; both are used
+		// 子区身份是 (group_no, short_id) 联合键；source_id 形如 {group_no}____{short_id}。
+		// 解析严格依赖 source_type==2，不靠 "____" 的出现与否猜测是否为子区
+		// （群 source_id 也可能含 "____{space_id}" 后缀，见 case 1）。
 		parts := strings.SplitN(sourceID, "____", 2)
-		if len(parts) == 2 {
-			groupNo := parts[0]
-			shortID := parts[1]
-			
-			var groupName string
-			_ = imDB.Table("group").Where("group_no = ?", groupNo).Pluck("name", &groupName).Error
-			
-			var threadName string
-			_ = imDB.Table("thread").Where("short_id = ?", shortID).Pluck("name", &threadName).Error
-			
-			if groupName != "" && threadName != "" {
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			// 非法子区 source_id：走确定性兜底，绝不退化成父群名。
+			log.Printf("[service] ResolveSourceNameWithType: malformed thread source_id=%q", sourceID)
+			return fallbackSourceName(sourceID, sourceType)
+		}
+		groupNo := parts[0]
+		shortID := parts[1]
+
+		// 一条 JOIN 同时取子区名与父群名；group_no 跨表比较必须加 COLLATE，
+		// 与 internal/pipeline/fetch.go:141、internal/api/handler/candidates.go:177/190 保持一致。
+		var row struct {
+			ThreadName string `gorm:"column:thread_name"`
+			GroupName  string `gorm:"column:group_name"`
+		}
+		err := imDB.Raw(
+			"SELECT t.name AS thread_name, g.name AS group_name "+
+				"FROM thread t "+
+				"LEFT JOIN `group` g ON g.group_no COLLATE utf8mb4_unicode_ci = t.group_no "+
+				"WHERE t.group_no = ? AND t.short_id = ? "+
+				"LIMIT 1",
+			groupNo, shortID,
+		).Scan(&row).Error
+		if err != nil {
+			// 不再吞错：打日志便于线上定位；返回确定性可区分兜底（含 short_id）。
+			log.Printf("[service] ResolveSourceNameWithType: thread query failed source_id=%q: %v", sourceID, err)
+			return threadFallbackName("", shortID)
+		}
+
+		threadName := strings.TrimSpace(row.ThreadName)
+		groupName := strings.TrimSpace(row.GroupName)
+
+		// 兜底顺序：子区名优先；其次“父群名-占位”；最后纯占位。
+		// 关键：未命名子区永远带 short_id 片段，保证同群多子区互不相同。
+		if threadName != "" {
+			if groupName != "" {
 				return groupName + "-" + threadName + "(子区)"
 			}
-			if threadName != "" {
-				return threadName + "(子区)"
-			}
-			if groupName != "" {
-				return groupName + "(子区)"
-			}
+			return threadName + "(子区)"
 		}
+		return threadFallbackName(groupName, shortID)
 	case 3: // DM (private chat)
 		var name string
 		err := imDB.Table("user").Where("uid = ?", sourceID).Pluck("name", &name).Error
@@ -106,6 +128,20 @@ func fallbackSourceName(sourceID string, sourceType int) string {
 		return "来源-" + sourceID[:8] + suffix
 	}
 	return "来源-" + sourceID + suffix
+}
+
+// threadFallbackName 为“未命名 / 未命中”的子区生成确定性、可区分的占位名。
+// 永远包含 short_id 的前若干位，确保同一父群下的不同子区不会撞名
+// （这正是 #93 的根因：旧逻辑退化成纯父群名导致同群子区全部同名）。
+func threadFallbackName(groupName, shortID string) string {
+	short := shortID
+	if len(short) > 6 {
+		short = short[:6]
+	}
+	if groupName != "" {
+		return groupName + "-子区" + short + "(子区)"
+	}
+	return "子区-" + short + "(子区)"
 }
 
 // ResolveSourceName returns source name from IM DB, fallback to placeholder.

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -63,10 +63,12 @@ func buildScheduledTaskSources(tx *gorm.DB, imDB *gorm.DB, taskID int64, raw mod
 		if src.SourceID == "" {
 			return fmt.Errorf("scheduled source_id is required")
 		}
-		sourceName := src.SourceName
-		if sourceName == "" {
-			sourceName = service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
-		}
+		// Always resolve the canonical source name from the IM DB; never trust a
+		// client-supplied source_name (the schedule-management UI can submit a raw
+		// group_no/thread id as the "name", e.g. "groupNo____shortId"). Resolving
+		// unconditionally keeps the stored name consistent with the instant-summary
+		// path, which already drops source_name and lets the backend look it up.
+		sourceName := service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
 		if err := tx.Create(&model.SummarySource{
 			TaskID:     taskID,
 			SourceType: src.SourceType,
@@ -156,10 +158,9 @@ func syncScheduledTaskSources(tx *gorm.DB, imDB *gorm.DB, taskID int64, raw mode
 		if src.SourceID == "" {
 			return fmt.Errorf("scheduled source_id is required")
 		}
-		sourceName := src.SourceName
-		if sourceName == "" {
-			sourceName = service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
-		}
+		// Always resolve the canonical source name from the IM DB; never trust a
+		// client-supplied source_name (see buildScheduledTaskSources).
+		sourceName := service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
 		if err := tx.Create(&model.SummarySource{
 			TaskID:     taskID,
 			SourceType: src.SourceType,

--- a/internal/worker/scheduled_replace_test.go
+++ b/internal/worker/scheduled_replace_test.go
@@ -167,21 +167,24 @@ func TestSyncScheduledTaskParticipants_AlwaysIncludesCreatorAndDedups(t *testing
 	}
 }
 
-// buildScheduledTaskSources must persist the source_name carried in the
-// schedule config verbatim (the fix for the dropped-name bug). It must NOT
-// degrade a config-provided real name into the fallback placeholder.
-func TestBuildScheduledTaskSources_UsesConfigSourceName(t *testing.T) {
+// buildScheduledTaskSources must ALWAYS re-resolve the source_name from the IM
+// DB and never trust the source_name carried in the schedule config (issue #93
+// / #94 follow-up: the schedule-management UI can submit a stale/dirty name,
+// e.g. a raw "groupNo____shortId", so the stored name must stay consistent with
+// the instant-summary path, which also ignores the client value).
+func TestBuildScheduledTaskSources_IgnoresConfigSourceName(t *testing.T) {
 	db := newReplaceTestDB(t)
 	if err := db.AutoMigrate(&model.SummarySource{}); err != nil {
 		t.Fatalf("migrate source: %v", err)
 	}
 	taskID := seedProcessingTask(t, db)
 
-	// Config carries the real group name -> it must be stored as-is.
-	raw := model.JSON(`[{"source_type":1,"source_id":"group-abcdef123456","source_name":"真实群名(群聊)"}]`)
+	// Config carries a dirty/stale name. With imDB=nil the resolver falls back
+	// to the deterministic placeholder; the key assertion is that the stored
+	// name is the RE-RESOLVED value and is NOT the config-supplied dirty value.
+	dirty := "脏值-不可信(群聊)"
+	raw := model.JSON(`[{"source_type":1,"source_id":"group-abcdef123456","source_name":"` + dirty + `"}]`)
 	if err := db.Transaction(func(tx *gorm.DB) error {
-		// imDB=nil on purpose: with a config name present the resolver must
-		// never be consulted, so nil is irrelevant here.
 		return buildScheduledTaskSources(tx, nil, taskID, raw)
 	}); err != nil {
 		t.Fatalf("build sources: %v", err)
@@ -189,8 +192,13 @@ func TestBuildScheduledTaskSources_UsesConfigSourceName(t *testing.T) {
 
 	var src model.SummarySource
 	db.Where("task_id = ?", taskID).First(&src)
-	if src.SourceName != "真实群名(群聊)" {
-		t.Errorf("source_name = %q, want config name %q", src.SourceName, "真实群名(群聊)")
+	if src.SourceName == dirty {
+		t.Errorf("source_name = %q, must NOT trust config dirty value", src.SourceName)
+	}
+	// imDB=nil -> ResolveSourceNameWithType returns the fallback placeholder.
+	want := "来源-group-ab(群聊)"
+	if src.SourceName != want {
+		t.Errorf("source_name = %q, want re-resolved %q", src.SourceName, want)
 	}
 }
 


### PR DESCRIPTION
## 背景 / Issue

修复 #93：智能总结中子区（`source_type=2`）的「信息来源名称」`source_name` 显示为父群名、同一父群下多个子区无法区分。同时统一即时总结与定时总结两条链路的命名口径。

历史数据回填作为独立 issue **#94** 处理，本 PR 仅交付代码修复。

## 改动

### 问题一：子区 source_name 解析（`internal/service/summary.go`）
- `case 2`（thread）改为用 **联合键 `(group_no, short_id)`** 的单条 JOIN 查询，联 `group` 表取父群名，跨表比较加 `COLLATE utf8mb4_unicode_ci`（与 `internal/pipeline/fetch.go`、`internal/api/handler/candidates.go` 既有写法一致）。替换原先 `WHERE short_id = ?` 的单键查询（可能命中其它群的同名 `short_id`）。
- 不再用 `_ =` 吞掉查询错误，改为 `log.Printf` 打日志，便于线上定位。
- 新增 `threadFallbackName()`：未命名 / 未命中的子区占位名**永远包含 `short_id` 片段**，保证同一父群下多个未命名子区互不撞名（#93 根因正是旧逻辑退化成纯父群名）。
- 子区 `source_id` 形态前置校验，非法值走确定性兜底。

### 问题二：即时 / 定时链路命名口径统一（`internal/worker/scheduled_replace_helpers.go`）
- `buildScheduledTaskSources` / `syncScheduledTaskSources` 改为**始终**调用 `ResolveSourceNameWithType` 重新解析，不再信任前端传入的 `source_name`（定时表单可能把脏值如 `groupNo____shortId` 当 name 传上来）。与即时总结链路口径对齐。

### 测试（`internal/worker/scheduled_replace_test.go`）
- 更新 `TestBuildScheduledTaskSources`：断言落库的 `source_name` 是**后端重解析值**、且**不等于**配置里的脏值。

## 验证

- `go test ./...` 全绿。
- 线上真实链路验证：同一父群 `qwen3-omni-speech-te` 下子区 `子区问题` 的定时总结，配置 `source_name` 为空，生成的 `summary_source.source_name` = `qwen3-omni-speech-te-子区问题(子区)`（HEX 还原确认正确 UTF-8），证明子区名正确带入 + 生成层重解析 + COLLATE 联合键 JOIN 均生效。

## 不涉及

- 无 DB schema 变更：`source_name` 仍 `varchar(200)`；`source_type` 枚举沿用 `1/2/3`。
- 历史数据回填 → #94 单独 PR。
- 前端 `octo-web` 不再发送 `source_name` → 跨仓、非阻塞，单独排期。
