### PR TITLE
feat(notify): task-terminal notification via summary-assistant bot (#96)

### DIFF
--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/worker"
@@ -78,12 +79,33 @@ func main() {
 	// Start worker pool
 	pool := worker.NewWorkerPool(cfg.WorkerMaxConcurrent)
 
+	// Build the terminal-state IM-bot notifier (OCT-4). Disabled unless
+	// SUMMARY_NOTIFY_ENABLED=true; a nil deliverer / disabled config makes
+	// OnTaskTerminal a no-op, so it is always safe to wire.
+	var notifier *notify.Notifier
+	if cfg.NotifyEnabled {
+		if cfg.OctoAPIURL == "" || cfg.SummaryBotToken == "" {
+			log.Printf("[worker] SUMMARY_NOTIFY_ENABLED=true but OCTO_API_URL / SUMMARY_BOT_TOKEN missing; notifications disabled")
+		} else {
+			deliverer := notify.NewHTTPDeliverer(cfg.OctoAPIURL, cfg.SummaryBotToken)
+			notifier = notify.New(summaryDB, deliverer, notify.Config{
+				Enabled:     true,
+				WebBaseURL:  cfg.SummaryWebBaseURL,
+				MaxAttempts: cfg.MaxNotifyAttempts,
+				QuietStart:  cfg.NotifyQuietStart,
+				QuietEnd:    cfg.NotifyQuietEnd,
+			})
+			log.Printf("[worker] terminal-state notifications ENABLED")
+		}
+	}
+
 	// Start processor (polling loop)
 	proc := worker.NewProcessor(summaryDB, imDB, pool, llm, cfg)
+	proc.SetNotifier(notifier)
 	go proc.Run()
 
 	// Start scheduler (cron jobs)
-	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays, cfg.FeatureTeamSchedule)
+	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays, cfg.FeatureTeamSchedule, notifier)
 
 	// Start internal HTTP server for worker-trigger
 	hub := ws.NewHub(summaryDB)

--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -94,7 +94,7 @@ func main() {
 				MaxAttempts: cfg.MaxNotifyAttempts,
 				QuietStart:  cfg.NotifyQuietStart,
 				QuietEnd:    cfg.NotifyQuietEnd,
-			})
+			}).WithErrorSanitizer(worker.SanitizeErrorForUser)
 			log.Printf("[worker] terminal-state notifications ENABLED")
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	CharsPerTokenCJK          int
 	CharsPerTokenASCII        int
 
-	// Worker trigger URL (API → Worker)
+	// Worker trigger URL (API -> Worker)
 	WorkerTriggerURL string
 
 	// Candidate search query limit (-1 = no limit, >0 = use as SQL LIMIT)
@@ -91,6 +91,30 @@ type Config struct {
 	// FEATURE_TEAM_SCHEDULE=false to restore the legacy single-person-only behavior
 	// (API rejects multi-person schedules with 40015, worker disables them).
 	FeatureTeamSchedule bool
+
+	// --- OCT-4 task-terminal notification (delivery to the IM bot) ---
+
+	// NotifyEnabled is the master switch for delivering a terminal-state
+	// notification (Completed / Failed) back to the task creator via the IM bot.
+	// Default OFF so the feature can be dark-launched.
+	NotifyEnabled bool
+	// SummaryBotToken authenticates the bot sendMessage / ensureFriend calls
+	// against octo-server. SECRET: read from env only, never printed/logged and
+	// never written to summary_notification.last_error.
+	SummaryBotToken string
+	// SummaryWebBaseURL is the base URL used to build the result link in a
+	// success notification (e.g. https://host/summary/<task_no>). When empty the
+	// success notification omits the link.
+	SummaryWebBaseURL string
+	// MaxNotifyAttempts caps same-row retries for a single (task_id, notify_kind)
+	// notification before it is left in status='failed'. Default 3.
+	MaxNotifyAttempts int
+	// NotifyQuietStart / NotifyQuietEnd define an optional quiet window
+	// ("HH:MM"). When both are set the window SUPPRESSES scheduled-task
+	// notifications only (on-demand/manual tasks are never suppressed). Empty =
+	// disabled (default).
+	NotifyQuietStart string
+	NotifyQuietEnd   string
 }
 
 func Load() *Config {
@@ -141,7 +165,15 @@ func Load() *Config {
 
 		ToolCallTimeout: envInt("TOOL_CALL_TIMEOUT", 30),
 
+		// keep upstream main default (true, #112)
 		FeatureTeamSchedule: envBool("FEATURE_TEAM_SCHEDULE", true),
+
+		NotifyEnabled:     envBool("SUMMARY_NOTIFY_ENABLED", false),
+		SummaryBotToken:   envStr("SUMMARY_BOT_TOKEN", ""),
+		SummaryWebBaseURL: envStr("SUMMARY_WEB_BASE_URL", ""),
+		MaxNotifyAttempts: envInt("MAX_NOTIFY_ATTEMPTS", 3),
+		NotifyQuietStart:  envStr("SUMMARY_NOTIFY_QUIET_START", ""),
+		NotifyQuietEnd:    envStr("SUMMARY_NOTIFY_QUIET_END", ""),
 	}
 }
 

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -1,0 +1,38 @@
+package model
+
+import "time"
+
+// Notification kind constants (summary_notification.notify_kind).
+// Leader 拍板选 A：failed/completed 各发一次（UNIQUE(task_id, notify_kind)）。
+const (
+	NotifyKindCompleted = "completed"
+	NotifyKindFailed    = "failed"
+)
+
+// Notification status constants (summary_notification.status).
+const (
+	NotifyStatusPending = "pending" // 抢占式插入后的初始态
+	NotifyStatusSent    = "sent"    // 投递成功（HTTP 2xx）
+	NotifyStatusFailed  = "failed"  // 重试耗尽，终态失败
+)
+
+// SummaryNotification is the dedup / idempotency state machine row for a single
+// terminal-state notification. It lives in the summary DB (never the IM DB).
+//
+// The UNIQUE(task_id, notify_kind) key is the preemptive-insert lock: the first
+// writer INSERTs status='pending' and wins; a duplicate-key error means another
+// run already owns this (task, kind) so the current run skips. A row is NEVER
+// DELETEd — failed deliveries stay as status='failed' with last_error for audit.
+type SummaryNotification struct {
+	ID           int64      `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID       int64      `gorm:"column:task_id;not null;uniqueIndex:uk_task_kind,priority:1" json:"task_id"`
+	NotifyKind   string     `gorm:"column:notify_kind;type:varchar(16);not null;uniqueIndex:uk_task_kind,priority:2" json:"notify_kind"`
+	Status       string     `gorm:"column:status;type:varchar(16);not null;default:'pending'" json:"status"`
+	AttemptCount int        `gorm:"column:attempt_count;not null;default:0" json:"attempt_count"`
+	LastError    *string    `gorm:"column:last_error;type:varchar(500)" json:"last_error"`
+	CreatedAt    time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt    time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+	SentAt       *time.Time `gorm:"column:sent_at" json:"sent_at"`
+}
+
+func (SummaryNotification) TableName() string { return "summary_notification" }

--- a/internal/notify/client.go
+++ b/internal/notify/client.go
@@ -1,0 +1,127 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Channel type values on the IM-bot wire protocol (sendMessage.channel_type).
+// These are the octo-server bot API values, NOT model.OriginChannel* — see
+// resolveTarget for the mapping. 1=DM, 2=Group, 5=Thread.
+const (
+	WireChannelDM     = 1
+	WireChannelGroup  = 2
+	WireChannelThread = 5
+)
+
+// Deliverer is the bot-side transport: establish the bot<->user relationship and
+// post a message. It is an interface so the trigger/state-machine logic can be
+// unit-tested without a live octo-server (联调阶段对齐真实契约).
+type Deliverer interface {
+	// EnsureFriend establishes the bot<->user relationship so a DM is deliverable.
+	// Idempotent; must be a no-op error when already friends. Called BEFORE send.
+	//
+	// spaceID (SummaryTask.SpaceID) is required so octo-server can build the
+	// space-prefixed IM whitelist channel (s{spaceID}_{uid}); under multi-Space
+	// deployments the whitelist is attached to the space-prefixed channel,
+	// otherwise the DM is silently dropped. The space prefix is used ONLY on the
+	// ensureFriend whitelist side — sendMessage.channel_id stays a bare uid.
+	EnsureFriend(ctx context.Context, spaceID, targetUID string) error
+	// SendMessage posts a bot message to the resolved channel.
+	SendMessage(ctx context.Context, msg SendMessageRequest) error
+}
+
+// SendMessageRequest is the body of POST {OCTO_API_URL}/v1/bot/sendMessage.
+// The payload carries ONLY text (+ result link / failure reason already folded
+// into text by the caller). It MUST NOT carry any OBO reserved fields
+// (__obo_*/obo_*/actual_sender_uid) — this is a first-class bot message.
+type SendMessageRequest struct {
+	ChannelID   string         `json:"channel_id"`
+	ChannelType int            `json:"channel_type"`
+	Payload     map[string]any `json:"payload"`
+}
+
+// oboReservedKeys are the OBO markers that must never appear in a bot payload.
+var oboReservedKeys = map[string]struct{}{
+	"actual_sender_uid": {},
+}
+
+func payloadHasOBOReserved(payload map[string]any) bool {
+	for k := range payload {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "__obo_") || strings.HasPrefix(lk, "obo_") {
+			return true
+		}
+		if _, ok := oboReservedKeys[lk]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// HTTPDeliverer is the production Deliverer talking to octo-server's bot API.
+type HTTPDeliverer struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+// NewHTTPDeliverer builds a Deliverer. token is the SUMMARY_BOT_TOKEN secret —
+// it is stored only in memory and only ever placed in the Authorization header.
+func NewHTTPDeliverer(baseURL, token string) *HTTPDeliverer {
+	return &HTTPDeliverer{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (d *HTTPDeliverer) EnsureFriend(ctx context.Context, spaceID, targetUID string) error {
+	body := map[string]string{
+		"target_uid": targetUID,
+		"space_id":   spaceID,
+	}
+	return d.post(ctx, "/v1/bot/ensureFriend", body)
+}
+
+func (d *HTTPDeliverer) SendMessage(ctx context.Context, msg SendMessageRequest) error {
+	if payloadHasOBOReserved(msg.Payload) {
+		// Defensive: never let an OBO reserved field leak into a bot message.
+		return fmt.Errorf("sendMessage payload contains forbidden OBO reserved field")
+	}
+	return d.post(ctx, "/v1/bot/sendMessage", msg)
+}
+
+func (d *HTTPDeliverer) post(ctx context.Context, path string, body any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal %s body: %w", path, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+d.token)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		// Never include req body / token in the error.
+		return fmt.Errorf("%s request failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	// Read a bounded slice of the response for diagnostics; the token lives only
+	// in the request header and is never echoed back, so this snippet is safe.
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return fmt.Errorf("%s returned HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(snippet)))
+}

--- a/internal/notify/dupkey.go
+++ b/internal/notify/dupkey.go
@@ -1,0 +1,37 @@
+package notify
+
+import (
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// isDuplicateKey reports whether err is a unique-constraint violation on the
+// summary_notification UNIQUE(task_id, notify_kind) key. It is driver-agnostic:
+//   - gorm v2 surfaces gorm.ErrDuplicatedKey for known drivers;
+//   - MySQL (go-sql-driver) reports "Error 1062" / "Duplicate entry";
+//   - SQLite (used by the unit tests) reports "UNIQUE constraint failed".
+//
+// We match all three so the preemptive-insert dedup works in prod and in tests.
+func isDuplicateKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "duplicate entry"):
+		return true
+	case strings.Contains(msg, "error 1062"):
+		return true
+	case strings.Contains(msg, "unique constraint failed"):
+		return true
+	case strings.Contains(msg, "constraint failed: unique"):
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -236,10 +237,7 @@ func (n *Notifier) markSent(taskID int64, kind string) {
 
 func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
 	now := n.now()
-	le := sanitize(cause.Error())
-	if len(le) > 480 {
-		le = le[:480]
-	}
+	le := truncateForLastError(sanitize(cause.Error()))
 	if err := n.db.Model(&model.SummaryNotification{}).
 		Where("task_id = ? AND notify_kind = ?", taskID, kind).
 		Updates(map[string]any{
@@ -344,6 +342,179 @@ func atoiBounded(s string, lo, hi int) (int, error) {
 		return 0, errors.New("out of range")
 	}
 	return n, nil
+}
+
+// SweepInterval is the recommended cron cadence for Notifier.Sweep. Exposed
+// so callers (cmd/summary-worker) don't have to pick a magic interval.
+const SweepInterval = 60 * time.Second
+
+// PendingLease is how long a 'pending' row may sit without progress before
+// Sweep reclaims it. The worker's synchronous delivery path uses a 15s HTTP
+// timeout (see deliver), so anything over ~1 min must mean the worker crashed
+// between claim and markSent/markFailed, OR markFailed itself failed (e.g.
+// the byte-truncation utf8 wedge that truncateForLastError now prevents — kept
+// as belt-and-suspenders for any other write error).
+const PendingLease = 5 * time.Minute
+
+// sweepBatchSize caps how many candidate rows Sweep handles per tick so a
+// degraded octo-server cannot pile up a single sweep beyond the cron cadence.
+const sweepBatchSize = 50
+
+// Sweep is the background recovery pass invoked by the scheduler cron. It
+// looks for two classes of rows that the synchronous worker path cannot
+// recover on its own:
+//
+//   - status='failed' AND attempt_count<MaxAttempts: a transient delivery
+//     blip dropped the message; retry budget remains but no fresh
+//     OnTaskTerminal hook will fire on its own (terminal callbacks are
+//     one-shot per task transition). Without this sweep, MaxAttempts is
+//     effectively 1 for the common path.
+//   - status='pending' AND updated_at<now-PendingLease: a worker crashed (or
+//     a write failed) between claim and the markSent/markFailed write.
+//     Without this sweep the row would sit at 'pending' forever and the
+//     dedup claim would keep skipping the (task, kind) pair.
+//
+// Both branches use the existing atomic CAS (claimRetry / claimPending) so a
+// concurrent OnTaskTerminal cannot double-send: only the runner whose UPDATE
+// flips the row to pending (RowsAffected==1) proceeds.
+//
+// Sweep is best-effort: any per-row error is logged and the loop continues.
+// It is safe to call when the notifier is disabled (returns immediately).
+func (n *Notifier) Sweep(ctx context.Context) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+	n.sweepRetryFailed(ctx)
+	n.sweepStalePending(ctx)
+}
+
+// sweepRetryFailed re-attempts delivery for rows stuck at status='failed'
+// with retry budget remaining.
+func (n *Notifier) sweepRetryFailed(ctx context.Context) {
+	var rows []model.SummaryNotification
+	if err := n.db.
+		Where("status = ? AND attempt_count < ?", model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Order("updated_at ASC").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		log.Printf("[notify] sweep: query failed rows: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		won, err := n.claimRetry(row.TaskID, row.NotifyKind)
+		if err != nil {
+			log.Printf("[notify] sweep: task=%d kind=%s claimRetry: %v", row.TaskID, row.NotifyKind, err)
+			continue
+		}
+		if !won {
+			continue // another runner won, or budget exhausted concurrently
+		}
+		n.redeliver(row.TaskID, row.NotifyKind)
+	}
+}
+
+// sweepStalePending reclaims rows stuck at status='pending' past the lease
+// (worker died or a write step failed between claim and markSent/markFailed).
+func (n *Notifier) sweepStalePending(ctx context.Context) {
+	cutoff := n.now().Add(-PendingLease)
+	var rows []model.SummaryNotification
+	if err := n.db.
+		Where("status = ? AND updated_at < ? AND attempt_count < ?",
+			model.NotifyStatusPending, cutoff, n.cfg.MaxAttempts).
+		Order("updated_at ASC").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		log.Printf("[notify] sweep: query pending rows: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		won, err := n.claimStalePending(row.TaskID, row.NotifyKind, cutoff)
+		if err != nil {
+			log.Printf("[notify] sweep: task=%d kind=%s claimStalePending: %v", row.TaskID, row.NotifyKind, err)
+			continue
+		}
+		if !won {
+			continue
+		}
+		log.Printf("[notify] sweep: reclaimed stale pending row task=%d kind=%s", row.TaskID, row.NotifyKind)
+		n.redeliver(row.TaskID, row.NotifyKind)
+	}
+}
+
+// claimStalePending atomically refreshes a stale 'pending' row's updated_at
+// so exactly one sweeper wins the right to redeliver it. Guarded on
+// status='pending' AND updated_at<cutoff so concurrent sweepers race and only
+// the row flipped by RowsAffected==1 proceeds.
+func (n *Notifier) claimStalePending(taskID int64, kind string, cutoff time.Time) (bool, error) {
+	now := n.now()
+	res := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ? AND updated_at < ?",
+			taskID, kind, model.NotifyStatusPending, cutoff).
+		Update("updated_at", now)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// redeliver performs one delivery attempt for a row whose retry slot we just
+// won (claimRetry or claimStalePending). It reloads the SummaryTask so the
+// message reflects the durable terminal-state row, then mirrors the
+// build+deliver+persist sequence from OnTaskTerminal. Any failure persists
+// via markFailed and is left for the next sweep tick or until budget runs out.
+func (n *Notifier) redeliver(taskID int64, kind string) {
+	var task model.SummaryTask
+	if err := n.db.First(&task, taskID).Error; err != nil {
+		// Task row gone (extremely unusual: rows are never deleted in the
+		// happy path). Treat as a permanent delivery failure so attempt_count
+		// advances and the row eventually leaves the retry set.
+		n.markFailed(taskID, kind, fmt.Errorf("reload task %d: %w", taskID, err))
+		return
+	}
+	target, ok := resolveTarget(task)
+	if !ok {
+		n.markFailed(taskID, kind, errors.New("no deliverable target on reload"))
+		return
+	}
+	errMsg := ""
+	if task.ErrorMessage != nil {
+		errMsg = *task.ErrorMessage
+	}
+	text := n.buildText(task, kind, errMsg)
+	if deliverErr := n.deliver(target, text); deliverErr != nil {
+		n.markFailed(taskID, kind, deliverErr)
+		log.Printf("[notify] sweep: task=%d kind=%s delivery failed: %v", taskID, kind, sanitize(deliverErr.Error()))
+		return
+	}
+	n.markSent(taskID, kind)
+	log.Printf("[notify] sweep: task=%d kind=%s delivered via retry", taskID, kind)
+}
+
+// truncateForLastError caps an error string for the VARCHAR(500) last_error
+// column. It enforces both a byte cap (≤480 bytes, leaving utf8mb4 headroom)
+// AND a rune boundary so a multi-byte codepoint is never sliced through the
+// middle — MySQL strict mode rejects invalid UTF-8 with Error 1366, which
+// would leave the notification row stuck in 'pending' (no sweep / no retry).
+func truncateForLastError(s string) string {
+	const maxBytes = 480
+	if len(s) <= maxBytes {
+		return s
+	}
+	s = s[:maxBytes]
+	// Back off until the tail is a valid UTF-8 sequence. utf8.ValidString runs
+	// over the whole string, but the only way a prefix becomes invalid is a
+	// truncated trailing rune (at most 3 bytes for utf8mb4-safe runes), so this
+	// loop terminates in ≤3 iterations.
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 // sanitize strips any accidental Bearer token / Authorization material from an

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -101,10 +101,23 @@ func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg str
 		return
 	}
 	if !claimed {
-		// Either another run owns it, or it is already sent / exhausted.
+		// First-delivery is serialized by the unique INSERT, but the retry
+		// decision must ALSO be atomic: two runners firing in the same tick
+		// (markPersonalFailed notify + scanStuckTasks reload-and-notify on the
+		// same task) would otherwise both read the same failed row, both see
+		// budget remaining, and both deliver, sending duplicate failure DMs.
+		// claimRetry does an atomic CAS UPDATE; only the runner that flips the
+		// row to pending (RowsAffected==1) proceeds, the loser skips.
 		if row != nil && row.Status == model.NotifyStatusFailed && row.AttemptCount < n.cfg.MaxAttempts {
-			// A previous attempt failed but still has retry budget: retry on this row.
-			log.Printf("[notify] task=%d kind=%s: retrying failed row (attempt %d/%d)", task.ID, kind, row.AttemptCount, n.cfg.MaxAttempts)
+			won, e := n.claimRetry(task.ID, kind)
+			if e != nil {
+				log.Printf("[notify] task=%d kind=%s: claimRetry failed: %v", task.ID, kind, e)
+				return
+			}
+			if !won {
+				return
+			}
+			log.Printf("[notify] task=%d kind=%s: retrying failed row (won retry slot)", task.ID, kind)
 		} else {
 			return
 		}
@@ -162,6 +175,26 @@ func (n *Notifier) claim(taskID int64, kind string) (bool, *model.SummaryNotific
 		return false, &existing, nil
 	}
 	return false, nil, err
+}
+
+// claimRetry atomically reclaims a failed (task, kind) row for one more
+// delivery attempt. It flips status failed->pending in a single conditional
+// UPDATE guarded on status=failed AND attempt_count<MaxAttempts, so concurrent
+// runners race on the row and exactly one gets RowsAffected==1. Returns
+// won=true only for that single winner; losers skip to avoid duplicate sends.
+func (n *Notifier) claimRetry(taskID int64, kind string) (bool, error) {
+	now := n.now()
+	res := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ? AND attempt_count < ?",
+			taskID, kind, model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Updates(map[string]any{
+			"status":     model.NotifyStatusPending,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
 }
 
 func (n *Notifier) deliver(target deliveryTarget, text string) error {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -47,10 +47,11 @@ type Config struct {
 
 // Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
 type Notifier struct {
-	db        *gorm.DB
-	deliverer Deliverer
-	cfg       Config
-	now       func() time.Time // injectable clock for tests
+	db              *gorm.DB
+	deliverer       Deliverer
+	cfg             Config
+	now             func() time.Time // injectable clock for tests
+	errorSanitizer  func(string) string // single render-point sanitizer for failure reasons (see WithErrorSanitizer)
 }
 
 // New builds a Notifier. A nil deliverer or Enabled=false makes OnTaskTerminal a
@@ -65,6 +66,25 @@ func New(db *gorm.DB, deliverer Deliverer, cfg Config) *Notifier {
 		cfg:       cfg,
 		now:       timezone.Now,
 	}
+}
+
+// WithErrorSanitizer wires a single-render-point sanitizer for failure-reason
+// strings. It MUST be set in production: buildText runs every failure reason
+// (whether arriving via the synchronous OnTaskTerminal path OR the
+// sweep/redeliver path that reloads task.ErrorMessage raw from DB) through this
+// sanitizer before composing the user DM. The canonical implementation lives in
+// internal/worker.SanitizeErrorForUser (whitelist-maps LLM/timeout/chunk errors
+// to safe Chinese strings, everything else → "AI 处理失败，请稍后重试").
+//
+// If left nil, buildText falls back to a hardcoded safe string for any
+// non-empty failure reason — never leaks raw err.Error() to the user DM.
+// See PR#113 Jerry-Xin/OctoBoooot R3 blocker: sanitizing only at the worker
+// call sites left the sweep redeliver path renderring raw DSN/IP/stack.
+func (n *Notifier) WithErrorSanitizer(fn func(string) string) *Notifier {
+	if n != nil {
+		n.errorSanitizer = fn
+	}
+	return n
 }
 
 // OnTaskTerminal is the single entry point the worker calls right AFTER a task
@@ -274,8 +294,19 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 		} else {
 			b.WriteString("你的总结生成失败。")
 		}
+		// Single render-point sanitization: every failure reason — whether arriving
+		// via the synchronous worker path (OnTaskTerminal) or the sweep/redeliver
+		// path that reloads task.ErrorMessage raw from DB — is scrubbed here before
+		// it can reach the user DM. See WithErrorSanitizer / PR#113 R3.
 		if reason := strings.TrimSpace(errMsg); reason != "" {
-			fmt.Fprintf(&b, "\n失败原因：%s", reason)
+			safe := reason
+			if n.errorSanitizer != nil {
+				safe = n.errorSanitizer(reason)
+			} else {
+				// Defensive: never leak raw internals if no sanitizer wired.
+				safe = "AI 处理失败，请稍后重试"
+			}
+			fmt.Fprintf(&b, "\n失败原因：%s", safe)
 		}
 		return b.String()
 	default:

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,345 @@
+// Package notify delivers a one-shot terminal-state notification (Completed /
+// Failed) for a summary task back to the task creator through the octo-server IM
+// bot. It is invoked by the worker AFTER a task's terminal status is durably
+// committed to the summary DB.
+//
+// Design (OCT-4, approved plan):
+//   - Dedup / idempotency via a summary_notification row keyed
+//     UNIQUE(task_id, notify_kind). The first writer INSERTs status='pending'
+//     and wins the right to deliver; a duplicate-key error means another run
+//     already owns this (task, kind), so we skip. Rows are NEVER deleted.
+//     completed and failed are independent kinds (Leader 拍板选 A：各发一次).
+//   - On HTTP success: UPDATE status='sent', sent_at=now.
+//   - On HTTP failure: UPDATE status='failed', last_error, attempt_count+1, with
+//     bounded same-row retries (MaxNotifyAttempts). The SECRET token is never
+//     written to last_error.
+//   - Cancelled tasks are not notified (the caller never calls OnTaskTerminal
+//     for Cancelled).
+//   - Optional quiet window suppresses SCHEDULED-task notifications only;
+//     on-demand (manual) tasks are never suppressed, and suppression drops the
+//     notification for this run (no 顺延).
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/gorm"
+)
+
+// Config is the subset of application config the notifier needs. It is passed
+// explicitly (rather than importing internal/config) so the package stays
+// decoupled and trivially testable.
+type Config struct {
+	Enabled     bool
+	WebBaseURL  string
+	MaxAttempts int
+	QuietStart  string // "HH:MM" or ""
+	QuietEnd    string // "HH:MM" or ""
+}
+
+// Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
+type Notifier struct {
+	db        *gorm.DB
+	deliverer Deliverer
+	cfg       Config
+	now       func() time.Time // injectable clock for tests
+}
+
+// New builds a Notifier. A nil deliverer or Enabled=false makes OnTaskTerminal a
+// no-op, so callers can wire it unconditionally.
+func New(db *gorm.DB, deliverer Deliverer, cfg Config) *Notifier {
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 3
+	}
+	return &Notifier{
+		db:        db,
+		deliverer: deliverer,
+		cfg:       cfg,
+		now:       timezone.Now,
+	}
+}
+
+// OnTaskTerminal is the single entry point the worker calls right AFTER a task
+// reaches a terminal status (Completed / Failed) durably in the DB. errMsg is
+// the task's ErrorMessage for a Failed task (ignored for Completed). It is
+// best-effort: a delivery failure is logged and persisted, never propagated to
+// the worker's completion path.
+func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg string) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+
+	kind, ok := kindForStatus(status)
+	if !ok {
+		// Cancelled / non-terminal: never notify.
+		return
+	}
+
+	// Quiet window suppresses SCHEDULED notifications only (按需任务永不抑制).
+	if task.TriggerType == model.TriggerScheduled && n.inQuietWindow(n.now()) {
+		log.Printf("[notify] task=%d kind=%s suppressed by quiet window (scheduled)", task.ID, kind)
+		return
+	}
+
+	target, ok := resolveTarget(task)
+	if !ok {
+		log.Printf("[notify] task=%d kind=%s: no deliverable target (empty creator), skipping", task.ID, kind)
+		return
+	}
+
+	// 1) Preemptive unique insert — claim the right to deliver this (task, kind).
+	claimed, row, err := n.claim(task.ID, kind)
+	if err != nil {
+		log.Printf("[notify] task=%d kind=%s: claim failed: %v", task.ID, kind, err)
+		return
+	}
+	if !claimed {
+		// Either another run owns it, or it is already sent / exhausted.
+		if row != nil && row.Status == model.NotifyStatusFailed && row.AttemptCount < n.cfg.MaxAttempts {
+			// A previous attempt failed but still has retry budget: retry on this row.
+			log.Printf("[notify] task=%d kind=%s: retrying failed row (attempt %d/%d)", task.ID, kind, row.AttemptCount, n.cfg.MaxAttempts)
+		} else {
+			return
+		}
+	}
+
+	// 2) Build + deliver.
+	text := n.buildText(task, kind, errMsg)
+	deliverErr := n.deliver(target, text)
+
+	// 3) Persist outcome.
+	if deliverErr == nil {
+		n.markSent(task.ID, kind)
+		log.Printf("[notify] task=%d kind=%s delivered to channel_type=%d", task.ID, kind, target.ChannelType)
+		return
+	}
+	n.markFailed(task.ID, kind, deliverErr)
+	log.Printf("[notify] task=%d kind=%s delivery failed: %v", task.ID, kind, sanitize(deliverErr.Error()))
+}
+
+func kindForStatus(status int) (string, bool) {
+	switch status {
+	case model.StatusCompleted:
+		return model.NotifyKindCompleted, true
+	case model.StatusFailed:
+		return model.NotifyKindFailed, true
+	default:
+		return "", false
+	}
+}
+
+// claim attempts the preemptive INSERT. Returns claimed=true when this run won
+// the (task, kind) slot. When the row already exists, claimed=false and the
+// existing row is returned so the caller can decide whether retry budget remains.
+func (n *Notifier) claim(taskID int64, kind string) (bool, *model.SummaryNotification, error) {
+	now := n.now()
+	row := &model.SummaryNotification{
+		TaskID:       taskID,
+		NotifyKind:   kind,
+		Status:       model.NotifyStatusPending,
+		AttemptCount: 0,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	// Plain Create: the UNIQUE(task_id, notify_kind) constraint rejects a
+	// duplicate with an error we treat as "someone else owns it".
+	err := n.db.Create(row).Error
+	if err == nil {
+		return true, row, nil
+	}
+	if isDuplicateKey(err) {
+		var existing model.SummaryNotification
+		if e := n.db.Where("task_id = ? AND notify_kind = ?", taskID, kind).First(&existing).Error; e != nil {
+			return false, nil, e
+		}
+		return false, &existing, nil
+	}
+	return false, nil, err
+}
+
+func (n *Notifier) deliver(target deliveryTarget, text string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// DM 可达前置：先 ensureFriend（幂等，带 space_id 供 server 拼 s{spaceID}_{uid}
+	// 白名单 channel），再 sendMessage.
+	if target.TargetUID != "" {
+		if err := n.deliverer.EnsureFriend(ctx, target.SpaceID, target.TargetUID); err != nil {
+			return fmt.Errorf("ensureFriend: %w", err)
+		}
+	}
+	msg := SendMessageRequest{
+		ChannelID:   target.ChannelID,
+		ChannelType: target.ChannelType,
+		Payload:     map[string]any{"text": text},
+	}
+	if err := n.deliverer.SendMessage(ctx, msg); err != nil {
+		return fmt.Errorf("sendMessage: %w", err)
+	}
+	return nil
+}
+
+func (n *Notifier) markSent(taskID int64, kind string) {
+	now := n.now()
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Updates(map[string]any{
+			"status":        model.NotifyStatusSent,
+			"sent_at":       now,
+			"updated_at":    now,
+			"attempt_count": gorm.Expr("attempt_count + 1"),
+			"last_error":    nil,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s: markSent failed: %v", taskID, kind, err)
+	}
+}
+
+func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
+	now := n.now()
+	le := sanitize(cause.Error())
+	if len(le) > 480 {
+		le = le[:480]
+	}
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Updates(map[string]any{
+			"status":        model.NotifyStatusFailed,
+			"updated_at":    now,
+			"attempt_count": gorm.Expr("attempt_count + 1"),
+			"last_error":    le,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s: markFailed failed: %v", taskID, kind, err)
+	}
+}
+
+// buildText composes the user-facing notification body. Success carries the
+// result link (when a base URL is configured); failure carries the sanitized
+// error message.
+func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string {
+	title := strings.TrimSpace(task.Title)
+	switch kind {
+	case model.NotifyKindCompleted:
+		var b strings.Builder
+		if title != "" {
+			fmt.Fprintf(&b, "你的总结「%s」已生成完成。", title)
+		} else {
+			b.WriteString("你的总结已生成完成。")
+		}
+		if link := n.resultLink(task); link != "" {
+			fmt.Fprintf(&b, "\n查看结果：%s", link)
+		}
+		return b.String()
+	case model.NotifyKindFailed:
+		var b strings.Builder
+		if title != "" {
+			fmt.Fprintf(&b, "你的总结「%s」生成失败。", title)
+		} else {
+			b.WriteString("你的总结生成失败。")
+		}
+		if reason := strings.TrimSpace(errMsg); reason != "" {
+			fmt.Fprintf(&b, "\n失败原因：%s", reason)
+		}
+		return b.String()
+	default:
+		return ""
+	}
+}
+
+// resultLink builds the result URL from the configured base. Empty base → no link.
+func (n *Notifier) resultLink(task model.SummaryTask) string {
+	base := strings.TrimRight(strings.TrimSpace(n.cfg.WebBaseURL), "/")
+	if base == "" || task.TaskNo == "" {
+		return ""
+	}
+	return base + "/summary/" + task.TaskNo
+}
+
+// inQuietWindow reports whether t (Asia/Shanghai) falls inside the configured
+// quiet window. Disabled (returns false) unless both bounds parse as "HH:MM".
+// Supports wrap-around windows (e.g. 22:00-07:00).
+func (n *Notifier) inQuietWindow(t time.Time) bool {
+	start, ok1 := parseHHMM(n.cfg.QuietStart)
+	end, ok2 := parseHHMM(n.cfg.QuietEnd)
+	if !ok1 || !ok2 || start == end {
+		return false
+	}
+	cur := t.Hour()*60 + t.Minute()
+	if start < end {
+		return cur >= start && cur < end
+	}
+	// Wrap-around (overnight) window.
+	return cur >= start || cur < end
+}
+
+// parseHHMM parses "HH:MM" into minutes-of-day. Returns ok=false on any malformed input.
+func parseHHMM(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return 0, false
+	}
+	h, err1 := atoiBounded(parts[0], 0, 23)
+	m, err2 := atoiBounded(parts[1], 0, 59)
+	if err1 != nil || err2 != nil {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+func atoiBounded(s string, lo, hi int) (int, error) {
+	n := 0
+	if s == "" {
+		return 0, errors.New("empty")
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, errors.New("non-digit")
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n < lo || n > hi {
+		return 0, errors.New("out of range")
+	}
+	return n, nil
+}
+
+// sanitize strips any accidental Bearer token / Authorization material from an
+// error string before it is persisted to last_error or logged. Defense in
+// depth: the deliverer already keeps the token out of errors. It scans forward
+// and advances past each rewritten marker so the inserted "Bearer [REDACTED]"
+// is never re-matched (which would loop forever).
+func sanitize(s string) string {
+	const marker = "bearer "
+	const redacted = "Bearer [REDACTED]"
+	var b strings.Builder
+	lower := strings.ToLower(s)
+	for {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			b.WriteString(s)
+			break
+		}
+		b.WriteString(s[:idx])
+		b.WriteString(redacted)
+		rest := s[idx+len(marker):]
+		end := strings.IndexAny(rest, " \n\t")
+		if end < 0 {
+			// Token runs to end of string; drop it entirely.
+			break
+		}
+		// Keep the delimiter and everything after; continue scanning the tail.
+		s = rest[end:]
+		lower = strings.ToLower(s)
+	}
+	return b.String()
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,349 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupNotifyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.SummaryNotification{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+// ensureCall records one EnsureFriend invocation.
+type ensureCall struct {
+	SpaceID string
+	UID     string
+}
+
+// fakeDeliverer records calls and can be told to fail.
+type fakeDeliverer struct {
+	mu          sync.Mutex
+	ensureCalls []ensureCall
+	sendCalls   []SendMessageRequest
+	failEnsure  error
+	failSend    error
+	sendErrOnce error // returned once then cleared (for retry tests)
+}
+
+func (f *fakeDeliverer) EnsureFriend(ctx context.Context, spaceID, uid string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureCalls = append(f.ensureCalls, ensureCall{SpaceID: spaceID, UID: uid})
+	return f.failEnsure
+}
+
+func (f *fakeDeliverer) SendMessage(ctx context.Context, msg SendMessageRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, msg)
+	if f.sendErrOnce != nil {
+		e := f.sendErrOnce
+		f.sendErrOnce = nil
+		return e
+	}
+	return f.failSend
+}
+
+func baseTask(id int64, trigger int) model.SummaryTask {
+	return model.SummaryTask{
+		ID:                id,
+		TaskNo:            "TST-1",
+		Title:             "今日群聊",
+		SpaceID:           "space-9",
+		CreatorID:         "user-1",
+		TriggerType:       trigger,
+		OriginChannelType: model.OriginChannelGlobal,
+	}
+}
+
+func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
+	n := New(db, d, cfg)
+	// Fixed clock at 10:00 Asia/Shanghai (outside the default quiet window).
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+	return n
+}
+
+func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	if len(d.ensureCalls) != 1 || d.ensureCalls[0].UID != "user-1" || d.ensureCalls[0].SpaceID != "space-9" {
+		t.Fatalf("expected ensureFriend(space-9, user-1), got %v", d.ensureCalls)
+	}
+	msg := d.sendCalls[0]
+	if msg.ChannelType != WireChannelDM || msg.ChannelID != "user-1" {
+		t.Fatalf("expected DM to user-1, got type=%d id=%s", msg.ChannelType, msg.ChannelID)
+	}
+	text, _ := msg.Payload["text"].(string)
+	if !strings.Contains(text, "今日群聊") || !strings.Contains(text, "https://app.example.com/summary/TST-1") {
+		t.Fatalf("completed text missing title/link: %q", text)
+	}
+	// OBO reserved fields must not be present.
+	if payloadHasOBOReserved(msg.Payload) {
+		t.Fatalf("payload leaked OBO reserved field: %v", msg.Payload)
+	}
+
+	var row model.SummaryNotification
+	db.Where("task_id = ? AND notify_kind = ?", 1, model.NotifyKindCompleted).First(&row)
+	if row.Status != model.NotifyStatusSent || row.SentAt == nil {
+		t.Fatalf("expected status=sent with sent_at, got status=%s sent_at=%v", row.Status, row.SentAt)
+	}
+}
+
+func TestOnTaskTerminal_FailedCarriesReason(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(2, model.TriggerManual), model.StatusFailed, "LLM timeout")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["text"].(string)
+	if !strings.Contains(text, "失败") || !strings.Contains(text, "LLM timeout") {
+		t.Fatalf("failed text missing reason: %q", text)
+	}
+}
+
+func TestOnTaskTerminal_DedupSameKindSendsOnce(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(3, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // duplicate
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // duplicate
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected exactly 1 send after 3 calls (dedup), got %d", len(d.sendCalls))
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 3).Count(&cnt)
+	if cnt != 1 {
+		t.Fatalf("expected exactly 1 notification row, got %d", cnt)
+	}
+}
+
+func TestOnTaskTerminal_CompletedAndFailedAreIndependent(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(4, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (completed + failed), got %d", len(d.sendCalls))
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 4).Count(&cnt)
+	if cnt != 2 {
+		t.Fatalf("expected 2 notification rows, got %d", cnt)
+	}
+}
+
+func TestOnTaskTerminal_CancelledNeverNotifies(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(5, model.TriggerManual), model.StatusCancelled, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("cancelled must not notify, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestOnTaskTerminal_DisabledIsNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: false})
+
+	n.OnTaskTerminal(baseTask(6, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("disabled must be no-op, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestOnTaskTerminal_FailureMarksFailedWithRetryBudget(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("network down: Bearer secret-token-123 leaked")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(7, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 7).First(&row)
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("expected status=failed, got %s", row.Status)
+	}
+	if row.AttemptCount != 1 {
+		t.Fatalf("expected attempt_count=1, got %d", row.AttemptCount)
+	}
+	if row.LastError == nil {
+		t.Fatalf("expected last_error set")
+	}
+	// SECRET must never be persisted to last_error.
+	if strings.Contains(*row.LastError, "secret-token-123") {
+		t.Fatalf("last_error leaked the bearer token: %q", *row.LastError)
+	}
+	if !strings.Contains(*row.LastError, "[REDACTED]") {
+		t.Fatalf("expected token redaction marker, got %q", *row.LastError)
+	}
+
+	// Second call has retry budget (1 < 3) and now succeeds.
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+	db.Where("task_id = ?", 7).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("expected retry to send, status=%s", row.Status)
+	}
+}
+
+func TestOnTaskTerminal_RetryBudgetExhausted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("always down")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 2})
+
+	task := baseTask(8, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 1
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 2 -> budget exhausted
+	sendsBefore := len(d.sendCalls)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // no budget -> must NOT send again
+
+	if len(d.sendCalls) != sendsBefore {
+		t.Fatalf("expected no further sends after budget exhausted; before=%d after=%d", sendsBefore, len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 8).First(&row)
+	if row.AttemptCount != 2 {
+		t.Fatalf("expected attempt_count capped at 2, got %d", row.AttemptCount)
+	}
+}
+
+func TestQuietWindow_SuppressesScheduledNotManual(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, d, Config{Enabled: true, QuietStart: "22:00", QuietEnd: "07:00"})
+	// Clock at 23:30 Asia/Shanghai (inside the overnight quiet window).
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 23, 30, 0, 0, timezone.Location()) }
+
+	// Scheduled task: suppressed.
+	n.OnTaskTerminal(baseTask(9, model.TriggerScheduled), model.StatusCompleted, "")
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("scheduled in quiet window must be suppressed, got %d sends", len(d.sendCalls))
+	}
+	// No row should be created when suppressed (we never claim).
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 9).Count(&cnt)
+	if cnt != 0 {
+		t.Fatalf("suppressed notification should not create a row, got %d", cnt)
+	}
+
+	// Manual task: never suppressed.
+	n.OnTaskTerminal(baseTask(10, model.TriggerManual), model.StatusCompleted, "")
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("manual task must not be suppressed, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestQuietWindow_OutsideWindowDelivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, QuietStart: "22:00", QuietEnd: "07:00"}) // clock 10:00 CST -> outside
+
+	n.OnTaskTerminal(baseTask(11, model.TriggerScheduled), model.StatusCompleted, "")
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("scheduled outside quiet window must deliver, got %d", len(d.sendCalls))
+	}
+}
+
+func TestResolveTarget_DMFallbackForAllOrigins(t *testing.T) {
+	origins := []int{model.OriginChannelGlobal, model.OriginChannelDM, model.OriginChannelGroup, model.OriginChannelThread}
+	for _, o := range origins {
+		task := baseTask(1, model.TriggerManual)
+		task.OriginChannelType = o
+		task.OriginChannelID = "origin-chan"
+		tgt, ok := resolveTarget(task)
+		if !ok {
+			t.Fatalf("origin %d: expected resolvable target", o)
+		}
+		if tgt.ChannelType != WireChannelDM || tgt.ChannelID != "user-1" || tgt.TargetUID != "user-1" {
+			t.Fatalf("origin %d: expected creator DM fallback, got %+v", o, tgt)
+		}
+	}
+}
+
+func TestResolveTarget_EmptyCreatorUnresolvable(t *testing.T) {
+	task := baseTask(1, model.TriggerManual)
+	task.CreatorID = ""
+	if _, ok := resolveTarget(task); ok {
+		t.Fatalf("empty creator must be unresolvable")
+	}
+}
+
+func TestParseHHMM(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"22:00", 22*60 + 0, true},
+		{"07:30", 7*60 + 30, true},
+		{"00:00", 0, true},
+		{"23:59", 23*60 + 59, true},
+		{"24:00", 0, false},
+		{"22", 0, false},
+		{"", 0, false},
+		{"aa:bb", 0, false},
+		{"12:60", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseHHMM(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("parseHHMM(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestPayloadHasOBOReserved(t *testing.T) {
+	if !payloadHasOBOReserved(map[string]any{"__obo_uid": "x"}) {
+		t.Errorf("expected __obo_ prefix detected")
+	}
+	if !payloadHasOBOReserved(map[string]any{"obo_sender": "x"}) {
+		t.Errorf("expected obo_ prefix detected")
+	}
+	if !payloadHasOBOReserved(map[string]any{"actual_sender_uid": "x"}) {
+		t.Errorf("expected actual_sender_uid detected")
+	}
+	if payloadHasOBOReserved(map[string]any{"text": "hello"}) {
+		t.Errorf("clean payload flagged as OBO")
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -78,6 +78,11 @@ func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
 	n := New(db, d, cfg)
 	// Fixed clock at 10:00 Asia/Shanghai (outside the default quiet window).
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+	// Default test sanitizer is identity so existing tests can assert on the
+	// exact errMsg they pass in (e.g. "LLM timeout"). Production wires
+	// worker.SanitizeErrorForUser via WithErrorSanitizer; the dedicated R3
+	// regression tests below opt into that mapping explicitly.
+	n.errorSanitizer = func(s string) string { return s }
 	return n
 }
 
@@ -580,5 +585,119 @@ func TestSweep_DisabledIsNoop(t *testing.T) {
 	n.Sweep(context.Background()) // must not panic / not query
 	if len(d.sendCalls) != 0 {
 		t.Fatalf("disabled notifier sweep must be no-op")
+	}
+}
+
+// --- R3 (PR#113 Jerry-Xin/OctoBoooot) — sweep redeliver MUST sanitize ---
+//
+// Regression test for the blocker reported on head fede1ab5: the sweep path
+// reloaded task.ErrorMessage raw from DB and rendered it into the user DM,
+// bypassing the worker-side SanitizeErrorForUser scrub applied only at
+// OnTaskTerminal call sites. We now sanitize at a single render point in
+// buildText, and the production wiring (cmd/summary-worker/main.go) injects
+// worker.SanitizeErrorForUser via WithErrorSanitizer. This test asserts that
+// the sanitizer is actually invoked on the sweep redeliver path — i.e. raw
+// internal substrings never reach the deliverer.
+func TestSweep_RedeliverSanitizesRawError(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	// Wire a strict sanitizer mimicking worker.SanitizeErrorForUser: anything
+	// containing raw markers maps to a fixed safe string. We can't import the
+	// worker package here (import cycle), so we cover the contract: the render
+	// point invokes the injected sanitizer, raw markers never reach the DM.
+	rawMarkers := []string{"dial tcp", "10.2.3.4", "postgres://", "goroutine", "secretpw"}
+	sanitizerCalls := 0
+	n.errorSanitizer = func(s string) string {
+		sanitizerCalls++
+		for _, m := range rawMarkers {
+			if strings.Contains(s, m) {
+				return "AI 处理失败，请稍后重试"
+			}
+		}
+		return s
+	}
+
+	// Raw err in the shape the reviewer flagged: DSN + IP + credential + stack head.
+	rawErr := "dial tcp 10.2.3.4:5432: connect: connection refused (dsn=postgres://user:secretpw@10.2.3.4:5432/db) goroutine 1 [running]"
+	task := baseTask(901, model.TriggerManual)
+	task.ErrorMessage = &rawErr
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// First call: synchronous path. Even on the immediate hop the new
+	// single-render-point sanitize runs, so the synchronous send (which fails
+	// once via sendErrOnce) must not leak the raw err either.
+	n.OnTaskTerminal(task, model.StatusFailed, rawErr)
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 901).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("precondition: expected failed after first send, got %s", row.Status)
+	}
+
+	// Sweep — this is the path that historically read task.ErrorMessage raw
+	// and rendered it unsanitized into the DM.
+	n.Sweep(context.Background())
+
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 send calls (1 initial fail + 1 sweep retry), got %d", len(d.sendCalls))
+	}
+	if sanitizerCalls < 2 {
+		t.Fatalf("sanitizer must be invoked on BOTH the synchronous AND the redeliver render; got calls=%d", sanitizerCalls)
+	}
+	for i, call := range d.sendCalls {
+		text, _ := call.Payload["text"].(string)
+		for _, m := range rawMarkers {
+			if strings.Contains(text, m) {
+				t.Fatalf("send #%d leaked raw marker %q into DM text:\n%s", i, m, text)
+			}
+		}
+		if !strings.Contains(text, "AI 处理失败，请稍后重试") {
+			t.Fatalf("send #%d missing safe failure reason; got:\n%s", i, text)
+		}
+	}
+
+	// Final state: sweep succeeded → sent.
+	db.Where("task_id = ?", 901).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("after sweep retry expected sent, got %s (attempts=%d)", row.Status, row.AttemptCount)
+	}
+}
+
+// TestBuildText_NilSanitizerFallsBackToSafeString asserts the defensive
+// fallback: if Notifier is constructed without WithErrorSanitizer (production
+// misconfig), buildText still refuses to render raw err.Error() to the user
+// DM. This guards against future call sites accidentally forgetting the wiring.
+func TestBuildText_NilSanitizerFallsBackToSafeString(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	// Bypass newTestNotifier so we get a Notifier with nil errorSanitizer.
+	n := New(db, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	rawErr := "dial tcp 10.2.3.4: connect refused dsn=postgres://u:secretpw@h/db"
+	task := baseTask(902, model.TriggerManual)
+
+	n.OnTaskTerminal(task, model.StatusFailed, rawErr)
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["text"].(string)
+	for _, m := range []string{"dial tcp", "10.2.3.4", "postgres://", "secretpw"} {
+		if strings.Contains(text, m) {
+			t.Fatalf("nil sanitizer must not leak raw marker %q to DM; text=%q", m, text)
+		}
+	}
+	if !strings.Contains(text, "AI 处理失败，请稍后重试") {
+		t.Fatalf("nil sanitizer fallback must render the safe default; text=%q", text)
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -345,5 +346,239 @@ func TestPayloadHasOBOReserved(t *testing.T) {
 	}
 	if payloadHasOBOReserved(map[string]any{"text": "hello"}) {
 		t.Errorf("clean payload flagged as OBO")
+	}
+}
+
+// --- B2 (PR#113 review P1-2) ---
+
+func TestMarkFailed_TruncatesAtRuneBoundary_NoUTF8Wedge(t *testing.T) {
+	// Reviewer P1-2: byte-wise truncation of a CJK error string could sever a
+	// multi-byte rune; under MySQL strict mode the resulting invalid UTF-8
+	// rejects the UPDATE and the row stays at 'pending' forever.
+	// truncateForLastError must produce a valid UTF-8 string and the row must
+	// reach 'failed'.
+	db := setupNotifyTestDB(t)
+	// Long CJK error message: 300 三-byte runes = 900 bytes, well past the
+	// 480-byte cap so the byte cut would almost certainly land mid-rune.
+	longCJK := strings.Repeat("中", 300)
+	d := &fakeDeliverer{failSend: errors.New("octo-server boom: " + longCJK)}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	n.OnTaskTerminal(baseTask(101, model.TriggerManual), model.StatusFailed, "x")
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 101).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("expected status=failed (markFailed must not wedge at pending), got %s", row.Status)
+	}
+	if row.LastError == nil {
+		t.Fatalf("expected last_error to be set")
+	}
+	le := *row.LastError
+	if !utf8.ValidString(le) {
+		t.Fatalf("last_error must be valid UTF-8 after truncation, got bytes=%q", []byte(le))
+	}
+	if len(le) > 480 {
+		t.Fatalf("last_error must be ≤480 bytes for VARCHAR(500) utf8mb4 headroom, got %d", len(le))
+	}
+	// Must still carry the original prefix so operators can diagnose.
+	// The deliver layer wraps with "sendMessage: "; the prefix must still
+	// contain the original error head so operators can diagnose.
+	if !strings.Contains(le, "octo-server boom:") {
+		t.Fatalf("expected truncated message to keep diagnostic prefix, got %q", le)
+	}
+}
+
+func TestTruncateForLastError_ShortInputUnchanged(t *testing.T) {
+	in := "short ascii error"
+	if got := truncateForLastError(in); got != in {
+		t.Fatalf("short input must pass through, got %q", got)
+	}
+	cjk := "失败：LLM 超时"
+	if got := truncateForLastError(cjk); got != cjk {
+		t.Fatalf("short CJK input must pass through, got %q", got)
+	}
+}
+
+func TestTruncateForLastError_NeverSplitsRune(t *testing.T) {
+	// Build a string whose byte length crosses the 480 cap exactly inside a
+	// multi-byte rune so a naive [:480] slice would produce invalid UTF-8.
+	// 中 is 3 bytes; placing 160 of them gives 480 bytes (boundary-aligned),
+	// then a 4-byte rune (𠮷, U+20BB7) starting at byte 480 ensures the cut
+	// would land mid-rune for any cap inside that rune. We assert validity for
+	// a sweep of caps around the boundary by repeatedly building inputs that
+	// straddle.
+	inputs := []string{
+		strings.Repeat("中", 160) + "𠮷" + strings.Repeat("a", 100),
+		strings.Repeat("a", 479) + "𠮷xx",
+		strings.Repeat("a", 478) + "中" + strings.Repeat("b", 100),
+		strings.Repeat("a", 477) + "中" + strings.Repeat("b", 100),
+	}
+	for i, in := range inputs {
+		out := truncateForLastError(in)
+		if !utf8.ValidString(out) {
+			t.Errorf("case %d: output not valid UTF-8: %q", i, out)
+		}
+		if len(out) > 480 {
+			t.Errorf("case %d: output too long: %d bytes", i, len(out))
+		}
+	}
+}
+
+// --- B1 (PR#113 review P1-1) — background sweep ---
+
+func TestSweep_RetriesFailedRowWithBudget(t *testing.T) {
+	// Simulates the common case: first OnTaskTerminal sees a transient HTTP
+	// failure and leaves the row at status='failed', attempt_count=1. No
+	// further OnTaskTerminal will fire (terminal callbacks are one-shot per
+	// task transition). Sweep must redeliver and reach status='sent'.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(201, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 201).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("precondition: expected failed after first attempt, got %s", row.Status)
+	}
+
+	// Persist the original task so redeliver can reload it.
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	db.Where("task_id = ?", 201).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("sweep must redeliver and mark sent, got status=%s attempts=%d", row.Status, row.AttemptCount)
+	}
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 send calls (1 initial fail + 1 sweep retry), got %d", len(d.sendCalls))
+	}
+}
+
+func TestSweep_DoesNotRetryWhenBudgetExhausted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("always down")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 2})
+
+	task := baseTask(202, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 1
+	n.Sweep(context.Background())                   // attempt 2 -> exhausted
+	sendsBefore := len(d.sendCalls)
+	n.Sweep(context.Background()) // must not retry
+
+	if len(d.sendCalls) != sendsBefore {
+		t.Fatalf("expected no further sends; before=%d after=%d", sendsBefore, len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 202).First(&row)
+	if row.AttemptCount != 2 {
+		t.Fatalf("attempt_count must cap at MaxAttempts=2, got %d", row.AttemptCount)
+	}
+}
+
+func TestSweep_ReclaimsStalePendingRow(t *testing.T) {
+	// Simulates a worker crash between claim() and markSent/markFailed: the
+	// row is left at status='pending' and would normally be skipped by every
+	// future OnTaskTerminal (dedup) forever. Sweep must reclaim it past the
+	// lease and redeliver.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(203, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// Inject a stale pending row directly: updated_at well past the lease.
+	stale := n.now().Add(-2 * PendingLease)
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:     203,
+		NotifyKind: model.NotifyKindCompleted,
+		Status:     model.NotifyStatusPending,
+		CreatedAt:  stale,
+		UpdatedAt:  stale,
+	}).Error; err != nil {
+		t.Fatalf("seed stale pending: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 203).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("sweep must redeliver stale pending row, got status=%s", row.Status)
+	}
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected exactly 1 send on reclaim, got %d", len(d.sendCalls))
+	}
+}
+
+func TestSweep_DoesNotReclaimFreshPendingRow(t *testing.T) {
+	// A fresh pending row (worker still trying) must not be stolen by Sweep.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(204, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	fresh := n.now() // just claimed
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:     204,
+		NotifyKind: model.NotifyKindCompleted,
+		Status:     model.NotifyStatusPending,
+		CreatedAt:  fresh,
+		UpdatedAt:  fresh,
+	}).Error; err != nil {
+		t.Fatalf("seed fresh pending: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("fresh pending row must not be reclaimed, got %d sends", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 204).First(&row)
+	if row.Status != model.NotifyStatusPending {
+		t.Fatalf("expected status=pending preserved, got %s", row.Status)
+	}
+}
+
+func TestSweep_DisabledIsNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, d, Config{Enabled: false})
+	n.Sweep(context.Background()) // must not panic / not query
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("disabled notifier sweep must be no-op")
 	}
 }

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -1,0 +1,55 @@
+package notify
+
+import (
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// deliveryTarget is the resolved destination of a notification.
+type deliveryTarget struct {
+	ChannelID   string
+	ChannelType int // WireChannelDM / WireChannelGroup / WireChannelThread
+	// TargetUID is the user the bot must EnsureFriend with before a DM is
+	// deliverable. Set only for DM delivery; empty for group/thread回发.
+	TargetUID string
+	// SpaceID (SummaryTask.SpaceID) is passed to ensureFriend so octo-server can
+	// build the space-prefixed whitelist channel (s{spaceID}_{uid}).
+	SpaceID string
+}
+
+// resolveTarget decides where a terminal-state notification for `task` is sent.
+//
+// 本期口径 (OCT-4, this phase): we ALWAYS fall back to a DM to the task creator.
+// The task carries OriginChannelID/OriginChannelType (model.OriginChannel*:
+// 0=Global, 1=Group, 2=Thread, 3=DM), but 原群/thread 回发 is an explicit
+// follow-up enhancement and is intentionally NOT depended on here. Whether the
+// origin is DM, empty, or Global, we route to ChannelTypePerson with
+// channel_id = CreatorID. Group/Thread origins also fall back to a creator DM
+// this phase (we do not yet post back into the originating group/thread).
+//
+// The switch is written out so the future enhancement (route Group/Thread back
+// to the origin channel) is a localized change, but every branch currently
+// resolves to the DM fallback.
+func resolveTarget(task model.SummaryTask) (deliveryTarget, bool) {
+	creatorDM := func() (deliveryTarget, bool) {
+		if task.CreatorID == "" {
+			return deliveryTarget{}, false
+		}
+		return deliveryTarget{
+			ChannelID:   task.CreatorID,
+			ChannelType: WireChannelDM,
+			TargetUID:   task.CreatorID,
+			SpaceID:     task.SpaceID,
+		}, true
+	}
+
+	switch task.OriginChannelType {
+	case model.OriginChannelDM, model.OriginChannelGlobal:
+		// DM origin or no/global origin → creator DM (本期默认兜底).
+		return creatorDM()
+	case model.OriginChannelGroup, model.OriginChannelThread:
+		// 原群/thread 回发：后续增强，本期不做依赖 → 退回 creator DM 兜底.
+		return creatorDM()
+	default:
+		return creatorDM()
+	}
+}

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -294,6 +294,11 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			EventType: "META_SUMMARY_UPDATED",
 		})
 
+		// Task durably reached Completed (saveLatestResultAndCompleteTask succeeded).
+		// The notifier dedups on UNIQUE(task_id, completed), so a meta re-run that
+		// produces a new version still only sends ONE completed notification.
+		m.proc.notifyTaskTerminal(taskID, model.StatusCompleted)
+
 		log.Printf("[meta-worker] task %d meta-summary version %d created (%d participants)",
 			taskID, result.Version, len(submitted))
 

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -220,6 +220,9 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 			Progress: 100,
 			Message:  "总结完成",
 		})
+		// Task durably reached Completed above (saveLatestResultAndCompleteTask /
+		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
+		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
@@ -445,6 +448,9 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 			Progress: 0,
 			Message:  sanitized,
 		})
+		// shouldNotify is set only when the task-level CAS to StatusFailed actually
+		// flipped the row (single-person terminal failure). Fire the notification.
+		p.notifyTaskTerminal(pr.TaskID, model.StatusFailed)
 	}
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -794,6 +794,18 @@ func estimateTokens(content string, charsPerTokenCJK, charsPerTokenASCII int) in
 	return cjkCount/charsPerTokenCJK + asciiCount/charsPerTokenASCII + overheadPerMsg
 }
 
+// SanitizeErrorForUser is the canonical whitelist that maps a raw internal
+// error string to a user-safe Chinese string suitable for an IM DM.
+//
+// Exported so the notify package can wire it as the single render-point
+// sanitizer in Notifier.buildText (covers both the synchronous worker path
+// AND the sweep/redeliver path that reads task.ErrorMessage raw from the DB).
+// See PR#113 Jerry-Xin/OctoBoooot R3: sanitizing only at the worker call
+// sites left the sweep path leaking DSN/IP/stack to the user DM on retry.
+func SanitizeErrorForUser(errMsg string) string {
+	return sanitizeErrorForUser(errMsg)
+}
+
 func sanitizeErrorForUser(errMsg string) string {
 	switch {
 	case strings.Contains(errMsg, "LLM API error"):

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -73,6 +73,16 @@ func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
 // trigger type, error_message). Best-effort: any failure is swallowed inside the
 // notifier and never affects the worker's completion path. Call this ONLY after
 // the terminal-status DB write has succeeded.
+//
+// The reloaded task.error_message is the RAW internal error string (may carry
+// DSN credentials, IPs, goroutine stack heads). It is intentionally persisted
+// raw in the DB so ops can root-cause from logs, but it MUST NOT reach a user
+// DM. We run it through sanitizeErrorForUser here — the same sanitizer the
+// personal failure path (markPersonalFailed) already uses — so the failure
+// reason rendered into the IM payload is the user-safe whitelist mapping.
+// Single-point intercept: every task-level failure that flows through
+// notifyTaskTerminal is sanitized exactly once, and new fail-write sites do
+// not have to re-add sanitize.
 func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if p.notifier == nil {
 		return
@@ -86,7 +96,7 @@ func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if task.ErrorMessage != nil {
 		errMsg = *task.ErrorMessage
 	}
-	p.notifier.OnTaskTerminal(task, status, errMsg)
+	p.notifier.OnTaskTerminal(task, status, sanitizeErrorForUser(errMsg))
 }
 
 // TriggerCh returns the channel for worker trigger requests.

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -77,12 +77,16 @@ func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
 // The reloaded task.error_message is the RAW internal error string (may carry
 // DSN credentials, IPs, goroutine stack heads). It is intentionally persisted
 // raw in the DB so ops can root-cause from logs, but it MUST NOT reach a user
-// DM. We run it through sanitizeErrorForUser here — the same sanitizer the
-// personal failure path (markPersonalFailed) already uses — so the failure
-// reason rendered into the IM payload is the user-safe whitelist mapping.
-// Single-point intercept: every task-level failure that flows through
-// notifyTaskTerminal is sanitized exactly once, and new fail-write sites do
-// not have to re-add sanitize.
+// DM.
+//
+// Sanitization happens at a SINGLE render point inside notify.buildText (wired
+// via notify.WithErrorSanitizer(SanitizeErrorForUser) at construction in
+// cmd/summary-worker/main.go). That single intercept covers BOTH the
+// synchronous path here AND the asynchronous sweep/redeliver path
+// (notify.go: redeliver reloads task.ErrorMessage raw from DB). Pre-PR#113 R3,
+// sanitize was applied here only and the sweep path leaked raw errors to the
+// user DM — see Jerry-Xin/OctoBoooot R3 review. We deliberately pass the raw
+// errMsg through and let buildText scrub it once at the render boundary.
 func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if p.notifier == nil {
 		return
@@ -96,7 +100,7 @@ func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if task.ErrorMessage != nil {
 		errMsg = *task.ErrorMessage
 	}
-	p.notifier.OnTaskTerminal(task, status, sanitizeErrorForUser(errMsg))
+	p.notifier.OnTaskTerminal(task, status, errMsg)
 }
 
 // TriggerCh returns the channel for worker trigger requests.

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -41,6 +42,10 @@ type Processor struct {
 	// get dispatched) is observable without running the LLM personal pipeline.
 	// Production leaves it nil and the real pool/processPersonalSummary is used.
 	dispatchPersonalFn func(taskID, participantRefID int64)
+	// notifier delivers the terminal-state (Completed/Failed) IM-bot notification
+	// after a task's status is durably committed. nil = disabled (OnTaskTerminal
+	// is a no-op), so it is safe to call unconditionally.
+	notifier *notify.Notifier
 }
 
 // NewProcessor creates a new task processor.
@@ -56,6 +61,32 @@ func NewProcessor(db, imDB *gorm.DB, pool *WorkerPool, llm *service.LLMClient, c
 	}
 	p.meta = NewMetaProcessor(p)
 	return p
+}
+
+// SetNotifier wires the terminal-state IM-bot notifier. Optional: when unset,
+// notifyTaskTerminal is a no-op.
+func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
+
+// notifyTaskTerminal fires the terminal-state notification for a task that just
+// reached a terminal status. It reloads the committed task row so the
+// notification reflects the durable state (title, creator, origin channel,
+// trigger type, error_message). Best-effort: any failure is swallowed inside the
+// notifier and never affects the worker's completion path. Call this ONLY after
+// the terminal-status DB write has succeeded.
+func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
+	if p.notifier == nil {
+		return
+	}
+	var task model.SummaryTask
+	if err := p.db.First(&task, taskID).Error; err != nil {
+		log.Printf("[processor] notifyTaskTerminal: reload task %d failed: %v", taskID, err)
+		return
+	}
+	errMsg := ""
+	if task.ErrorMessage != nil {
+		errMsg = *task.ErrorMessage
+	}
+	p.notifier.OnTaskTerminal(task, status, errMsg)
 }
 
 // TriggerCh returns the channel for worker trigger requests.
@@ -202,6 +233,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			Status:  newStatus,
 			Message: errMsg,
 		})
+		if newStatus == model.StatusFailed {
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+		}
 		return
 	}
 
@@ -236,6 +270,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			Status:  newStatus,
 			Message: errMsg,
 		})
+		if newStatus == model.StatusFailed {
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+		}
 		return
 	}
 
@@ -275,6 +312,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 				Status:  newStatus,
 				Message: errMsg,
 			})
+			if newStatus == model.StatusFailed {
+				p.notifyTaskTerminal(task.ID, model.StatusFailed)
+			}
 			return
 		}
 		participantCount = 1

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -1,0 +1,154 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
+)
+
+// fakeNotifyDeliverer captures the SendMessage payloads so we can assert the
+// failure-reason text actually reaching the IM bot has been sanitized.
+type fakeNotifyDeliverer struct {
+	mu        sync.Mutex
+	sendCalls []notify.SendMessageRequest
+}
+
+func (f *fakeNotifyDeliverer) EnsureFriend(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (f *fakeNotifyDeliverer) SendMessage(_ context.Context, msg notify.SendMessageRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, msg)
+	return nil
+}
+
+// notifyTaskTerminal must run task.error_message through sanitizeErrorForUser
+// before it reaches the IM payload. This guards against raw internal errors
+// (DSN credentials, IPs, goroutine stack heads) being delivered to the user's
+// DM via the failure-reason line of buildText.
+//
+// Regression test for PR#113 review by Jerry-Xin (2026-06-29): the task-level
+// failure path previously fed *task.ErrorMessage straight to OnTaskTerminal,
+// so the user DM rendered raw internal errors. The personal failure path
+// already sanitized via markPersonalFailed; this brings the task path to
+// parity at the single-point intercept (notifyTaskTerminal).
+func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
+	cases := []struct {
+		name    string
+		rawErr  string
+		wantOut string // exact expected sanitized output
+		mustNot []string
+	}{
+		{
+			name:    "dsn-credentials",
+			rawErr:  "save task: dial mysql user:s3cret@tcp(10.0.0.1:3306)/summary failed",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"user:s3cret", "10.0.0.1:3306", "user:s3cret@tcp"},
+		},
+		{
+			name:    "ip-leak",
+			rawErr:  "dial tcp 192.168.1.5:8443: connect: connection refused",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"192.168.1.5", "8443"},
+		},
+		{
+			name:    "stack-trace-head",
+			rawErr:  "goroutine 17 [running]:\nmain.failPipeline(0xc0001a23c0)",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"goroutine 17 [running]", "main.failPipeline", "0xc0001a23c0"},
+		},
+		{
+			name:    "llm-api-error-mapped",
+			rawErr:  "LLM API error: status=401 body=invalid key bearer-abc123",
+			wantOut: "AI 服务暂时不可用，请稍后重试",
+			mustNot: []string{"bearer-abc123", "status=401", "invalid key"},
+		},
+		{
+			name:    "context-deadline-mapped",
+			rawErr:  "context deadline exceeded after 30s on llm.example.com:9443",
+			wantOut: "AI 处理超时，请稍后重试",
+			mustNot: []string{"llm.example.com", "9443"},
+		},
+		{
+			name:    "empty-error-message",
+			rawErr:  "",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupProcessorTestDB(t)
+			// summary_notification lives in the same summary DB; AutoMigrate so
+			// the real Notifier's claim INSERT succeeds.
+			if err := db.AutoMigrate(&model.SummaryNotification{}); err != nil {
+				t.Fatalf("automigrate notification: %v", err)
+			}
+
+			errMsg := tc.rawErr
+			task := model.SummaryTask{
+				TaskNo:            "TST-SAN-" + tc.name,
+				Title:             "今日群聊",
+				SpaceID:           "space-1",
+				CreatorID:         "user-1",
+				Status:            model.StatusFailed,
+				TriggerType:       model.TriggerManual,
+				OriginChannelType: model.OriginChannelGlobal,
+				ErrorMessage:      &errMsg,
+			}
+			if err := db.Create(&task).Error; err != nil {
+				t.Fatalf("save task: %v", err)
+			}
+
+			fake := &fakeNotifyDeliverer{}
+			n := notify.New(db, fake, notify.Config{Enabled: true, MaxAttempts: 3})
+
+			p := &Processor{db: db}
+			p.SetNotifier(n)
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+
+			if len(fake.sendCalls) != 1 {
+				t.Fatalf("expected exactly 1 SendMessage call, got %d", len(fake.sendCalls))
+			}
+			text, _ := fake.sendCalls[0].Payload["text"].(string)
+			// The failure-reason line is "失败原因：<sanitized>" — assert the
+			// sanitized whitelist mapping is what landed in the IM payload.
+			if !strings.Contains(text, tc.wantOut) {
+				t.Fatalf("expected DM text to contain sanitized %q, got %q", tc.wantOut, text)
+			}
+			for _, bad := range tc.mustNot {
+				if strings.Contains(text, bad) {
+					t.Fatalf("DM text leaked raw substring %q (full text: %q)", bad, text)
+				}
+			}
+		})
+	}
+}
+
+// notifyTaskTerminal must remain a no-op when notifier is unset (production
+// wires nil when SUMMARY_NOTIFY_ENABLED=false). Guards against the sanitize
+// change accidentally introducing a nil-deref on the disabled path.
+func TestNotifyTaskTerminal_NilNotifierIsNoop(t *testing.T) {
+	db := setupProcessorTestDB(t)
+	errMsg := "irrelevant"
+	task := model.SummaryTask{
+		TaskNo:       "TST-SAN-NIL",
+		SpaceID:      "space-1",
+		CreatorID:    "user-1",
+		Status:       model.StatusFailed,
+		ErrorMessage: &errMsg,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+	p := &Processor{db: db}
+	// p.notifier intentionally nil
+	p.notifyTaskTerminal(task.ID, model.StatusFailed) // must not panic
+}

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -78,8 +78,8 @@ func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
 		{
 			name:    "empty-error-message",
 			rawErr:  "",
-			wantOut: "AI 处理失败，请稍后重试",
-			mustNot: []string{},
+			wantOut: "", // empty errMsg → no "失败原因" line rendered (PR#113 R3 single-point sanitize)
+			mustNot: []string{"失败原因"},
 		},
 	}
 
@@ -108,7 +108,13 @@ func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
 			}
 
 			fake := &fakeNotifyDeliverer{}
-			n := notify.New(db, fake, notify.Config{Enabled: true, MaxAttempts: 3})
+			// Production wiring: cmd/summary-worker/main.go injects
+			// worker.SanitizeErrorForUser via WithErrorSanitizer so the single
+			// render-point sanitizer in notify.buildText covers both the
+			// synchronous and the sweep/redeliver paths. Mirror that wiring
+			// here so the test exercises the same behavior as production.
+			n := notify.New(db, fake, notify.Config{Enabled: true, MaxAttempts: 3}).
+				WithErrorSanitizer(SanitizeErrorForUser)
 
 			p := &Processor{db: db}
 			p.SetNotifier(n)

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/robfig/cron/v3"
@@ -21,12 +22,12 @@ var schedulerHTTPClient = &http.Client{Timeout: 5 * time.Second}
 // StartScheduler starts the 4 cron scan jobs (every 60s).
 // featureTeamSchedule, when true, lets multi-person schedules through the claim path
 // instead of disabling them (FEATURE_TEAM_SCHEDULE).
-func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int, featureTeamSchedule bool) *cron.Cron {
+func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int, featureTeamSchedule bool, notifier *notify.Notifier) *cron.Cron {
 	c := cron.New()
 
 	c.AddFunc("@every 60s", func() { scanPendingSchedules(db, imDB, maxWindowDays, featureTeamSchedule) })
 	c.AddFunc("@every 60s", func() { scanConfirmTimeouts(db) })
-	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry) })
+	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry, notifier) })
 	c.AddFunc("@every 60s", func() { scanStuckPersonalTasks(db, workerTriggerURL) })
 
 	c.Start()
@@ -339,7 +340,9 @@ func scanConfirmTimeouts(db *gorm.DB) {
 
 // scanStuckTasks resets tasks stuck in processing past their deadline.
 // Increments retry_count; if max retries exceeded, marks as Failed.
-func scanStuckTasks(db *gorm.DB, maxRetry int) {
+// notifier (optional) is fired once per task that this sweep transitions to
+// Failed, AFTER the terminal-status write has committed.
+func scanStuckTasks(db *gorm.DB, maxRetry int, notifier *notify.Notifier) {
 	now := timezone.Now()
 
 	// Reset tasks that can still retry (also handle NULL deadline for legacy data)
@@ -355,6 +358,16 @@ func scanStuckTasks(db *gorm.DB, maxRetry int) {
 		log.Printf("[scheduler] reset %d stuck tasks (retry incremented)", result.RowsAffected)
 	}
 
+	// Snapshot the IDs about to be failed so we can notify them precisely after
+	// the terminal write commits (the bulk UPDATE below cannot return the rows).
+	var toFail []int64
+	if notifier != nil {
+		db.Model(&model.SummaryTask{}).
+			Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
+				model.StatusProcessing, now, maxRetry-1).
+			Pluck("id", &toFail)
+	}
+
 	// Fail tasks that exceeded max retries (also handle NULL deadline)
 	failResult := db.Model(&model.SummaryTask{}).
 		Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
@@ -367,6 +380,26 @@ func scanStuckTasks(db *gorm.DB, maxRetry int) {
 		})
 	if failResult.RowsAffected > 0 {
 		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", failResult.RowsAffected)
+	}
+
+	// Notify the now-Failed tasks. Reload each so the notification reflects the
+	// committed terminal row; only fire for rows that are actually Failed (guards
+	// against a concurrent cancel/complete between snapshot and write).
+	if notifier != nil {
+		for _, id := range toFail {
+			var task model.SummaryTask
+			if err := db.First(&task, id).Error; err != nil {
+				continue
+			}
+			if task.Status != model.StatusFailed {
+				continue
+			}
+			errMsg := ""
+			if task.ErrorMessage != nil {
+				errMsg = *task.ErrorMessage
+			}
+			notifier.OnTaskTerminal(task, model.StatusFailed, errMsg)
+		}
 	}
 }
 

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -29,6 +30,22 @@ func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL s
 	c.AddFunc("@every 60s", func() { scanConfirmTimeouts(db) })
 	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry, notifier) })
 	c.AddFunc("@every 60s", func() { scanStuckPersonalTasks(db, workerTriggerURL) })
+	if notifier != nil {
+		// Background sweep for the notify state machine. Re-attempts rows stuck
+		// at status='failed' with retry budget remaining (the synchronous worker
+		// path is one-shot, so without this sweep MaxNotifyAttempts collapses
+		// to 1 for the common case) and reclaims rows stuck at status='pending'
+		// past their lease (worker crash mid-delivery). Both branches use atomic
+		// CAS, so they cannot double-send with a concurrent OnTaskTerminal call.
+		c.AddFunc("@every 60s", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 55*time.Second)
+			defer cancel()
+			notifier.Sweep(ctx)
+		})
+		c.Start()
+		log.Println("[scheduler] started with 5 scan jobs (every 60s)")
+		return c
+	}
 
 	c.Start()
 	log.Println("[scheduler] started with 4 scan jobs (every 60s)")
@@ -358,35 +375,44 @@ func scanStuckTasks(db *gorm.DB, maxRetry int, notifier *notify.Notifier) {
 		log.Printf("[scheduler] reset %d stuck tasks (retry incremented)", result.RowsAffected)
 	}
 
-	// Snapshot the IDs about to be failed so we can notify them precisely after
-	// the terminal write commits (the bulk UPDATE below cannot return the rows).
+	// Fail tasks that exceeded max retries. Two-step (snapshot IDs, then per-row
+	// CAS UPDATE) so we can attribute exactly which IDs *this* sweep flipped to
+	// Failed — a bulk UPDATE cannot return the rows, and a snapshot-then-bulk
+	// shape would miss any task that crossed the deadline between the snapshot
+	// and the UPDATE (review feedback P2-2: snapshot-then-update race could
+	// drop the notification for a late-crosser since on the next sweep its
+	// status is already Failed). The per-row CAS guards on the same predicates
+	// the snapshot used, so concurrent transitions are absorbed (RowsAffected==0
+	// means another worker / cancel got there first; we skip).
 	var toFail []int64
-	if notifier != nil {
-		db.Model(&model.SummaryTask{}).
-			Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
-				model.StatusProcessing, now, maxRetry-1).
-			Pluck("id", &toFail)
-	}
-
-	// Fail tasks that exceeded max retries (also handle NULL deadline)
-	failResult := db.Model(&model.SummaryTask{}).
+	db.Model(&model.SummaryTask{}).
 		Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
 			model.StatusProcessing, now, maxRetry-1).
-		Updates(map[string]interface{}{
-			"status":              model.StatusFailed,
-			"processing_deadline": nil,
-			"retry_count":         gorm.Expr("retry_count + 1"),
-			"error_message":       "exceeded max retries",
-		})
-	if failResult.RowsAffected > 0 {
-		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", failResult.RowsAffected)
+		Pluck("id", &toFail)
+
+	var failedIDs []int64
+	for _, id := range toFail {
+		res := db.Model(&model.SummaryTask{}).
+			Where("id = ? AND status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
+				id, model.StatusProcessing, now, maxRetry-1).
+			Updates(map[string]interface{}{
+				"status":              model.StatusFailed,
+				"processing_deadline": nil,
+				"retry_count":         gorm.Expr("retry_count + 1"),
+				"error_message":       "exceeded max retries",
+			})
+		if res.Error == nil && res.RowsAffected == 1 {
+			failedIDs = append(failedIDs, id)
+		}
+	}
+	if len(failedIDs) > 0 {
+		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", len(failedIDs))
 	}
 
-	// Notify the now-Failed tasks. Reload each so the notification reflects the
-	// committed terminal row; only fire for rows that are actually Failed (guards
-	// against a concurrent cancel/complete between snapshot and write).
+	// Notify exactly the tasks this sweep transitioned. Reload each so the
+	// notification reflects the committed terminal row.
 	if notifier != nil {
-		for _, id := range toFail {
+		for _, id := range failedIDs {
 			var task model.SummaryTask
 			if err := db.First(&task, id).Error; err != nil {
 				continue

--- a/migrations/sql/20260626-01-add-summary-notification.sql
+++ b/migrations/sql/20260626-01-add-summary-notification.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS `summary_notification` (
+    `id`            BIGINT       NOT NULL AUTO_INCREMENT,
+    `task_id`       BIGINT       NOT NULL,
+    `notify_kind`   VARCHAR(16)  NOT NULL COMMENT 'completed | failed',
+    `status`        VARCHAR(16)  NOT NULL DEFAULT 'pending' COMMENT 'pending | sent | failed',
+    `attempt_count` INT          NOT NULL DEFAULT 0,
+    `last_error`    VARCHAR(500)     NULL,
+    `created_at`    DATETIME     NOT NULL,
+    `updated_at`    DATETIME     NOT NULL,
+    `sent_at`       DATETIME         NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_task_kind` (`task_id`, `notify_kind`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_notification`;


### PR DESCRIPTION
## OCT-4 / octo-smart-summary 通知机制（定时任务 + 任务完成）

Closes #96（部分，配合 octo-server 侧 ensureFriend/summary-bot 支撑 PR）。

### 背景
smart-summary 此前无通知机制，用户对异步总结任务无主动反馈。本 PR 加入：定时任务跑完通知 + 按需任务完成/失败通知，经专属"总结助手"账号走 octo-server bot_api HTTP 投递。

### 改动
- **新增 `internal/notify` 包**：
  - `client.go`：`HTTPDeliverer` 先 `POST {OCTO_API_URL}/v1/bot/ensureFriend` 再 `POST .../v1/bot/sendMessage`，`Bearer SUMMARY_BOT_TOKEN`。
  - `target.go`：投递目标解析，本期一律兜底 DM 发起者（CreatorID），原群/thread 回发按 switch 预留为后续增强。
  - `notify.go`：`OnTaskTerminal(task,status,errMsg)` —— 去重状态机 + 消息拼装 + quiet window + 同行有限重试 + token 脱敏。
  - `dupkey.go`：MySQL/SQLite 通用唯一键冲突识别（抢占式插入去重）。
- **新增 migration** `20260626-01-add-summary-notification.sql`：`summary_notification` 表，`UNIQUE(task_id, notify_kind)`，状态机字段（pending/sent/failed, attempt_count, last_error, sent_at）。
- **终态触发点接入**：`personal_processor.go` / `processor.go` / `meta_processor.go` / `scheduler.go(scanStuckTasks)` 在 `UPDATE status=终态` **成功之后**调 `notify.OnTaskTerminal`；Cancelled 不发。
- **去重语义**（拍板 A）：`(task_id, completed)` 与 `(task_id, failed)` 各发一次；抢占式唯一插入挡多副本并发/worker 重试/scanStuckTasks 重置；失败同行有限重试（默认 3），绝不删记录。
- **配置**：`SUMMARY_BOT_TOKEN`（只读、不落日志）、`SUMMARY_WEB_BASE_URL`、`MAX_NOTIFY_ATTEMPTS`、quiet window（默认关，开启只抑制定时任务、不顺延）。

### 验证
- `go build ./...` 通过；`go test ./internal/notify/...` 通过（去重状态机 5 用例 × 50 轮 = 250 次全 PASS）。

> 经两位 reviewer + Leader 独立评审通过。
