### PR TITLE
test: fix flaky pipeline in-memory DB flake (OCT-51)

### DIFF
--- a/internal/pipeline/fetch_archive_test.go
+++ b/internal/pipeline/fetch_archive_test.go
@@ -48,6 +48,16 @@ func setupPipelineImDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open pipeline im db: %v", err)
 	}
+	// A ":memory:" SQLite database is scoped to a single connection. gorm's
+	// default pool may open several, each getting its own empty database, so a
+	// seed write and a later read can land on different connections — the reader
+	// then sees "no such table" / zero rows. Pin the pool to one connection so
+	// every statement in a test shares the same in-memory database. (OCT-51)
+	if sqlDB, sqlErr := db.DB(); sqlErr == nil {
+		sqlDB.SetMaxOpenConns(1)
+	} else {
+		t.Fatalf("get pipeline im sql db: %v", sqlErr)
+	}
 	db.Exec(`CREATE TABLE "group" (group_no TEXT NOT NULL, name TEXT, space_id TEXT, status INTEGER DEFAULT 1, creator TEXT, updated_at INTEGER DEFAULT 0)`)
 	db.Exec(`CREATE TABLE thread (id INTEGER PRIMARY KEY, short_id TEXT, name TEXT, group_no TEXT, status INTEGER DEFAULT 1, message_count INTEGER DEFAULT 0, creator_uid TEXT, updated_at INTEGER DEFAULT 0)`)
 	db.Exec(`CREATE TABLE thread_member (thread_id INTEGER NOT NULL, uid TEXT NOT NULL)`)


### PR DESCRIPTION
## Summary
`internal/pipeline/fetch_archive_test.go`'s `setupPipelineImDB` opened a `:memory:` SQLite DB with gorm's **default connection pool**. A `:memory:` database is scoped to one connection, so a seed write and a later read could land on different pooled connections — the reader then saw `no such table` / zero rows. The heavy `ResolveAndFetchMessagesForPersonal` path hit it most, so `TestResolveAndFetch_NoSources_ArchivedExcluded` failed intermittently (~1/5 locally, reliably under CI's parallel `go test ./...`).

Fix: pin the pool to a single connection (`SetMaxOpenConns(1)`) so every statement in a test shares the same in-memory database.

## Why it matters
This flake non-deterministically reds the repo-level `Test` check for unrelated PRs (it red-flagged the handler-only PR #99). Flaky merge-gate tests are P1.

## Test plan
- [x] `go test ./internal/pipeline/` run 10× → 0 failures (was ~20% fail rate)
- [x] `go test ./internal/pipeline/ -race` → pass
- [x] `gofmt` clean
- [ ] CI green

Fixes OCT-51.

Co-Authored-By: Paperclip <noreply@paperclip.ing>