### PR TITLE
fix(config): default FEATURE_TEAM_SCHEDULE to true

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,8 +86,10 @@ type Config struct {
 	ToolCallTimeout int
 
 	// FeatureTeamSchedule gates multi-participant scheduled summaries across both the
-	// API guards and the worker scheduler. Default OFF: API keeps rejecting multi-person
-	// schedules (40015) and the worker keeps disabling multi-person schedules.
+	// API guards and the worker scheduler. Default ON: API accepts multi-person
+	// schedules and the worker runs them via the multi-person execution path. Set
+	// FEATURE_TEAM_SCHEDULE=false to restore the legacy single-person-only behavior
+	// (API rejects multi-person schedules with 40015, worker disables them).
 	FeatureTeamSchedule bool
 }
 
@@ -139,7 +141,7 @@ func Load() *Config {
 
 		ToolCallTimeout: envInt("TOOL_CALL_TIMEOUT", 30),
 
-		FeatureTeamSchedule: envBool("FEATURE_TEAM_SCHEDULE", false),
+		FeatureTeamSchedule: envBool("FEATURE_TEAM_SCHEDULE", true),
 	}
 }
 


### PR DESCRIPTION
## 问题

多人协作的定时更新（team scheduled summaries）由 `FEATURE_TEAM_SCHEDULE` 开关控制，当前默认 **false（关闭）**。

这导致**默认部署**（未显式设置该环境变量）无法使用多人协作定时更新：
- API 侧：创建/更新多人 schedule 被拒绝（返回 40015）
- Worker 侧：扫描时把多人 schedule 直接禁用（is_active=0）并通知创建者

线上环境因为没设这个 env，多人协作定时更新一直跑不起来。

## 改动

把默认值翻成 **true（开启）**，让多人协作开箱即用。

- `internal/config/config.go`: `envBool("FEATURE_TEAM_SCHEDULE", false)` → `envBool("FEATURE_TEAM_SCHEDULE", true)`
- 同步更新字段注释（Default OFF → Default ON）以免注释与代码矛盾

## 兼容性

环境变量依然可覆盖默认值：显式设置 `FEATURE_TEAM_SCHEDULE=false` 即可恢复旧的「仅单人」行为（API 拒绝多人 schedule、worker 禁用多人 schedule）。`envBool` 在变量未设或为空时返回默认值，已设的部署不受影响。

## 验证

- `go build ./...` 通过（golang:1.25）