### PR TITLE
test(pipeline): fix flaky TestResolveAndFetch_NoSources_ArchivedExcluded (OCT-51)

### DIFF
--- a/internal/pipeline/fetch_archive_test.go
+++ b/internal/pipeline/fetch_archive_test.go
@@ -48,6 +48,18 @@ func setupPipelineImDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open pipeline im db: %v", err)
 	}
+	// Pin the pool to a single connection. go-sqlite3 gives every new connection
+	// to ":memory:" its own empty database, so without this the concurrent Layer 4
+	// fetch goroutines in ResolveAndFetchMessagesForPersonal can grab a freshly
+	// opened (unmigrated) connection and hit "no such table", dropping messages
+	// non-deterministically. One connection => seed and all queries share the same
+	// in-memory DB. (OCT-51)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("pipeline im db handle: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
 	db.Exec(`CREATE TABLE "group" (group_no TEXT NOT NULL, name TEXT, space_id TEXT, status INTEGER DEFAULT 1, creator TEXT, updated_at INTEGER DEFAULT 0)`)
 	db.Exec(`CREATE TABLE thread (id INTEGER PRIMARY KEY, short_id TEXT, name TEXT, group_no TEXT, status INTEGER DEFAULT 1, message_count INTEGER DEFAULT 0, creator_uid TEXT, updated_at INTEGER DEFAULT 0)`)
 	db.Exec(`CREATE TABLE thread_member (thread_id INTEGER NOT NULL, uid TEXT NOT NULL)`)


### PR DESCRIPTION
## Summary
- Fixes the ~1-in-5 flaky `TestResolveAndFetch_NoSources_ArchivedExcluded` (`internal/pipeline/fetch_archive_test.go`) that was non-deterministically red-flagging unrelated PRs (e.g. #99) via the repo-level `go test ./...` gate. Per our standard, flaky tests are **P1**.
- **Root cause:** `setupPipelineImDB` opened gorm against a `":memory:"` sqlite DSN without pinning the connection pool. go-sqlite3 gives every *new* connection to `":memory:"` its **own empty database**. The concurrent Layer 4 fetch in `ResolveAndFetchMessagesForPersonal` (`fetch.go:675-696`) fans out goroutines; one could grab a freshly-opened, unmigrated connection and hit `no such table: message`, whose error is silently logged-and-skipped (`fetch.go:701-703`), dropping the active thread's message → `got 0 messages`. Scheduling-dependent, hence the flake. (The `timeout` log lines in the report come from an unrelated sibling LLM stub in `resolve_channel_test.go:338` running concurrently — noise, not the cause.)
- **Fix:** pin the in-memory pool to a single connection (`SetMaxOpenConns(1)` / `SetMaxIdleConns(1)`) so the seed and all concurrent queries share the one database holding the migrated tables. Per-test isolation preserved; test-only change, no production code touched.

## Verification
- Focused 64-goroutine repro: **24–54/64** queries hit `no such table` unpinned; **0/64** pinned.
- Full package: **12×** plain runs green, **5×** under `-race` green. `go vet` clean.

Fixes [OCT-51](/OCT/issues/OCT-51).