### PR TITLE
feat(notify): server-side notify-policy gate + idempotent summary-notify emit (OCT-43)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,23 @@ type Config struct {
 
 	// Tool call per-attempt timeout (seconds)
 	ToolCallTimeout int
+
+	// Summary-notify outbound (OCT-43). When a task completes the worker emits
+	// a directed contentType=21 tip to the creator + explicit participants via
+	// octo-server's bot API. Disabled unless NotifyEnabled is true AND both URL
+	// and token are set (see NotifyConfigured).
+	NotifyEnabled   bool   // SUMMARY_NOTIFY_ENABLED master switch
+	NotifyBotAPIURL string // SUMMARY_NOTIFY_BOT_API_URL full endpoint, e.g. http://octo-server:8080/v1/bot/sendMessage
+	NotifyBotToken  string // SUMMARY_NOTIFY_BOT_TOKEN system App-Bot token (app_ prefix) — provisioning is OCT-43 decision #1
+	NotifyBotUID    string // SUMMARY_NOTIFY_BOT_UID stable from_uid surfaced in the payload (server stamps the authoritative from_uid from the token)
+	NotifyBotName   string // SUMMARY_NOTIFY_BOT_NAME stable from_name display string
+}
+
+// NotifyConfigured reports whether the summary-notify emit path is fully
+// configured and enabled. The worker builds a no-op notifier otherwise, so an
+// unconfigured deploy never burns the notified_at idempotency anchor.
+func (c *Config) NotifyConfigured() bool {
+	return c.NotifyEnabled && c.NotifyBotAPIURL != "" && c.NotifyBotToken != ""
 }
 
 func Load() *Config {
@@ -133,6 +150,12 @@ func Load() *Config {
 		ChannelScopeEnabled: envBool("CHANNEL_SCOPE_ENABLED", true),
 
 		ToolCallTimeout: envInt("TOOL_CALL_TIMEOUT", 30),
+
+		NotifyEnabled:   envBool("SUMMARY_NOTIFY_ENABLED", false),
+		NotifyBotAPIURL: envStr("SUMMARY_NOTIFY_BOT_API_URL", ""),
+		NotifyBotToken:  envStr("SUMMARY_NOTIFY_BOT_TOKEN", ""),
+		NotifyBotUID:    envStr("SUMMARY_NOTIFY_BOT_UID", ""),
+		NotifyBotName:   envStr("SUMMARY_NOTIFY_BOT_NAME", "智能总结"),
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -115,9 +115,14 @@ type SummaryTask struct {
 	OriginChannelType  int        `gorm:"column:origin_channel_type;type:tinyint;not null;default:0" json:"origin_channel_type"`
 	ProcessingDeadline *time.Time `gorm:"column:processing_deadline" json:"processing_deadline"`
 	ConfirmDeadline    *time.Time `gorm:"column:confirm_deadline" json:"confirm_deadline"`
-	CreatedAt          time.Time  `gorm:"column:created_at;not null" json:"created_at"`
-	UpdatedAt          time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
-	DeletedAt          *time.Time `gorm:"column:deleted_at;index" json:"deleted_at,omitempty"`
+	// NotifiedAt is the crash-safe idempotency anchor for the summary-notify
+	// tip. A single-writer CAS (notified_at IS NULL → now) guarantees
+	// exactly-once emit per task even across worker restarts. NULL = not yet
+	// notified.
+	NotifiedAt *time.Time `gorm:"column:notified_at" json:"notified_at,omitempty"`
+	CreatedAt  time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt  time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+	DeletedAt  *time.Time `gorm:"column:deleted_at;index" json:"deleted_at,omitempty"`
 }
 
 func (SummaryTask) TableName() string { return "summary_task" }

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -217,6 +217,10 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			EventType: "META_SUMMARY_UPDATED",
 		})
 
+		// Emit the access-gated summary-notify tip (OCT-43). Idempotent via the
+		// notified_at CAS, so dirty re-runs of this loop never double-emit.
+		m.proc.emitSummaryNotify(taskID)
+
 		log.Printf("[meta-worker] task %d meta-summary version %d created (%d participants)",
 			taskID, result.Version, len(submitted))
 

--- a/internal/worker/notify.go
+++ b/internal/worker/notify.go
@@ -1,0 +1,203 @@
+package worker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"gorm.io/gorm"
+)
+
+// contentTypeSummaryNotify is the IM message content type the octo-web client
+// (#291) registers to render the summary-notify tip. OCT-43 decision #2
+// (Frontend) owns the authoritative payload key contract for this type.
+const contentTypeSummaryNotify = 21
+
+// channelTypePerson is octo-server's DM (person) channel type
+// (octo-lib common.ChannelTypePerson). The tip is delivered as a directed DM
+// to each authorized user, never broadcast to the origin channel.
+const channelTypePerson = 1
+
+// Notifier emits the summary-completed tip for a finished task. Implementations
+// must be idempotent: NotifyCompleted may be invoked more than once for the
+// same task (concurrent CAS winners, restarts) and must emit at most once.
+type Notifier interface {
+	NotifyCompleted(taskID int64)
+}
+
+// noopNotifier is installed when summary-notify is unconfigured. It does
+// nothing — crucially it does NOT touch notified_at, so enabling the feature
+// later can still notify previously-completed tasks.
+type noopNotifier struct{}
+
+func (noopNotifier) NotifyCompleted(int64) {}
+
+// emitSummaryNotify fires the summary-completed tip for a task that this
+// goroutine just transitioned to Completed. Nil-safe so Processors built via
+// struct literal (tests) don't panic.
+func (p *Processor) emitSummaryNotify(taskID int64) {
+	if p.notifier == nil {
+		return
+	}
+	p.notifier.NotifyCompleted(taskID)
+}
+
+// messageSender is the outbound transport to octo-server's bot API. Extracted
+// so tests can assert target set + payload without a live HTTP server.
+type messageSender interface {
+	Send(channelID string, channelType int, payload map[string]interface{}) error
+}
+
+// botNotifier emits a directed contentType=21 tip to the access-gated target
+// set (creator + explicit participants) of a completed task.
+type botNotifier struct {
+	db       *gorm.DB
+	sender   messageSender
+	fromUID  string
+	fromName string
+}
+
+// NewNotifier builds the summary-notify emitter. Returns a no-op when the
+// feature is not fully configured (see config.NotifyConfigured).
+func NewNotifier(db *gorm.DB, cfg *config.Config) Notifier {
+	if !cfg.NotifyConfigured() {
+		log.Printf("[notify] summary-notify disabled (not configured); emit is a no-op")
+		return noopNotifier{}
+	}
+	return &botNotifier{
+		db: db,
+		sender: &botAPISender{
+			url:    cfg.NotifyBotAPIURL,
+			token:  cfg.NotifyBotToken,
+			client: &http.Client{Timeout: 5 * time.Second},
+		},
+		fromUID:  cfg.NotifyBotUID,
+		fromName: cfg.NotifyBotName,
+	}
+}
+
+// NotifyCompleted emits the tip exactly once per task. The notified_at CAS
+// (notified_at IS NULL → now) is the idempotency anchor: only the single
+// goroutine whose CAS affects one row proceeds to send, so concurrent callers
+// and post-restart retries are deduplicated even across processes.
+func (n *botNotifier) NotifyCompleted(taskID int64) {
+	now := time.Now().UTC()
+	cas := n.db.Model(&model.SummaryTask{}).
+		Where("id = ? AND notified_at IS NULL", taskID).
+		Update("notified_at", now)
+	if cas.Error != nil {
+		log.Printf("[notify] task %d notified_at CAS error: %v", taskID, cas.Error)
+		return
+	}
+	if cas.RowsAffected != 1 {
+		// Already notified (lost the CAS race or replayed after restart).
+		return
+	}
+
+	var task model.SummaryTask
+	if err := n.db.Where("id = ?", taskID).First(&task).Error; err != nil {
+		log.Printf("[notify] task %d load failed after CAS: %v", taskID, err)
+		return
+	}
+
+	targets := notifyTargetUserIDs(n.db, &task)
+	payload := n.buildPayload(&task)
+	sent := 0
+	for _, uid := range targets {
+		if err := n.sender.Send(uid, channelTypePerson, payload); err != nil {
+			// Best-effort per recipient: one failed DM must not block the rest.
+			log.Printf("[notify] task %d send to %s failed: %v", taskID, uid, err)
+			continue
+		}
+		sent++
+	}
+	log.Printf("[notify] task %d emitted summary-notify: %d/%d targets", taskID, sent, len(targets))
+}
+
+// notifyTargetUserIDs returns the access-gated notify target set for a task:
+// the creator plus every explicit participant, deduplicated and creator-first.
+// This mirrors handler.canAccessTask — origin-channel membership alone does NOT
+// receive a tip, which is what prevents the channel-wide leak (octo-web #291).
+func notifyTargetUserIDs(db *gorm.DB, task *model.SummaryTask) []string {
+	seen := make(map[string]struct{})
+	var targets []string
+	add := func(uid string) {
+		if uid == "" {
+			return
+		}
+		if _, ok := seen[uid]; ok {
+			return
+		}
+		seen[uid] = struct{}{}
+		targets = append(targets, uid)
+	}
+
+	add(task.CreatorID)
+
+	var participants []model.SummaryParticipant
+	db.Where("task_id = ?", task.ID).Find(&participants)
+	for _, p := range participants {
+		add(p.UserID)
+	}
+	return targets
+}
+
+// buildPayload constructs the contentType=21 tip payload.
+//
+// OCT-43 decision #2 (Frontend): these keys are the proposed contract; the
+// authoritative shape is whatever octo-web #291 registered client-side. Confirm
+// the exact required keys (link / task ref form) before merge. from_uid /
+// from_name are surfaced here for the renderer even though octo-server stamps
+// the authoritative from_uid from the bot token.
+func (n *botNotifier) buildPayload(task *model.SummaryTask) map[string]interface{} {
+	return map[string]interface{}{
+		"type":      contentTypeSummaryNotify,
+		"from_uid":  n.fromUID,
+		"from_name": n.fromName,
+		"task_id":   task.ID,
+		"task_no":   task.TaskNo,
+		"title":     task.Title,
+	}
+}
+
+// botAPISender posts to octo-server's POST /v1/bot/sendMessage as a system
+// App-Bot. octo-server stamps from_uid = the authenticated bot.
+type botAPISender struct {
+	url    string
+	token  string
+	client *http.Client
+}
+
+func (s *botAPISender) Send(channelID string, channelType int, payload map[string]interface{}) error {
+	body, err := json.Marshal(map[string]interface{}{
+		"channel_id":   channelID,
+		"channel_type": channelType,
+		"payload":      payload,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("bot api status %d: %s", resp.StatusCode, string(b))
+	}
+	return nil
+}

--- a/internal/worker/notify.go
+++ b/internal/worker/notify.go
@@ -88,8 +88,13 @@ func NewNotifier(db *gorm.DB, cfg *config.Config) Notifier {
 // and post-restart retries are deduplicated even across processes.
 func (n *botNotifier) NotifyCompleted(taskID int64) {
 	now := time.Now().UTC()
+	// deleted_at IS NULL mirrors authorizeTaskAccess: SummaryTask.DeletedAt is a
+	// plain *time.Time (not gorm.DeletedAt), so GORM applies no automatic
+	// soft-delete scoping — the predicate must be explicit. A soft-deleted task
+	// must neither win the CAS nor burn the notified_at anchor, so an undelete
+	// can still notify later.
 	cas := n.db.Model(&model.SummaryTask{}).
-		Where("id = ? AND notified_at IS NULL", taskID).
+		Where("id = ? AND notified_at IS NULL AND deleted_at IS NULL", taskID).
 		Update("notified_at", now)
 	if cas.Error != nil {
 		log.Printf("[notify] task %d notified_at CAS error: %v", taskID, cas.Error)
@@ -103,6 +108,11 @@ func (n *botNotifier) NotifyCompleted(taskID int64) {
 	var task model.SummaryTask
 	if err := n.db.Where("id = ?", taskID).First(&task).Error; err != nil {
 		log.Printf("[notify] task %d load failed after CAS: %v", taskID, err)
+		return
+	}
+	// Defense in depth: the CAS already excludes soft-deleted rows, but bail if
+	// the row was deleted between CAS and load so a deleted task never fans out.
+	if task.DeletedAt != nil {
 		return
 	}
 

--- a/internal/worker/notify_test.go
+++ b/internal/worker/notify_test.go
@@ -220,3 +220,33 @@ func TestNotifyAlreadyNotifiedNoop(t *testing.T) {
 		t.Fatalf("Send called %d times, want 0 for an already-notified task", got)
 	}
 }
+
+// TestNotifyDeletedTaskNoop verifies a soft-deleted task (deleted_at non-null)
+// fires no tip and does NOT burn the notified_at anchor. The API treats a
+// soft-deleted task as nonexistent (authorizeTaskAccess: WHERE deleted_at IS
+// NULL → 404); the notify path must fail closed the same way. Leaving
+// notified_at NULL means a later undelete can still legitimately notify.
+func TestNotifyDeletedTaskNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	taskID := seedNotifyTask(t, db, "creator1", []string{"alice"})
+	deletedAt := time.Now().UTC().Add(-time.Minute)
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("deleted_at", deletedAt).Error; err != nil {
+		t.Fatalf("preset deleted_at: %v", err)
+	}
+
+	sender := &recordingSender{}
+	n := &botNotifier{db: db, sender: sender, fromUID: "bot-uid", fromName: "智能总结"}
+	n.NotifyCompleted(taskID)
+
+	if got := atomic.LoadInt32(&sender.calls); got != 0 {
+		t.Fatalf("Send called %d times, want 0 for a soft-deleted task", got)
+	}
+
+	var task model.SummaryTask
+	if err := db.First(&task, taskID).Error; err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if task.NotifiedAt != nil {
+		t.Errorf("notified_at must stay NULL for a soft-deleted task (anchor not burned), got %v", task.NotifiedAt)
+	}
+}

--- a/internal/worker/notify_test.go
+++ b/internal/worker/notify_test.go
@@ -1,0 +1,222 @@
+package worker
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupNotifyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Pin to a single connection so the concurrent idempotency test shares one
+	// in-memory database (separate sqlite :memory: connections are separate DBs).
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.SummaryTask{}, &model.SummaryParticipant{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+type capturedSend struct {
+	channelID   string
+	channelType int
+	payload     map[string]interface{}
+}
+
+// recordingSender captures every Send call. Thread-safe so it can be used under
+// the concurrent idempotency test.
+type recordingSender struct {
+	mu    sync.Mutex
+	sends []capturedSend
+	calls int32
+}
+
+func (r *recordingSender) Send(channelID string, channelType int, payload map[string]interface{}) error {
+	atomic.AddInt32(&r.calls, 1)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sends = append(r.sends, capturedSend{channelID: channelID, channelType: channelType, payload: payload})
+	return nil
+}
+
+func (r *recordingSender) recipients() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.sends))
+	for _, s := range r.sends {
+		out = append(out, s.channelID)
+	}
+	return out
+}
+
+func seedNotifyTask(t *testing.T, db *gorm.DB, creator string, participants []string) int64 {
+	t.Helper()
+	now := time.Now().UTC()
+	task := model.SummaryTask{
+		TaskNo:         "TST-NOTIFY",
+		SpaceID:        "space1",
+		CreatorID:      creator,
+		Title:          "周会纪要",
+		SummaryMode:    model.ModeByPerson,
+		TimeRangeStart: now.Add(-time.Hour),
+		TimeRangeEnd:   now,
+		Status:         model.StatusCompleted,
+		TriggerType:    model.TriggerManual,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	for _, uid := range participants {
+		if err := db.Create(&model.SummaryParticipant{TaskID: task.ID, UserID: uid}).Error; err != nil {
+			t.Fatalf("create participant: %v", err)
+		}
+	}
+	return task.ID
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNotifyPolicyGate verifies the target set is exactly creator + explicit
+// participants (deduped), and that a non-participant — e.g. a member of the
+// origin channel who never joined the task — is NEVER targeted. This is the
+// policy gate that prevents the channel-wide leak (octo-web #291).
+func TestNotifyPolicyGate(t *testing.T) {
+	tests := []struct {
+		name         string
+		creator      string
+		participants []string
+		wantTargets  []string
+		neverTarget  string
+	}{
+		{
+			name:         "private creator-only",
+			creator:      "creator1",
+			participants: nil,
+			wantTargets:  []string{"creator1"},
+			neverTarget:  "outsider",
+		},
+		{
+			name:         "creator plus participants",
+			creator:      "creator1",
+			participants: []string{"alice", "bob"},
+			wantTargets:  []string{"creator1", "alice", "bob"},
+			neverTarget:  "outsider",
+		},
+		{
+			name:         "creator also a participant is deduped",
+			creator:      "creator1",
+			participants: []string{"creator1", "alice"},
+			wantTargets:  []string{"creator1", "alice"},
+			neverTarget:  "outsider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupNotifyTestDB(t)
+			taskID := seedNotifyTask(t, db, tt.creator, tt.participants)
+
+			sender := &recordingSender{}
+			n := &botNotifier{db: db, sender: sender, fromUID: "bot-uid", fromName: "智能总结"}
+			n.NotifyCompleted(taskID)
+
+			got := sender.recipients()
+			if len(got) != len(tt.wantTargets) {
+				t.Fatalf("target count = %d (%v), want %d (%v)", len(got), got, len(tt.wantTargets), tt.wantTargets)
+			}
+			for _, want := range tt.wantTargets {
+				if !contains(got, want) {
+					t.Errorf("missing expected target %q in %v", want, got)
+				}
+			}
+			if contains(got, tt.neverTarget) {
+				t.Errorf("non-participant %q must never be targeted, got %v", tt.neverTarget, got)
+			}
+			// Every emit is a directed DM, never a channel broadcast.
+			for _, s := range sender.sends {
+				if s.channelType != channelTypePerson {
+					t.Errorf("channelType = %d, want person DM (%d)", s.channelType, channelTypePerson)
+				}
+				if s.payload["type"] != contentTypeSummaryNotify {
+					t.Errorf("payload type = %v, want %d", s.payload["type"], contentTypeSummaryNotify)
+				}
+			}
+		})
+	}
+}
+
+// TestNotifyIdempotencyConcurrent fires NotifyCompleted from many goroutines
+// against one task and asserts exactly one fan-out occurs — the notified_at CAS
+// must let a single winner through. This is the per-task exactly-once guarantee
+// regardless of how many clients/workers observe completion.
+func TestNotifyIdempotencyConcurrent(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	participants := []string{"alice", "bob"}
+	taskID := seedNotifyTask(t, db, "creator1", participants)
+	wantTargetsPerEmit := 1 + len(participants) // creator + participants
+
+	sender := &recordingSender{}
+	n := &botNotifier{db: db, sender: sender, fromUID: "bot-uid", fromName: "智能总结"}
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			n.NotifyCompleted(taskID)
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&sender.calls); got != int32(wantTargetsPerEmit) {
+		t.Fatalf("Send called %d times, want exactly %d (single fan-out)", got, wantTargetsPerEmit)
+	}
+
+	var task model.SummaryTask
+	if err := db.First(&task, taskID).Error; err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if task.NotifiedAt == nil {
+		t.Error("notified_at must be set after emit")
+	}
+}
+
+// TestNotifyAlreadyNotifiedNoop verifies a task whose notified_at is already set
+// (e.g. emitted before a worker restart) is not re-notified.
+func TestNotifyAlreadyNotifiedNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	taskID := seedNotifyTask(t, db, "creator1", []string{"alice"})
+	already := time.Now().UTC().Add(-time.Minute)
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("notified_at", already).Error; err != nil {
+		t.Fatalf("preset notified_at: %v", err)
+	}
+
+	sender := &recordingSender{}
+	n := &botNotifier{db: db, sender: sender, fromUID: "bot-uid", fromName: "智能总结"}
+	n.NotifyCompleted(taskID)
+
+	if got := atomic.LoadInt32(&sender.calls); got != 0 {
+		t.Fatalf("Send called %d times, want 0 for an already-notified task", got)
+	}
+}

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -220,6 +220,9 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 			Progress: 100,
 			Message:  "总结完成",
 		})
+		// CAS-win: this goroutine transitioned the task to Completed, so emit
+		// the access-gated summary-notify tip exactly once (OCT-43).
+		p.emitSummaryNotify(taskID)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -31,6 +31,7 @@ type Processor struct {
 	stopCh     chan struct{}
 	triggerCh  chan model.WorkerTriggerRequest
 	meta       *MetaProcessor
+	notifier   Notifier
 	createPRFn func(tx *gorm.DB, pr *model.PersonalResult) error
 }
 
@@ -46,6 +47,7 @@ func NewProcessor(db, imDB *gorm.DB, pool *WorkerPool, llm *service.LLMClient, c
 		triggerCh: make(chan model.WorkerTriggerRequest, 100),
 	}
 	p.meta = NewMetaProcessor(p)
+	p.notifier = NewNotifier(db, cfg)
 	return p
 }
 

--- a/migrations/sql/20260618-01-add-summary-task-notified-at.sql
+++ b/migrations/sql/20260618-01-add-summary-task-notified-at.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+-- OCT-43: crash-safe idempotency anchor for the summary-notify tip. A
+-- single-writer CAS (UPDATE ... SET notified_at = NOW() WHERE notified_at IS
+-- NULL) guarantees exactly-once emit per task across worker restarts. NULL =
+-- not yet notified.
+ALTER TABLE `summary_task`
+    ADD COLUMN `notified_at` DATETIME NULL DEFAULT NULL AFTER `confirm_deadline`;
+
+-- +migrate Down
+ALTER TABLE `summary_task` DROP COLUMN `notified_at`;


### PR DESCRIPTION
## Summary

Server-side emit for the summary-notify tip — OCT-35 part 2/3, following part 1 (`creator_id` in DTOs, #99). Resolves all three defects from octo-web #291:

- **wrong author** → tip is sent by a stable system App-Bot (`from_uid`/`from_name`), not an arbitrary member.
- **channel-wide leak of a private summary** → tip goes only to the access-gated target set (creator + explicit participants) as directed DMs; never broadcast to `origin_channel_id`.
- **N-member duplicate fan-out** → exactly-once per task via a `notified_at` CAS anchor.

## What changed

- `internal/worker/notify.go` (new): `Notifier` + `botNotifier`.
  - `notifyTargetUserIDs` = creator + participants, deduped — mirrors `handler.canAccessTask` (channel membership alone grants no tip).
  - `NotifyCompleted` does a single-writer CAS `notified_at IS NULL -> now`; only the row-affecting winner sends → exactly-once even across restarts / concurrent winners.
  - `botAPISender` POSTs to octo-server `POST /v1/bot/sendMessage` (`Authorization: Bearer app_*`) with a `contentType=21` payload.
  - No-op until configured (`config.NotifyConfigured()`), so an unconfigured deploy never burns the `notified_at` anchor.
- Emit wired into the CAS-win branch of both completion paths: `personal_processor.go` (single-person) and `meta_processor.go` (multi-person, idempotent across dirty re-runs).
- `summary_task.notified_at` column + migration `20260618-01-add-summary-task-notified-at.sql`.
- Config: `SUMMARY_NOTIFY_ENABLED`, `SUMMARY_NOTIFY_BOT_API_URL`, `SUMMARY_NOTIFY_BOT_TOKEN`, `SUMMARY_NOTIFY_BOT_UID`, `SUMMARY_NOTIFY_BOT_NAME`.

## Tests

- `TestNotifyPolicyGate` — creator-only / creator+participants / creator-deduped; asserts a non-participant is never targeted and every emit is a person DM with `type=21`.
- `TestNotifyIdempotencyConcurrent` — 16 goroutines → single fan-out; race-clean.
- `TestNotifyAlreadyNotifiedNoop` — already-set `notified_at` → no re-emit.
- Full `internal/worker` package + `go vet` green.

## ⚠️ Draft — blocked on before-merge coordination

1. **Sender identity (CTO/infra):** provision the system App-Bot (`robotID` + `app_*` token) + token distribution — decision #1.
2. **`contentType=21` payload contract (Frontend):** confirm exact required keys vs. what octo-web #291 registered. `buildPayload` keys are proposed (`type`, `from_uid`, `from_name`, `task_id`, `task_no`, `title`) and flagged in code.
3. **Security review (SecurityEngineer):** new authenticated outbound sender posting into user channels with access-gating.

Refs OCT-43.