### PR TITLE
feat(pipeline): fetch personal summary messages via octo-search-batch

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -7,7 +7,10 @@ All configuration is done via environment variables.
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `MYSQL_DSN` | MySQL DSN for the summary database | Yes | — |
-| `IM_MYSQL_DSN` | MySQL DSN for the IM database (read-only, message tables) | Yes | — |
+| `IM_MYSQL_DSN` | MySQL DSN for the IM database (read-only channel/member metadata) | Yes | — |
+| `MESSAGE_FETCH_BACKEND` | Message content backend: `batch` or `mysql` | No | `batch` |
+| `OCTO_SEARCH_URL` | octo-search-batch base URL for message export (without `/v1`) | Yes when `MESSAGE_FETCH_BACKEND=batch` | — |
+| `OCTO_SEARCH_TOKEN` | S2S bearer token for octo-search-batch | Yes when `MESSAGE_FETCH_BACKEND=batch` | — |
 | `OCTO_API_URL` | Authentication API base URL | Yes (API) | — |
 | `LLM_API_URL` | LLM gateway base URL (OpenAI-compatible) | Yes (Worker) | — |
 | `LLM_API_KEY` | API key for the LLM gateway | Yes (Worker) | — |

--- a/README.md
+++ b/README.md
@@ -50,10 +50,17 @@ go build ./cmd
 # minimal config via env
 export LLM_API_URL=https://api.example.com/v1
 export LLM_API_KEY=sk-your-key-here
+export MESSAGE_FETCH_BACKEND=batch
+export OCTO_SEARCH_URL=http://octo-search-batch:8080
+export OCTO_SEARCH_TOKEN=your-s2s-token
 export SUMMARY_LISTEN_ADDR=:8090
 
 ./cmd serve
 ```
+
+`OCTO_SEARCH_URL` is the octo-search-batch base URL; do not include the `/v1`
+suffix because the client appends the API path. Set `MESSAGE_FETCH_BACKEND=mysql`
+to use the legacy MySQL message-content path.
 
 Then, from another terminal:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,11 @@ type Config struct {
 	// Fetch concurrency for parallel channel message retrieval
 	FetchConcurrency int
 
+	// Message content fetch backend: "batch" or "mysql".
+	MessageFetchBackend string
+	OctoSearchURL       string
+	OctoSearchToken     string
+
 	// Channel scope narrowing
 	ChannelScopeEnabled bool
 
@@ -148,6 +153,10 @@ func Load() *Config {
 		CandidateQueryLimit: envInt("SUMMARY_CHAT_CANDIDATE_LIMIT", -1),
 
 		FetchConcurrency: envInt("FETCH_CONCURRENCY", 10),
+
+		MessageFetchBackend: strings.ToLower(strings.TrimSpace(envStr("MESSAGE_FETCH_BACKEND", "batch"))),
+		OctoSearchURL:       envStr("OCTO_SEARCH_URL", ""),
+		OctoSearchToken:     envStr("OCTO_SEARCH_TOKEN", ""),
 
 		ChannelScopeEnabled: envBool("CHANNEL_SCOPE_ENABLED", true),
 
@@ -219,16 +228,16 @@ var modelMapThresholds = []modelThreshold{
 	{"claude-opus-4-6", 350000},
 	{"claude-haiku-4-5", 200000},
 	// Qwen models
-	{"qwen3.6-max", 300000},  
-	{"qwen3.6-plus", 300000},  
-	{"qwen3.6-flash", 300000}, 
+	{"qwen3.6-max", 300000},
+	{"qwen3.6-plus", 300000},
+	{"qwen3.6-flash", 300000},
 	// DeepSeek models
-	{"deepseek-v4-flash", 300000}, 
-	{"deepseek-v4-pro", 300000},   
+	{"deepseek-v4-flash", 300000},
+	{"deepseek-v4-pro", 300000},
 	// Kimi models
 	{"kimi-k2", 150000},
 	{"kimi_k2", 150000},
-	// GLM models (智谱)
+	// GLM models
 	{"glm-5.2", 300000},
 }
 
@@ -289,7 +298,7 @@ var modelSkipThresholds = []modelThreshold{
 	{"gpt-4o", 500000},
 	{"gpt-4", 500000},
 	// Kimi models
-	{"kimi-k2", 200000}, // Kimi 上下文 265K，留余量
+	{"kimi-k2", 200000}, // Leave headroom for Kimi's 265K context.
 	{"kimi_k2", 200000},
 }
 

--- a/internal/config/config_workflow_test.go
+++ b/internal/config/config_workflow_test.go
@@ -13,9 +13,13 @@ func TestLoad_WorkflowConfigs(t *testing.T) {
 		t.Setenv("DEFAULT_TIME_RANGE_DAYS", "")
 		t.Setenv("SKIP_MAP_REDUCE_THRESHOLD", "")
 		t.Setenv("TOKENIZER_HTTP_TIMEOUT", "")
+		t.Setenv("MESSAGE_FETCH_BACKEND", "")
 
 		cfg := Load()
 
+		if cfg.MessageFetchBackend != "batch" {
+			t.Errorf("MessageFetchBackend = %q, want batch", cfg.MessageFetchBackend)
+		}
 		if cfg.EnableIntentShortcut != true {
 			t.Errorf("EnableIntentShortcut = %v, want true", cfg.EnableIntentShortcut)
 		}
@@ -40,9 +44,13 @@ func TestLoad_WorkflowConfigs(t *testing.T) {
 		t.Setenv("DEFAULT_TIME_RANGE_DAYS", "14")
 		t.Setenv("SKIP_MAP_REDUCE_THRESHOLD", "150000")
 		t.Setenv("TOKENIZER_HTTP_TIMEOUT", "20")
+		t.Setenv("MESSAGE_FETCH_BACKEND", "mysql")
 
 		cfg := Load()
 
+		if cfg.MessageFetchBackend != "mysql" {
+			t.Errorf("MessageFetchBackend = %q, want mysql", cfg.MessageFetchBackend)
+		}
 		if cfg.EnableIntentShortcut != false {
 			t.Errorf("EnableIntentShortcut = %v, want false", cfg.EnableIntentShortcut)
 		}

--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"log"
 	"sort"
 	"strings"
@@ -205,7 +206,7 @@ func getPeerUID(channelID, selfUID string) string {
 }
 
 // NormalizeDMChannelID converts a logical DM channel id (peerUID or peer@self)
-// into the storage-layer format: max(uid1,uid2)@min(uid1,uid2).
+// into the WuKongIM storage format: the UID with the larger CRC32 hash comes first.
 // For non-DM channels (channelType != 1), returns input unchanged.
 func NormalizeDMChannelID(channelID string, selfUID string, channelType int) string {
 	if channelType != 1 {
@@ -219,10 +220,10 @@ func NormalizeDMChannelID(channelID string, selfUID string, channelType int) str
 		a = channelID
 		b = selfUID
 	}
-	if a < b {
-		a, b = b, a
+	if crc32.ChecksumIEEE([]byte(a)) > crc32.ChecksumIEEE([]byte(b)) {
+		return a + "@" + b
 	}
-	return a + "@" + b
+	return b + "@" + a
 }
 
 // mapFrontendSourceType maps frontend source_type to backend channelType.
@@ -413,6 +414,81 @@ func FetchMessagesFromChannel(ctx context.Context, channelID string, channelType
 	log.Printf("[pipeline-personal] FetchMessagesFromChannel %s: %d rows fetched (maxPerChannel=%d)",
 		channelID, len(messages), maxPerChannel)
 	return messages, nil
+}
+
+func fetchMessagesByBackend(ctx context.Context, backend string, octoClient octoSearchClient, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, imDB *gorm.DB, tableCount int, maxPerChannel int, fetchConcurrency int) ([]Message, error) {
+	selected := strings.ToLower(strings.TrimSpace(backend))
+	if selected == "" {
+		selected = "batch"
+	}
+	switch selected {
+	case "batch":
+		if octoClient == nil {
+			return nil, fmt.Errorf("octo-search client is not configured")
+		}
+		return fetchViaBatch(ctx, octoClient, candidates, creatorUID, startTS, endTS, fetchConcurrency)
+	case "mysql":
+		return fetchViaMySQL(ctx, candidates, creatorUID, startTS, endTS, imDB, tableCount, maxPerChannel, fetchConcurrency)
+	default:
+		return nil, fmt.Errorf("unsupported message fetch backend %q", backend)
+	}
+}
+
+func fetchViaMySQL(ctx context.Context, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, imDB *gorm.DB, tableCount int, maxPerChannel int, fetchConcurrency int) ([]Message, error) {
+	if imDB == nil {
+		return nil, fmt.Errorf("IM database not available")
+	}
+	normIDs, infoByID := normalizeAndIndexCandidates(candidates, creatorUID)
+	if len(normIDs) == 0 {
+		return nil, nil
+	}
+	if fetchConcurrency <= 0 {
+		fetchConcurrency = octoSearchDefaultConc
+	}
+
+	var (
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+		all []Message
+		sem = make(chan struct{}, fetchConcurrency)
+	)
+	for _, id := range normIDs {
+		info := infoByID[id]
+		wg.Add(1)
+		go func(ch ChannelInfo) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+
+			msgs, err := FetchMessagesFromChannel(ctx, ch.ChannelID, ch.ChannelType, startTS, endTS, imDB, tableCount, creatorUID, maxPerChannel)
+			if err != nil {
+				log.Printf("[pipeline-personal] mysql message fetch skipped channel=%s: %v", ch.ChannelID, err)
+				return
+			}
+			for i := range msgs {
+				msgs[i].SourceName = ch.ChannelName
+				msgs[i].ChannelType = ch.ChannelType
+			}
+			mu.Lock()
+			all = append(all, msgs...)
+			mu.Unlock()
+		}(info)
+	}
+	wg.Wait()
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].ChannelID != all[j].ChannelID {
+			return all[i].ChannelID < all[j].ChannelID
+		}
+		return all[i].MessageSeq < all[j].MessageSeq
+	})
+	return all, nil
 }
 
 // IntersectParticipantChannels filters channels to only those where both
@@ -618,14 +694,14 @@ func FilterMessagesByRelevance(messages []Message, topic string, participantUIDs
 
 // ResolveAndFetchMessagesForPersonal runs the pipeline with participant-aware
 // filtering: Layer 1.5 (channel intersection) and Layer 4.5 (mutual activity).
-// 
+//
 // Intent recognition is consolidated into a single LLM call that extracts:
 // - Time range (Layer 0)
-// - Channel scope (Layer 1.7) 
+// - Channel scope (Layer 1.7)
 // - Target persons (for post-fetch filtering)
 //
 // Returns messages, intent result (for target person filtering), and error.
-func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, participantUIDs []string, participantNames []string, specifiedSources []map[string]interface{}, topic string, timeStart, timeEnd time.Time, imDB *gorm.DB, toolCallFn LLMToolCallFn, llmFn LLMCallFn, tableCount int, maxPerChannel int, fetchConcurrency int, channelScopeOpts *ChannelScopeOptions) ([]Message, *IntentResult, error) {
+func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, participantUIDs []string, participantNames []string, specifiedSources []map[string]interface{}, topic string, timeStart, timeEnd time.Time, imDB *gorm.DB, octoClient octoSearchClient, messageFetchBackend string, toolCallFn LLMToolCallFn, llmFn LLMCallFn, tableCount int, maxPerChannel int, fetchConcurrency int, channelScopeOpts *ChannelScopeOptions) ([]Message, *IntentResult, error) {
 	maxDays := DefaultTimeRangeDays
 	if timeEnd.Sub(timeStart) > time.Duration(maxDays)*24*time.Hour {
 		return nil, nil, fmt.Errorf("时间范围不能超过 %d 天", maxDays)
@@ -720,62 +796,14 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 	log.Printf("[pipeline-personal] Layer 2 (source constraints) took %dms (%d → %d candidates)",
 		time.Since(l2Start).Milliseconds(), len(userChannels), len(candidates))
 
-	// Layer 4: message fetching（并发）
+	// Layer 4: fetch message content from the configured backend.
 	fetchStart := time.Now()
-	if fetchConcurrency <= 0 {
-		fetchConcurrency = 10
+	allMessages, err := fetchMessagesByBackend(ctx, messageFetchBackend, octoClient, candidates, creatorUID, startTS, endTS, imDB, tableCount, maxPerChannel, fetchConcurrency)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch messages via %s: %w", messageFetchBackend, err)
 	}
-
-	type fetchResult struct {
-		msgs []Message
-		err  error
-		ch   ChannelInfo
-	}
-
-	resultsCh := make(chan fetchResult, len(candidates))
-	sem := make(chan struct{}, fetchConcurrency)
-	var wg sync.WaitGroup
-
-	for _, ch := range candidates {
-		wg.Add(1)
-		go func(channel ChannelInfo) {
-			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-			case <-ctx.Done():
-				resultsCh <- fetchResult{nil, ctx.Err(), channel}
-				return
-			}
-			defer func() { <-sem }()
-			msgs, err := FetchMessagesFromChannel(ctx, channel.ChannelID, channel.ChannelType, startTS, endTS, imDB, tableCount, creatorUID, maxPerChannel)
-			if err == nil {
-				for i := range msgs {
-					msgs[i].SourceName = channel.ChannelName
-					msgs[i].ChannelType = channel.ChannelType
-				}
-			}
-			resultsCh <- fetchResult{msgs, err, channel}
-		}(ch)
-	}
-	wg.Wait()
-	close(resultsCh)
-
-	var allMessages []Message
-	for r := range resultsCh {
-		if r.err != nil {
-			log.Printf("[pipeline-personal] fetch from %s error: %v", r.ch.ChannelID, r.err)
-			continue
-		}
-		allMessages = append(allMessages, r.msgs...)
-	}
-	sort.Slice(allMessages, func(i, j int) bool {
-		if allMessages[i].ChannelID != allMessages[j].ChannelID {
-			return allMessages[i].ChannelID < allMessages[j].ChannelID
-		}
-		return allMessages[i].MessageSeq < allMessages[j].MessageSeq
-	})
-	log.Printf("[pipeline-personal] Layer 4: fetched %d messages from %d channels in %dms",
-		len(allMessages), len(candidates), time.Since(fetchStart).Milliseconds())
+	log.Printf("[pipeline-personal] Layer 4 (%s): fetched %d messages from %d candidates in %dms",
+		messageFetchBackend, len(allMessages), len(candidates), time.Since(fetchStart).Milliseconds())
 
 	// Layer 4.5: mutual activity filter
 	l45Start := time.Now()

--- a/internal/pipeline/fetch_archive_test.go
+++ b/internal/pipeline/fetch_archive_test.go
@@ -5,14 +5,63 @@ package pipeline
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	sqlite3 "github.com/mattn/go-sqlite3"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// echoOctoClient returns one synthetic message per submitted channel and sender.
+// Archive tests use it to focus on channel discovery and filtering behavior.
+// senders defaults to ["user1"]; multi-person cases pass multiple senders for
+// the mutual-activity filter.
+func echoOctoClient(senders ...string) *fakeOctoClient {
+	if len(senders) == 0 {
+		senders = []string{"user1"}
+	}
+	var mu sync.Mutex
+	tasks := map[string][]string{}
+	seq := 0
+	return &fakeOctoClient{
+		submitFn: func(chs []string, _, _ int64) (string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			seq++
+			id := fmt.Sprintf("task-%d", seq)
+			tasks[id] = append([]string(nil), chs...)
+			return id, nil
+		},
+		pollFn: func(taskID string) (*service.BatchStatus, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return &service.BatchStatus{
+				Status: "completed",
+				Parts:  []service.Part{{URL: taskID, ChannelIDs: tasks[taskID]}},
+			}, nil
+		},
+		parseFn: func(parts []service.Part) ([]service.BatchMessageRow, error) {
+			var rows []service.BatchMessageRow
+			var n int64
+			for _, p := range parts {
+				for _, ch := range p.ChannelIDs {
+					for _, s := range senders {
+						n++
+						rows = append(rows, service.BatchMessageRow{
+							MessageSeq: n, FromUID: s, ChannelID: ch,
+							Timestamp: time.Now().Unix(), Payload: "hello",
+						})
+					}
+				}
+			}
+			return rows, nil
+		},
+	}
+}
 
 // archiveDriverOnce registers a sqlite3 driver variant that knows the MySQL
 // collation name (utf8mb4_unicode_ci) hardcoded into the pipeline's thread
@@ -167,7 +216,7 @@ func TestResolveAndFetch_SelectedArchivedThread_ProducesMessages(t *testing.T) {
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, specifiedSources, "",
-		start, end, db, nil, nil, 1, 0, 2, nil,
+		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -182,6 +231,34 @@ func TestResolveAndFetch_SelectedArchivedThread_ProducesMessages(t *testing.T) {
 	}
 }
 
+func TestResolveAndFetch_MySQLBackend_UsesLegacyMessageFilter(t *testing.T) {
+	db := setupPipelineImDB(t)
+	ts := time.Now().Add(-time.Hour).Unix()
+	seedPipelineThreads(db, ts)
+	db.Exec(`INSERT INTO message (message_seq, from_uid, channel_id, channel_type, timestamp, payload, is_deleted) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		4, "user1", "grp1____thB", 5, ts, []byte(`{"type":1,"content":"deleted"}`), 1)
+
+	specifiedSources := []map[string]interface{}{
+		{"source_id": "grp1____thB", "source_type": 2},
+	}
+	start := time.Now().Add(-24 * time.Hour)
+	end := time.Now().Add(time.Hour)
+
+	msgs, _, err := ResolveAndFetchMessagesForPersonal(
+		context.Background(), "user1", nil, nil, specifiedSources, "",
+		start, end, db, nil, "mysql", nil, nil, 1, 0, 2, nil,
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Content != "hello" {
+		t.Fatalf("content = %q, want hello", msgs[0].Content)
+	}
+}
+
 func TestResolveAndFetch_NoSources_ArchivedExcluded(t *testing.T) {
 	db := setupPipelineImDB(t)
 	ts := time.Now().Add(-time.Hour).Unix()
@@ -193,7 +270,7 @@ func TestResolveAndFetch_NoSources_ArchivedExcluded(t *testing.T) {
 	// No explicit sources -> auto discovery -> only the active thread's message.
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, nil, "",
-		start, end, db, nil, nil, 1, 0, 2, nil,
+		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -282,7 +359,7 @@ func seedSharedArchivedThread(db *gorm.DB, ts int64) {
 }
 
 // TestResolveAndFetch_MultiPerson_SelectedArchivedThread_Retained is the
-// regression guard for the Layer 1.5 blocker: a participant channel lookup that
+// regression guard for Layer 1.5: a participant channel lookup that
 // ignored the selected-thread scope removed the creator-side archived thread in
 // the intersect, yielding an empty summary. With the scope threaded through, the
 // shared archived thread survives and its messages are returned.
@@ -300,7 +377,7 @@ func TestResolveAndFetch_MultiPerson_SelectedArchivedThread_Retained(t *testing.
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", []string{"user2"}, nil, specifiedSources, "",
-		start, end, db, nil, nil, 1, 0, 2, nil,
+		start, end, db, echoOctoClient("user1", "user2"), "batch", nil, nil, 1, 0, 2, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)

--- a/internal/pipeline/fetch_test.go
+++ b/internal/pipeline/fetch_test.go
@@ -25,18 +25,18 @@ func TestNormalizeDMChannelID(t *testing.T) {
 			want:        "5904fca8@2c56cb",
 		},
 		{
-			name:        "already has @ reorder",
+			name:        "already has @ normalized by crc32",
 			channelID:   "a@b",
 			selfUID:     "x",
 			channelType: 1,
-			want:        "b@a",
+			want:        "a@b",
 		},
 		{
-			name:        "already correct order",
+			name:        "already has @ reordered by crc32",
 			channelID:   "b@a",
 			selfUID:     "x",
 			channelType: 1,
-			want:        "b@a",
+			want:        "a@b",
 		},
 		{
 			name:        "non-DM unchanged",

--- a/internal/pipeline/octo_search_fetch.go
+++ b/internal/pipeline/octo_search_fetch.go
@@ -1,0 +1,394 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+)
+
+// octo_search_fetch.go implements the Layer 4 octo-search-batch data source.
+//
+// Pure helpers handle normalization, deduplication, reverse lookup maps,
+// <=30-channel batching, and 413 bisection. fetchViaBatch orchestrates submit,
+// poll, download, parse, 413 splitting/window shrinking, abort handling,
+// and per-batch failure isolation. service.OctoSearchBatchClient stays
+// stateless; polling and split policy live here.
+
+// octoSearchBatchSize is the maximum channel count for one batch task.
+const octoSearchBatchSize = 30
+
+const (
+	octoSearchPollInterval = 5 * time.Second  // API-recommended polling interval.
+	octoSearchTotalBudget  = 20 * time.Minute // Total client-side budget; upstream ctx has no deadline.
+	octoSearchDefaultConc  = 10               // Default concurrency, matching existing fetchConcurrency.
+	octoSearchMinWindowSec = int64(6 * 3600)  // Minimum single-channel split window before skipping.
+	octoSearchDeleteBudget = 5 * time.Second  // Independent timeout for best-effort Delete.
+)
+
+// normalizeAndIndexCandidates normalizes candidate channel IDs to the storage
+// form used by the octo-search indexer and builds a normalized-ID -> ChannelInfo
+// reverse lookup for SourceName / ChannelType backfill after batch export.
+//
+// The old MySQL helper performed this normalization internally. After switching
+// Layer 4 to batch, it must happen before Submit; otherwise DM IDs can miss the
+// indexed key and return empty results. Duplicate normalized IDs keep the first
+// candidate, empty IDs are skipped, and ChannelInfo.ChannelID is overwritten
+// with the normalized ID to avoid later use of the original form.
+func normalizeAndIndexCandidates(candidates []ChannelInfo, creatorUID string) ([]string, map[string]ChannelInfo) {
+	ids := make([]string, 0, len(candidates))
+	byID := make(map[string]ChannelInfo, len(candidates))
+	for _, ch := range candidates {
+		if ch.ChannelID == "" {
+			continue
+		}
+		norm := NormalizeDMChannelID(ch.ChannelID, creatorUID, ch.ChannelType)
+		if norm == "" {
+			continue
+		}
+		if _, seen := byID[norm]; seen {
+			continue
+		}
+		ch.ChannelID = norm // Store only the normalized ID in the reverse map.
+		byID[norm] = ch
+		ids = append(ids, norm)
+	}
+	return ids, byID
+}
+
+// chunkChannelIDs splits normalized channel IDs into batches of at most size.
+// Invalid sizes are clamped to the API limit to avoid oversized submissions.
+func chunkChannelIDs(ids []string, size int) [][]string {
+	if size <= 0 || size > octoSearchBatchSize {
+		size = octoSearchBatchSize
+	}
+	var batches [][]string
+	for i := 0; i < len(ids); i += size {
+		end := i + size
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batches = append(batches, ids[i:end])
+	}
+	return batches
+}
+
+// splitBatch bisects a channel batch after Submit returns 413.
+//
+// splittable=false means the caller cannot split by channel any further and
+// should switch to time-window shrinking or failure handling. Empty input never
+// produces an empty batch.
+func splitBatch(chs []string) (parts [][]string, splittable bool) {
+	switch {
+	case len(chs) == 0:
+		return nil, false
+	case len(chs) == 1:
+		return [][]string{chs}, false
+	default:
+		mid := len(chs) / 2
+		return [][]string{chs[:mid], chs[mid:]}, true
+	}
+}
+
+// octoSearchClient is the minimal dependency needed by fetchViaBatch. The
+// concrete *service.OctoSearchBatchClient satisfies it. Keeping an interface
+// here lets tests exercise orchestration without a real HTTP server.
+type octoSearchClient interface {
+	Submit(ctx context.Context, channelIDs []string, startTS, endTS int64) (string, error)
+	Poll(ctx context.Context, taskID string) (*service.BatchStatus, error)
+	Delete(ctx context.Context, taskID string) error
+	DownloadAndParse(ctx context.Context, parts []service.Part) ([]service.BatchMessageRow, error)
+}
+
+// fetchViaBatch replaces Layer 4 per-channel MySQL reads with the async
+// octo-search-batch API. The returned []Message keeps the same shape expected by
+// the upper pipeline.
+//
+// fetchConcurrency preserves the existing configurable concurrency behavior.
+// This function creates the total timeout because the upstream context has no
+// deadline.
+func fetchViaBatch(ctx context.Context, client octoSearchClient, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, fetchConcurrency int) ([]Message, error) {
+	if len(candidates) == 0 {
+		return nil, nil // Do not submit an empty channel list.
+	}
+	normIDs, infoByID := normalizeAndIndexCandidates(candidates, creatorUID)
+	if len(normIDs) == 0 {
+		return nil, nil
+	}
+	batches := chunkChannelIDs(normIDs, octoSearchBatchSize)
+
+	if fetchConcurrency <= 0 {
+		fetchConcurrency = octoSearchDefaultConc
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, octoSearchTotalBudget)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		all      []Message
+		fatalErr error
+		wg       sync.WaitGroup
+		sem      = make(chan struct{}, fetchConcurrency)
+	)
+
+	for _, batch := range batches {
+		mu.Lock()
+		stop := fatalErr != nil
+		mu.Unlock()
+		if stop {
+			break // Stop scheduling new batches after an aborting error.
+		}
+		wg.Add(1)
+		go func(chs []string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+
+			msgs, err := runBatchWithSplit(ctx, client, chs, startTS, endTS, infoByID)
+			if err != nil {
+				if isFatalBatchErr(err) {
+					// Aborting errors stop the whole fetch.
+					mu.Lock()
+					if fatalErr == nil {
+						fatalErr = err
+					}
+					mu.Unlock()
+					cancel()
+					return
+				}
+				// Isolatable errors skip only this batch.
+				log.Printf("[pipeline-personal] octo-search batch (%d channels) isolated after failure: %v", len(chs), err)
+				return
+			}
+			mu.Lock()
+			all = append(all, msgs...)
+			mu.Unlock()
+		}(batch)
+	}
+	wg.Wait()
+
+	if fatalErr != nil {
+		return nil, fatalErr
+	}
+	// If the total budget expires or upstream cancels before a goroutine reports
+	// an aborting error, still propagate ctx.Err(); otherwise a semaphore wait can
+	// exit early and make a partial result look successful.
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Keep Layer 4 ordering: (channel_id, message_seq) ascending.
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].ChannelID != all[j].ChannelID {
+			return all[i].ChannelID < all[j].ChannelID
+		}
+		return all[i].MessageSeq < all[j].MessageSeq
+	})
+	return all, nil
+}
+
+// isFatalBatchErr reports errors that abort the whole fetch rather than
+// being isolated to a single batch. Context cancellation/deadline and client
+// contract/config errors are returned instead of becoming partial success.
+func isFatalBatchErr(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, service.ErrFatalClient) ||
+		errors.Is(err, service.ErrUnauthorized) ||
+		errors.Is(err, service.ErrBadRequest) ||
+		errors.Is(err, service.ErrTaskNotFound) ||
+		errors.Is(err, service.ErrTimeRangeTooLong)
+}
+
+// runBatchWithSplit submits one batch. On 413 it first bisects by channel; when
+// a single channel is still too large, it switches to time-window splitting.
+// Other errors are returned for the caller to classify.
+func runBatchWithSplit(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
+	msgs, err := runOneBatch(ctx, client, chs, startTS, endTS, infoByID)
+	if err == nil {
+		return msgs, nil
+	}
+	if !errors.Is(err, service.ErrSingleTaskTooLarge) {
+		return nil, err
+	}
+
+	// For 413, split by channel first.
+	parts, splittable := splitBatch(chs)
+	if splittable {
+		var out []Message
+		for _, p := range parts {
+			sub, subErr := runBatchWithSplit(ctx, client, p, startTS, endTS, infoByID)
+			if subErr != nil {
+				if isFatalBatchErr(subErr) {
+					return nil, subErr
+				}
+				// Isolate this sub-batch and keep successful siblings.
+				log.Printf("[pipeline-personal] octo-search sub-batch (%d channels) isolated after split: %v", len(p), subErr)
+				continue
+			}
+			out = append(out, sub...)
+		}
+		return out, nil
+	}
+
+	// A single channel is still too large; shrink the time window.
+	return runWithTimeWindowSplit(ctx, client, chs, startTS, endTS, infoByID)
+}
+
+// runWithTimeWindowSplit bisects the time window for a single channel after
+// 413. If the minimum window is still too large, the channel is skipped instead
+// of retrying forever.
+func runWithTimeWindowSplit(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
+	if endTS-startTS <= octoSearchMinWindowSec {
+		log.Printf("[pipeline-personal] octo-search: channel %v still 413 at min window (%ds), skipping", chs, endTS-startTS)
+		return nil, nil
+	}
+	mid := startTS + (endTS-startTS)/2
+	var out []Message
+	// Recurse on both halves; aborting errors stop the fetch, isolatable errors skip only
+	// that half.
+	for _, w := range [2][2]int64{{startTS, mid}, {mid + 1, endTS}} {
+		sub, err := runBatchWithSplit(ctx, client, chs, w[0], w[1], infoByID)
+		if err != nil {
+			if isFatalBatchErr(err) {
+				return nil, err
+			}
+			log.Printf("[pipeline-personal] octo-search time-window [%d,%d] for %v isolated: %v", w[0], w[1], chs, err)
+			continue
+		}
+		out = append(out, sub...)
+	}
+	return out, nil
+}
+
+// runOneBatch submits one batch, polls to a terminal status, downloads rows,
+// then maps rows back to pipeline messages.
+func runOneBatch(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
+	taskID, err := client.Submit(ctx, chs, startTS, endTS)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := pollUntilTerminal(ctx, client, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch status.Status {
+	case "completed", "partial":
+		if status.Status == "partial" {
+			for _, w := range status.Warnings {
+				log.Printf("[pipeline-personal] octo-search partial truncation: channel=%s code=%s limit=%d seen=%d",
+					w.ChannelID, w.Code, w.Limit, w.ActualSeen)
+			}
+		}
+		if err := validateBatchStatusParts(status, chs); err != nil {
+			return nil, err
+		}
+		rows, err := client.DownloadAndParse(ctx, status.Parts)
+		if err != nil {
+			return nil, err
+		}
+		return rowsToMessages(rows, infoByID)
+	case "failed":
+		return nil, fmt.Errorf("octo-search task %s failed: %s %s", taskID, status.ErrorCode, status.ErrorMsg)
+	case "cancelled":
+		return nil, fmt.Errorf("octo-search task %s cancelled", taskID)
+	default:
+		return nil, fmt.Errorf("octo-search task %s unexpected terminal status %q", taskID, status.Status)
+	}
+}
+
+func validateBatchStatusParts(status *service.BatchStatus, chs []string) error {
+	if status.ActualCount > 0 && len(status.Parts) == 0 {
+		return fmt.Errorf("octo-search status actual_count=%d but no parts", status.ActualCount)
+	}
+	allowed := make(map[string]struct{}, len(chs))
+	for _, ch := range chs {
+		allowed[ch] = struct{}{}
+	}
+	for _, part := range status.Parts {
+		for _, ch := range part.ChannelIDs {
+			if _, ok := allowed[ch]; !ok {
+				return fmt.Errorf("octo-search part contains unexpected channel_id %q", ch)
+			}
+		}
+	}
+	return nil
+}
+
+// pollUntilTerminal polls at a fixed interval until a terminal status. On
+// cancellation or poll error it attempts best-effort Delete.
+func pollUntilTerminal(ctx context.Context, client octoSearchClient, taskID string) (*service.BatchStatus, error) {
+	ticker := time.NewTicker(octoSearchPollInterval)
+	defer ticker.Stop()
+	for {
+		status, err := client.Poll(ctx, taskID)
+		if err != nil {
+			// Submit already succeeded, so clean up the queued/running task on
+			// both context and non-context poll errors.
+			bestEffortDelete(client, taskID)
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return nil, err
+		}
+		if status.IsTerminal() {
+			return status, nil
+		}
+		select {
+		case <-ctx.Done():
+			bestEffortDelete(client, taskID)
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// bestEffortDelete uses an independent short timeout because the caller's
+// context may already be cancelled.
+func bestEffortDelete(client octoSearchClient, taskID string) {
+	dctx, cancel := context.WithTimeout(context.Background(), octoSearchDeleteBudget)
+	defer cancel()
+	if err := client.Delete(dctx, taskID); err != nil {
+		log.Printf("[pipeline-personal] octo-search best-effort delete %s failed: %v", taskID, err)
+	}
+}
+
+// rowsToMessages maps batch rows into pipeline.Message. Payload is already plain
+// text from octo-search-batch, so no ExtractText pass is needed. Empty payload
+// rows are skipped, matching the old path where ExtractText returned !ok.
+func rowsToMessages(rows []service.BatchMessageRow, infoByID map[string]ChannelInfo) ([]Message, error) {
+	msgs := make([]Message, 0, len(rows))
+	for _, r := range rows {
+		info, ok := infoByID[r.ChannelID]
+		if !ok {
+			return nil, fmt.Errorf("octo-search row contains unexpected channel_id %q", r.ChannelID)
+		}
+		if r.Payload == "" {
+			continue
+		}
+		m := Message{
+			MessageSeq: r.MessageSeq,
+			SenderUID:  r.FromUID,
+			ChannelID:  r.ChannelID,
+			Timestamp:  r.Timestamp,
+			SendTime:   time.Unix(r.Timestamp, 0).Format(time.RFC3339),
+			Content:    r.Payload,
+		}
+		m.SourceName = info.ChannelName
+		m.ChannelType = info.ChannelType
+		msgs = append(msgs, m)
+	}
+	return msgs, nil
+}

--- a/internal/pipeline/octo_search_fetch_test.go
+++ b/internal/pipeline/octo_search_fetch_test.go
@@ -1,0 +1,427 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+)
+
+func TestChunkChannelIDs(t *testing.T) {
+	mkIDs := func(n int) []string {
+		ids := make([]string, n)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("g%d", i)
+		}
+		return ids
+	}
+	cases := []struct {
+		name        string
+		n           int
+		size        int
+		wantBatches int
+	}{
+		{"empty", 0, 30, 0},
+		{"one", 1, 30, 1},
+		{"exactly 30", 30, 30, 1},
+		{"31 -> 2 batches", 31, 30, 2},
+		{"65 -> 3 batches", 65, 30, 3},
+		{"size<=0 falls back to 30", 31, 0, 2},
+		{"size>30 clamped to 30", 31, 100, 2}, // Oversized input must still be clamped.
+		{"size>30 clamped, 60", 60, 50, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ids := mkIDs(c.n)
+			batches := chunkChannelIDs(ids, c.size)
+			if len(batches) != c.wantBatches {
+				t.Fatalf("got %d batches, want %d", len(batches), c.wantBatches)
+			}
+			total := 0
+			for _, b := range batches {
+				if len(b) > octoSearchBatchSize {
+					t.Fatalf("batch size %d exceeds %d (clamp failed)", len(b), octoSearchBatchSize)
+				}
+				total += len(b)
+			}
+			if total != c.n {
+				t.Fatalf("total channels %d, want %d (lost or duplicated)", total, c.n)
+			}
+		})
+	}
+}
+
+func TestNormalizeAndIndexCandidates_DedupAndBackfillMap(t *testing.T) {
+	// Group channels are not changed by NormalizeDMChannelID.
+	candidates := []ChannelInfo{
+		{ChannelID: "g100", ChannelType: 2, ChannelName: "群A"},
+		{ChannelID: "g200", ChannelType: 2, ChannelName: "群B"},
+		{ChannelID: "g100", ChannelType: 2, ChannelName: "群A-dup"},
+		{ChannelID: "", ChannelType: 2, ChannelName: "空"},
+	}
+	ids, byID := normalizeAndIndexCandidates(candidates, "self-uid")
+
+	if len(ids) != 2 {
+		t.Fatalf("got %d unique ids, want 2 (dedup/empty-skip failed): %v", len(ids), ids)
+	}
+	if len(byID) != 2 {
+		t.Fatalf("reverse map size %d, want 2", len(byID))
+	}
+	if info, ok := byID["g100"]; !ok || info.ChannelName != "群A" {
+		t.Fatalf("byID[g100] = %+v, want first-seen 群A", info)
+	}
+	if byID["g100"].ChannelName == "群A-dup" {
+		t.Fatal("dedup should keep first occurrence, not the later duplicate")
+	}
+	// The reverse-map value should store the normalized ID.
+	if byID["g100"].ChannelID != "g100" {
+		t.Fatalf("map ChannelID = %q, want normalized id g100", byID["g100"].ChannelID)
+	}
+}
+
+func TestNormalizeAndIndexCandidates_DMNormalizationDedup(t *testing.T) {
+	// All three DM forms should normalize to the same storage ID.
+	// - "bob"        : peer UID, combined with self
+	// - "alice@bob"  : reversed input order
+	// - "bob@alice"  : already normalized for this pair
+	candidates := []ChannelInfo{
+		{ChannelID: "bob", ChannelType: 1, ChannelName: "DM-bob-1"},
+		{ChannelID: "alice@bob", ChannelType: 1, ChannelName: "DM-bob-2"},
+		{ChannelID: "bob@alice", ChannelType: 1, ChannelName: "DM-bob-3"},
+	}
+	ids, byID := normalizeAndIndexCandidates(candidates, "alice")
+
+	if len(ids) != 1 {
+		t.Fatalf("3 DM forms of same peer should dedup to 1, got %d: %v", len(ids), ids)
+	}
+	if ids[0] != "bob@alice" {
+		t.Fatalf("normalized id = %q, want bob@alice", ids[0])
+	}
+	if info := byID["bob@alice"]; info.ChannelName != "DM-bob-1" {
+		t.Fatalf("dedup should keep first form, got %q", info.ChannelName)
+	}
+}
+
+func TestSplitBatch(t *testing.T) {
+	// Multiple channels are bisected without losing entries.
+	got, splittable := splitBatch([]string{"a", "b", "c", "d", "e"})
+	if !splittable {
+		t.Fatal("multi-element batch should be splittable")
+	}
+	if len(got) != 2 || len(got[0])+len(got[1]) != 5 {
+		t.Fatalf("split lost channels: %v", got)
+	}
+	if len(got[0]) != 2 || len(got[1]) != 3 {
+		t.Fatalf("split halves = %d/%d, want 2/3", len(got[0]), len(got[1]))
+	}
+	// A single channel cannot be split further by channel.
+	if parts, ok := splitBatch([]string{"solo"}); ok || len(parts) != 1 || len(parts[0]) != 1 {
+		t.Fatalf("single channel: got parts=%v splittable=%v, want [[solo]] false", parts, ok)
+	}
+	// Empty input must not produce an empty batch.
+	if parts, ok := splitBatch(nil); parts != nil || ok {
+		t.Fatalf("nil input: got parts=%v splittable=%v, want nil false", parts, ok)
+	}
+}
+
+// fetchViaBatch orchestration tests use a fake client instead of HTTP.
+
+type fakeOctoClient struct {
+	submitFn func(chs []string, startTS, endTS int64) (string, error)
+	pollFn   func(taskID string) (*service.BatchStatus, error)
+	parseFn  func(parts []service.Part) ([]service.BatchMessageRow, error)
+	deleted  []string
+}
+
+func (f *fakeOctoClient) Submit(_ context.Context, chs []string, s, e int64) (string, error) {
+	return f.submitFn(chs, s, e)
+}
+func (f *fakeOctoClient) Poll(_ context.Context, taskID string) (*service.BatchStatus, error) {
+	return f.pollFn(taskID)
+}
+func (f *fakeOctoClient) Delete(_ context.Context, taskID string) error {
+	f.deleted = append(f.deleted, taskID)
+	return nil
+}
+func (f *fakeOctoClient) DownloadAndParse(_ context.Context, parts []service.Part) ([]service.BatchMessageRow, error) {
+	return f.parseFn(parts)
+}
+
+// completedWithChannel echoes taskID as the part channel to help parseFn emit
+// matching rows.
+func completedWithChannel(taskID string) (*service.BatchStatus, error) {
+	return &service.BatchStatus{
+		Status: "completed",
+		Parts:  []service.Part{{URL: "u", ChannelIDs: []string{taskID}}},
+	}, nil
+}
+
+func TestFetchViaBatch_HappyPathMappingAndBackfill(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func(chs []string, _, _ int64) (string, error) { return chs[0], nil },
+		pollFn:   func(taskID string) (*service.BatchStatus, error) { return completedWithChannel(taskID) },
+		parseFn: func(parts []service.Part) ([]service.BatchMessageRow, error) {
+			ch := parts[0].ChannelIDs[0]
+			return []service.BatchMessageRow{
+				{MessageSeq: 2, FromUID: "u2", ChannelID: ch, Timestamp: 1000, Payload: "world"},
+				{MessageSeq: 1, FromUID: "u1", ChannelID: ch, Timestamp: 900, Payload: "hello"},
+				{MessageSeq: 3, FromUID: "u3", ChannelID: ch, Timestamp: 1100, Payload: ""}, // Empty payload should be skipped.
+			}, nil
+		},
+	}
+	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2, ChannelName: "群一"}}
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2 (empty payload should be skipped)", len(msgs))
+	}
+	// Sort by (channel_id, message_seq) ascending.
+	if msgs[0].MessageSeq != 1 || msgs[1].MessageSeq != 2 {
+		t.Fatalf("not sorted by message_seq: %d,%d", msgs[0].MessageSeq, msgs[1].MessageSeq)
+	}
+	// Field mapping and reverse-map backfill.
+	m := msgs[0]
+	if m.SenderUID != "u1" || m.Content != "hello" || m.SourceName != "群一" || m.ChannelType != 2 {
+		t.Fatalf("mapping/backfill wrong: %+v", m)
+	}
+	if m.SendTime == "" {
+		t.Fatal("SendTime should be formatted from Timestamp")
+	}
+}
+
+func TestRunOneBatch_RejectsUnexpectedRowChannel(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) { return "task-1", nil },
+		pollFn: func(string) (*service.BatchStatus, error) {
+			return &service.BatchStatus{
+				Status: "completed",
+				Parts:  []service.Part{{URL: "u", ChannelIDs: []string{"g1"}}},
+			}, nil
+		},
+		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) {
+			return []service.BatchMessageRow{{MessageSeq: 1, ChannelID: "evil", Timestamp: 1, Payload: "bad"}}, nil
+		},
+	}
+	_, err := runOneBatch(context.Background(), fc, []string{"g1"}, 0, 100, map[string]ChannelInfo{
+		"g1": {ChannelID: "g1", ChannelType: 2},
+	})
+	if err == nil {
+		t.Fatal("unexpected row channel must fail the batch")
+	}
+}
+
+func TestRunOneBatch_RejectsUnexpectedPartChannel(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) { return "task-1", nil },
+		pollFn: func(string) (*service.BatchStatus, error) {
+			return &service.BatchStatus{
+				Status: "completed",
+				Parts:  []service.Part{{URL: "u", ChannelIDs: []string{"g1", "evil"}}},
+			}, nil
+		},
+		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) {
+			t.Fatal("should not download parts with unexpected channel ids")
+			return nil, nil
+		},
+	}
+	_, err := runOneBatch(context.Background(), fc, []string{"g1"}, 0, 100, map[string]ChannelInfo{
+		"g1": {ChannelID: "g1", ChannelType: 2},
+	})
+	if err == nil {
+		t.Fatal("unexpected part channel must fail the batch")
+	}
+}
+
+func TestRunOneBatch_RejectsPositiveCountWithoutParts(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) { return "task-1", nil },
+		pollFn: func(string) (*service.BatchStatus, error) {
+			return &service.BatchStatus{Status: "completed", ActualCount: 1}, nil
+		},
+		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) {
+			t.Fatal("should not parse empty parts when actual_count is positive")
+			return nil, nil
+		},
+	}
+	_, err := runOneBatch(context.Background(), fc, []string{"g1"}, 0, 100, map[string]ChannelInfo{
+		"g1": {ChannelID: "g1", ChannelType: 2},
+	})
+	if err == nil {
+		t.Fatal("positive actual_count without parts must fail the batch")
+	}
+}
+
+func TestFetchViaBatch_FatalErrorAborts(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) { return "", service.ErrUnauthorized },
+		pollFn:   func(string) (*service.BatchStatus, error) { return nil, nil },
+		parseFn:  func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
+	}
+	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
+	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if !errors.Is(err, service.ErrUnauthorized) {
+		t.Fatalf("401 must abort whole fetch, got err=%v", err)
+	}
+}
+
+func TestFetchViaBatch_IsolatableSkipsBadBatchKeepsRest(t *testing.T) {
+	// 31 channels become [30, 1]; the large batch is isolated, the small one succeeds.
+	fc := &fakeOctoClient{
+		submitFn: func(chs []string, _, _ int64) (string, error) {
+			if len(chs) == 1 {
+				return chs[0], nil
+			}
+			return "", errors.New("server error 503: exhausted") // Non-typed error is isolatable.
+		},
+		pollFn: func(taskID string) (*service.BatchStatus, error) { return completedWithChannel(taskID) },
+		parseFn: func(parts []service.Part) ([]service.BatchMessageRow, error) {
+			ch := parts[0].ChannelIDs[0]
+			return []service.BatchMessageRow{{MessageSeq: 1, ChannelID: ch, Timestamp: 1, Payload: "ok"}}, nil
+		},
+	}
+	candidates := make([]ChannelInfo, 31)
+	for i := range candidates {
+		candidates[i] = ChannelInfo{ChannelID: fmt.Sprintf("g%02d", i), ChannelType: 2}
+	}
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if err != nil {
+		t.Fatalf("isolatable failure must NOT abort, got err=%v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("bad batch isolated, good batch kept → want 1 message, got %d", len(msgs))
+	}
+}
+
+func TestFetchViaBatch_413SplitsByChannel(t *testing.T) {
+	// 2 channels -> 413 -> split into single-channel batches -> both succeed.
+	fc := &fakeOctoClient{
+		submitFn: func(chs []string, _, _ int64) (string, error) {
+			if len(chs) >= 2 {
+				return "", service.ErrSingleTaskTooLarge
+			}
+			return chs[0], nil
+		},
+		pollFn: func(taskID string) (*service.BatchStatus, error) { return completedWithChannel(taskID) },
+		parseFn: func(parts []service.Part) ([]service.BatchMessageRow, error) {
+			ch := parts[0].ChannelIDs[0]
+			return []service.BatchMessageRow{{MessageSeq: 1, ChannelID: ch, Timestamp: 1, Payload: "x"}}, nil
+		},
+	}
+	candidates := []ChannelInfo{
+		{ChannelID: "c1", ChannelType: 2},
+		{ChannelID: "c2", ChannelType: 2},
+	}
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if err != nil {
+		t.Fatalf("413 should split, not fail: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("413 split should yield 2 messages (one per channel), got %d", len(msgs))
+	}
+}
+
+func TestFetchViaBatch_EmptyCandidates(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) {
+			t.Fatal("should not submit on empty candidates")
+			return "", nil
+		},
+		pollFn:  func(string) (*service.BatchStatus, error) { return nil, nil },
+		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
+	}
+	msgs, err := fetchViaBatch(context.Background(), fc, nil, "self", 0, 100000, 4)
+	if err != nil || msgs != nil {
+		t.Fatalf("empty candidates → (nil,nil), got msgs=%v err=%v", msgs, err)
+	}
+}
+
+// A non-context Poll error happens after Submit succeeded, so Delete must run.
+func TestFetchViaBatch_PollErrorTriggersDelete(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) { return "task-leak-check", nil },
+		pollFn:   func(string) (*service.BatchStatus, error) { return nil, errors.New("network boom") }, // Non-context error.
+		parseFn:  func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
+	}
+	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
+	// Plain errors are isolatable, but the submitted task must still be deleted.
+	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if err != nil {
+		t.Fatalf("plain poll error should be isolatable (nil err), got %v", err)
+	}
+	if len(fc.deleted) != 1 || fc.deleted[0] != "task-leak-check" {
+		t.Fatalf("Poll error must trigger best-effort Delete, deleted=%v", fc.deleted)
+	}
+}
+
+// One failed leaf must not discard successful sibling data.
+func TestFetchViaBatch_413SplitKeepsSuccessfulSiblingOnIsolatableFailure(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func(chs []string, _, _ int64) (string, error) {
+			if len(chs) >= 2 {
+				return "", service.ErrSingleTaskTooLarge // Whole batch 413 -> split into [c1] and [c2].
+			}
+			if chs[0] == "c2" {
+				return "", errors.New("server error 503: exhausted") // Isolatable non-sentinel error.
+			}
+			return chs[0], nil // c1 succeeds.
+		},
+		pollFn: func(taskID string) (*service.BatchStatus, error) { return completedWithChannel(taskID) },
+		parseFn: func(parts []service.Part) ([]service.BatchMessageRow, error) {
+			ch := parts[0].ChannelIDs[0]
+			return []service.BatchMessageRow{{MessageSeq: 1, ChannelID: ch, Timestamp: 1, Payload: "kept"}}, nil
+		},
+	}
+	candidates := []ChannelInfo{
+		{ChannelID: "c1", ChannelType: 2},
+		{ChannelID: "c2", ChannelType: 2},
+	}
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if err != nil {
+		t.Fatalf("isolatable sibling failure must NOT fail the whole batch: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].ChannelID != "c1" || msgs[0].Content != "kept" {
+		t.Fatalf("successful sibling c1 must be kept, got %+v", msgs)
+	}
+}
+
+// Unknown 4xx errors are wrapped as service.ErrFatalClient and must abort the
+// whole fetch instead of being isolated.
+func TestFetchViaBatch_UnknownClientErrorAborts(t *testing.T) {
+	fc := &fakeOctoClient{
+		submitFn: func([]string, int64, int64) (string, error) {
+			return "", fmt.Errorf("%w (Submit: unexpected status 403)", service.ErrFatalClient)
+		},
+		pollFn:  func(string) (*service.BatchStatus, error) { return nil, nil },
+		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
+	}
+	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
+	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	if !errors.Is(err, service.ErrFatalClient) {
+		t.Fatalf("unknown 4xx must abort whole fetch, got err=%v", err)
+	}
+}
+
+// Context cancellation/deadline must propagate instead of becoming partial
+// success.
+func TestFetchViaBatch_ContextDeadlinePropagates(t *testing.T) {
+	fc := &fakeOctoClient{
+		// Simulate a stuck Submit that returns only after the context is done.
+		submitFn: func([]string, int64, int64) (string, error) {
+			return "", context.DeadlineExceeded
+		},
+		pollFn:  func(string) (*service.BatchStatus, error) { return nil, nil },
+		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
+	}
+	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := fetchViaBatch(ctx, fc, candidates, "self", 0, 100000, 4)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ctx deadline must propagate (not be swallowed as isolatable), got err=%v", err)
+	}
+}

--- a/internal/service/octo_search.go
+++ b/internal/service/octo_search.go
@@ -1,0 +1,522 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// OctoSearchBatchClient is a stateless HTTP client for the octo-search Batch
+// Messages API (api-spec v0.1). It exposes single atomic operations
+// (Submit / Poll / Delete / DownloadAndParse); the polling loop, 413 split
+// retry and ndjson row -> Message mapping are orchestrated by the caller
+// (pipeline.fetchViaBatch). The client never imports the pipeline package.
+type OctoSearchBatchClient struct {
+	baseURL string // root address WITHOUT /v1 suffix (see plan §5.4)
+	token   string // s2s bearer token, never logged
+	http    *http.Client
+}
+
+// NewOctoSearchBatchClient creates a client.
+//
+// baseURL should be the root address without the /v1 suffix
+// (e.g. "http://octo-search-batch:8080"); the client appends
+// "/v1/messages/batch" itself. A trailing slash is trimmed defensively.
+func NewOctoSearchBatchClient(baseURL, token string) *OctoSearchBatchClient {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+	return &OctoSearchBatchClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		// No client-wide Timeout: per-request deadlines come from ctx, while the
+		// transport timeout prevents a peer from accepting a connection and never
+		// sending response headers.
+		http: &http.Client{Transport: transport},
+	}
+}
+
+// ── Typed errors (contract point 1) ────────────────────────────────────────
+// 4xx are surfaced as identifiable sentinels so fetchViaBatch can branch:
+//   - ErrSingleTaskTooLarge (413) -> caller bisects the batch / shrinks window
+//   - ErrUnauthorized (401) / ErrBadRequest (400) -> caller fails fast
+//     & alert (config/contract problem, NOT isolated as a per-batch skip)
+//   - ErrTaskNotFound (404) / ErrTimeRangeTooLong (422) -> caller fail-fast
+//
+// 5xx (500/503) are NOT given sentinels: the client retries them internally
+// with backoff (<=3 times, 503 spaced >=10s). Only after retries are
+// exhausted does it return a plain (wrapped) error, which the caller treats
+// as an isolatable per-batch failure (continue).
+var (
+	ErrSingleTaskTooLarge = errors.New("octo-search: single task too large (413)")
+	ErrBadRequest         = errors.New("octo-search: invalid request (400)")
+	ErrUnauthorized       = errors.New("octo-search: unauthorized (401)")
+	ErrTaskNotFound       = errors.New("octo-search: task not found (404)")
+	ErrTimeRangeTooLong   = errors.New("octo-search: time range too long (422)")
+	// ErrFatalClient wraps any *other* 4xx (403/409/429/...) that has no
+	// dedicated sentinel. The caller fails fast rather than
+	// isolating the batch, because a misconfig/permission/rate-limit
+	// problem causes silent partial data). See classifyHTTPError default case.
+	ErrFatalClient = errors.New("octo-search: fatal client error (4xx)")
+)
+
+// ── DTOs ───────────────────────────────────────────────────────────────────
+
+// BatchMessageRow is one raw ndjson row (api-spec §5.1). Field names mirror the
+// message export schema. Payload is already parsed plain text produced by
+// octo-search-batch, not the original IM JSON payload. The client only produces
+// raw rows; from_uid->SenderUID, SourceName/ChannelType backfill and SendTime
+// formatting are the caller's job (it holds the reverse-lookup map).
+type BatchMessageRow struct {
+	MessageSeq int64  `json:"message_seq"`
+	FromUID    string `json:"from_uid"`
+	ChannelID  string `json:"channel_id"`
+	Timestamp  int64  `json:"timestamp"`
+	Payload    string `json:"payload"`
+}
+
+// BatchStatus is the GET /v1/messages/batch/{task_id} response (api-spec §3.2).
+type BatchStatus struct {
+	Status      string    `json:"status"` // queued/running/completed/partial/failed/cancelled
+	ActualCount int64     `json:"actual_count"`
+	Parts       []Part    `json:"parts"`
+	Warnings    []Warning `json:"warnings"`
+	ErrorCode   string    `json:"error_code"`    // failed only
+	ErrorMsg    string    `json:"error_message"` // failed only
+}
+
+// Part is one NDJSON shard descriptor (api-spec §3.2 / §5.2).
+type Part struct {
+	URL          string   `json:"url"`
+	SizeBytes    int64    `json:"size_bytes"`
+	MessageCount int      `json:"message_count"`
+	SHA256       string   `json:"sha256"`
+	ExpiresAt    int64    `json:"expires_at"`
+	ChannelIDs   []string `json:"channel_ids"`
+}
+
+// Warning is a truncation / partial warning (api-spec §3.2).
+type Warning struct {
+	ChannelID  string `json:"channel_id"`
+	Code       string `json:"code"` // per_channel_truncated / total_truncated
+	Limit      int    `json:"limit"`
+	ActualSeen int    `json:"actual_seen"`
+}
+
+// IsTerminal reports whether the status is a terminal state (state machine
+// §3.3). The caller's polling loop stops on terminal states.
+func (s *BatchStatus) IsTerminal() bool {
+	switch s.Status {
+	case "completed", "partial", "failed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+// ── Request bodies ───────────────────────────────────────────────────────────
+
+type batchSubmitChannel struct {
+	ChannelID string `json:"channel_id"`
+}
+
+type batchSubmitScope struct {
+	Channels []batchSubmitChannel `json:"channels"`
+}
+
+type batchSubmitTimeRange struct {
+	StartTS int64 `json:"start_ts"`
+	EndTS   int64 `json:"end_ts"`
+}
+
+// IsDeleted is sent explicitly to match the legacy MySQL content query's
+// is_deleted = 0 predicate.
+type batchSubmitRequest struct {
+	Scope     batchSubmitScope     `json:"scope"`
+	TimeRange batchSubmitTimeRange `json:"time_range"`
+	IsDeleted int                  `json:"is_deleted"`
+}
+
+type batchSubmitResponse struct {
+	TaskID    string `json:"task_id"`
+	RequestID string `json:"request_id"`
+}
+
+// ── Retry / backoff config ───────────────────────────────────────────────────
+
+const (
+	maxServerRetries      = 3                // 5xx retries (api-spec §7)
+	base5xxBackoff        = 1 * time.Second  // 500 backoff base (exp + jitter)
+	min503Backoff         = 10 * time.Second // 503 must space >=10s (api-spec §7)
+	responseHeaderTimeout = 60 * time.Second
+	partDownloadTries     = 2 // per-part integrity retries (§5.3)
+	maxPartBytes          = int64(256 * 1024 * 1024)
+
+	pathBatch = "/v1/messages/batch"
+)
+
+// ── Submit ───────────────────────────────────────────────────────────────────
+
+// Submit posts a batch task. Expects HTTP 202. 4xx are mapped to the typed
+// sentinels above; 5xx are retried internally then returned as a plain error.
+func (c *OctoSearchBatchClient) Submit(ctx context.Context, channelIDs []string, startTS, endTS int64) (string, error) {
+	chs := make([]batchSubmitChannel, 0, len(channelIDs))
+	for _, id := range channelIDs {
+		chs = append(chs, batchSubmitChannel{ChannelID: id})
+	}
+	reqBody := batchSubmitRequest{
+		Scope:     batchSubmitScope{Channels: chs},
+		TimeRange: batchSubmitTimeRange{StartTS: startTS, EndTS: endTS},
+		IsDeleted: 0,
+	}
+	raw, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("octo-search submit: marshal request: %w", err)
+	}
+
+	var taskID string
+	doErr := c.doWithRetry(ctx, func() (retry bool, status int, err error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+pathBatch, bytes.NewReader(raw))
+		if err != nil {
+			return false, 0, fmt.Errorf("octo-search submit: build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		c.setAuth(req)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			// transport error: retryable (acts like a 5xx)
+			return true, 0, fmt.Errorf("octo-search submit: do request: %w", err)
+		}
+		defer resp.Body.Close()
+		c.logRequestID("submit", resp)
+
+		if resp.StatusCode == http.StatusAccepted { // 202
+			var sr batchSubmitResponse
+			if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+				return false, resp.StatusCode, fmt.Errorf("octo-search submit: decode 202 body: %w", err)
+			}
+			if sr.TaskID == "" {
+				return false, resp.StatusCode, errors.New("octo-search submit: 202 with empty task_id")
+			}
+			taskID = sr.TaskID
+			return false, resp.StatusCode, nil
+		}
+		return c.classifyHTTPError("submit", resp)
+	})
+	if doErr != nil {
+		return "", doErr
+	}
+	return taskID, nil
+}
+
+// ── Poll ─────────────────────────────────────────────────────────────────────
+
+// Poll performs a SINGLE status query (api-spec §3). It only retries 5xx
+// internally; it does NOT loop waiting for a terminal state — that loop
+// (5s backoff / 20min total / ctx-cancel -> Delete) is the caller's job.
+func (c *OctoSearchBatchClient) Poll(ctx context.Context, taskID string) (*BatchStatus, error) {
+	url := c.baseURL + pathBatch + "/" + taskID
+
+	var status *BatchStatus
+	doErr := c.doWithRetry(ctx, func() (retry bool, statusCode int, err error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return false, 0, fmt.Errorf("octo-search poll: build request: %w", err)
+		}
+		c.setAuth(req)
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return true, 0, fmt.Errorf("octo-search poll: do request: %w", err)
+		}
+		defer resp.Body.Close()
+		c.logRequestID("poll", resp)
+
+		if resp.StatusCode == http.StatusOK { // 200
+			var bs BatchStatus
+			if err := json.NewDecoder(resp.Body).Decode(&bs); err != nil {
+				return false, resp.StatusCode, fmt.Errorf("octo-search poll: decode body: %w", err)
+			}
+			status = &bs
+			return false, resp.StatusCode, nil
+		}
+		return c.classifyHTTPError("poll", resp)
+	})
+	if doErr != nil {
+		return nil, doErr
+	}
+	return status, nil
+}
+
+// ── Delete ───────────────────────────────────────────────────────────────────
+
+// Delete cancels a task (api-spec §4). Idempotent: terminal tasks also return
+// 200. This is a best-effort cleanup — callers invoke it on ctx-cancel /
+// poll-timeout with an independent short timeout and treat failure as a
+// warning, not a hard error.
+func (c *OctoSearchBatchClient) Delete(ctx context.Context, taskID string) error {
+	url := c.baseURL + pathBatch + "/" + taskID
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("octo-search delete: build request: %w", err)
+	}
+	c.setAuth(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("octo-search delete: do request: %w", err)
+	}
+	defer resp.Body.Close()
+	c.logRequestID("delete", resp)
+
+	// 200 = accepted (incl. already-terminal). 404 = unknown/not-ours; for a
+	// best-effort cleanup that is effectively "nothing to cancel".
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNotFound:
+		return nil
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("octo-search delete: unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+// ── DownloadAndParse ─────────────────────────────────────────────────────────
+
+// DownloadAndParse downloads every part, verifies gzip sha256, and parses the
+// decompressed ndjson into raw BatchMessageRow values.
+//
+// Per-part failure isolation (api-spec §5.3): a part whose sha256 never
+// matches after partDownloadTries retries is SKIPPED with a warning log; it
+// does not fail the whole call. Returns (good rows, nil) when some/all parts
+// succeed. Only when EVERY part fails (zero rows parsed AND at least one part
+// was bad) does it return an error, so the caller does not mistake a
+// total download failure for an empty result.
+func (c *OctoSearchBatchClient) DownloadAndParse(ctx context.Context, parts []Part) ([]BatchMessageRow, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+
+	rows := make([]BatchMessageRow, 0, 1024)
+	var badParts int
+	for i := range parts {
+		partRows, err := c.downloadPart(ctx, parts[i])
+		if err != nil {
+			badParts++
+			log.Printf("octo-search download: part %d/%d skipped after retries: %v", i+1, len(parts), err)
+			continue
+		}
+		rows = append(rows, partRows...)
+	}
+
+	// All parts bad and nothing recovered -> surface as error so the caller's
+	// per-batch isolation kicks in (don't masquerade as legit empty result).
+	if badParts == len(parts) && len(rows) == 0 {
+		return nil, fmt.Errorf("octo-search download: all %d part(s) failed", len(parts))
+	}
+	return rows, nil
+}
+
+// downloadPart downloads one part URL, retrying on transport error or sha256
+// mismatch up to partDownloadTries times, then parses gzip ndjson.
+func (c *OctoSearchBatchClient) downloadPart(ctx context.Context, part Part) ([]BatchMessageRow, error) {
+	var lastErr error
+	for attempt := 1; attempt <= partDownloadTries; attempt++ {
+		raw, err := c.fetchPartBytes(ctx, part.URL)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if part.SHA256 == "" {
+			lastErr = errors.New("missing sha256")
+			continue
+		}
+		sum := sha256.Sum256(raw)
+		got := hex.EncodeToString(sum[:])
+		if !strings.EqualFold(got, part.SHA256) {
+			lastErr = fmt.Errorf("sha256 mismatch: want %s got %s", part.SHA256, got)
+			continue
+		}
+		rows, err := parseGzipNDJSON(raw)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		// Treat a manifest/content row-count disagreement as part corruption
+		// (same tier as sha256): the part file does not match what the manifest
+		// declares, so retry; if it still mismatches it is reported as a bad part.
+		// This is part-level integrity, not server-side completeness — we do not
+		// validate aggregate ActualCount here.
+		if part.MessageCount > 0 && len(rows) != part.MessageCount {
+			lastErr = fmt.Errorf("message_count mismatch: manifest %d got %d", part.MessageCount, len(rows))
+			continue
+		}
+		return rows, nil
+	}
+	return nil, lastErr
+}
+
+// fetchPartBytes GETs the presigned URL and returns the raw (still gzipped)
+// body bytes for sha256 verification.
+func (c *OctoSearchBatchClient) fetchPartBytes(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build part request: %w", err)
+	}
+	// Disable Go's transparent gzip handling. With no explicit Accept-Encoding,
+	// the default Transport adds "Accept-Encoding: gzip" and auto-decompresses
+	// responses carrying "Content-Encoding: gzip" (stripping the header too).
+	// Our part objects are gzip *payloads* and sha256 is computed over the raw
+	// gzip bytes; if the object store also returns a Content-Encoding: gzip
+	// header, ReadAll would yield decompressed ndjson -> sha256 would never
+	// match and parseGzipNDJSON would fail. "identity" forces the raw bytes.
+	req.Header.Set("Accept-Encoding", "identity")
+	// Presigned S3 URL: no Authorization header.
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get part: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("get part: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxPartBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > maxPartBytes {
+		return nil, fmt.Errorf("get part: body exceeds %d bytes", maxPartBytes)
+	}
+	return raw, nil
+}
+
+// parseGzipNDJSON decompresses gzip bytes and parses one JSON row per line.
+func parseGzipNDJSON(gz []byte) ([]BatchMessageRow, error) {
+	gr, err := gzip.NewReader(bytes.NewReader(gz))
+	if err != nil {
+		return nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	rows := make([]BatchMessageRow, 0, 256)
+	sc := bufio.NewScanner(gr)
+	// Single ndjson line may exceed the default 64KB; enlarge the buffer.
+	const maxLine = 8 * 1024 * 1024
+	sc.Buffer(make([]byte, 0, 64*1024), maxLine)
+	line := 0
+	for sc.Scan() {
+		line++
+		b := bytes.TrimSpace(sc.Bytes())
+		if len(b) == 0 {
+			continue
+		}
+		var row BatchMessageRow
+		if err := json.Unmarshal(b, &row); err != nil {
+			return nil, fmt.Errorf("ndjson line %d: %w", line, err)
+		}
+		rows = append(rows, row)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("ndjson scan: %w", err)
+	}
+	return rows, nil
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+func (c *OctoSearchBatchClient) setAuth(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.token)
+}
+
+// logRequestID logs the server-echoed X-Request-Id for tracing. The token is
+// never logged.
+func (c *OctoSearchBatchClient) logRequestID(op string, resp *http.Response) {
+	if rid := resp.Header.Get("X-Request-Id"); rid != "" {
+		log.Printf("octo-search %s: status=%d x-request-id=%s", op, resp.StatusCode, rid)
+	}
+}
+
+// classifyHTTPError maps a non-success status to a typed sentinel (4xx) or a
+// retry signal (5xx). It returns (retry, status, err): retry=true asks
+// doWithRetry to back off and try again; retry=false is terminal. status is the
+// real HTTP status code so backoff can branch reliably (e.g. 503 spacing)
+// without fragile string matching on the error text.
+func (c *OctoSearchBatchClient) classifyHTTPError(op string, resp *http.Response) (bool, int, error) {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	snippet := strings.TrimSpace(string(body))
+	st := resp.StatusCode
+	switch st {
+	case http.StatusBadRequest: // 400
+		return false, st, fmt.Errorf("%w (%s: %s)", ErrBadRequest, op, snippet)
+	case http.StatusUnauthorized: // 401
+		return false, st, fmt.Errorf("%w (%s)", ErrUnauthorized, op)
+	case http.StatusNotFound: // 404
+		return false, st, fmt.Errorf("%w (%s: %s)", ErrTaskNotFound, op, snippet)
+	case http.StatusRequestEntityTooLarge: // 413
+		return false, st, fmt.Errorf("%w (%s: %s)", ErrSingleTaskTooLarge, op, snippet)
+	case 422: // Unprocessable Entity — time_range_too_long
+		return false, st, fmt.Errorf("%w (%s: %s)", ErrTimeRangeTooLong, op, snippet)
+	case http.StatusInternalServerError, http.StatusServiceUnavailable: // 500/503
+		return true, st, fmt.Errorf("octo-search %s: server error %d: %s", op, st, snippet)
+	default:
+		// Unknown 4xx -> fail-fast (wrap ErrFatalClient so the caller's
+		// isFatalBatchErr recognises it); unknown 5xx -> retry.
+		if st >= 500 {
+			return true, st, fmt.Errorf("octo-search %s: server error %d: %s", op, st, snippet)
+		}
+		return false, st, fmt.Errorf("%w (%s: unexpected status %d: %s)", ErrFatalClient, op, st, snippet)
+	}
+}
+
+// doWithRetry runs fn, retrying when fn returns retry=true, up to
+// maxServerRetries, with exponential backoff + jitter (503 spaced >=10s).
+// fn returns (retry, status, err): status carries the HTTP status code (0 for
+// transport errors) so backoff can branch on 503 reliably.
+func (c *OctoSearchBatchClient) doWithRetry(ctx context.Context, fn func() (retry bool, status int, err error)) error {
+	var lastErr error
+	for attempt := 0; attempt <= maxServerRetries; attempt++ {
+		retry, status, err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retry || attempt == maxServerRetries {
+			return lastErr
+		}
+		// backoff before next attempt
+		delay := backoffDelay(attempt, status)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("octo-search: context cancelled during retry: %w (last: %v)", ctx.Err(), lastErr)
+		case <-time.After(delay):
+		}
+	}
+	return lastErr
+}
+
+// backoffDelay computes exponential backoff with jitter. 503 (service_degraded)
+// is spaced at least min503Backoff per api-spec §7. status is the real HTTP
+// status code (0 for transport errors) — branching on it is reliable, unlike
+// matching "503" in the error string.
+func backoffDelay(attempt, status int) time.Duration {
+	d := base5xxBackoff << attempt // 1s, 2s, 4s...
+	// 503 must be spaced >=10s.
+	if status == http.StatusServiceUnavailable && d < min503Backoff {
+		d = min503Backoff
+	}
+	// +/-20% jitter
+	jitter := time.Duration(rand.Int63n(int64(d) / 5))
+	return d + jitter
+}

--- a/internal/service/octo_search_test.go
+++ b/internal/service/octo_search_test.go
@@ -1,0 +1,450 @@
+package service
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// gzipRows is a test helper: marshal rows to ndjson, gzip, return (bytes, hexSha256).
+func gzipRows(t *testing.T, rows []BatchMessageRow) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	for _, r := range rows {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal row: %v", err)
+		}
+		gw.Write(b)
+		gw.Write([]byte("\n"))
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	raw := buf.Bytes()
+	sum := sha256.Sum256(raw)
+	return raw, hex.EncodeToString(sum[:])
+}
+
+func TestSubmit_Success202(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/messages/batch" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
+			t.Errorf("auth header = %q", got)
+		}
+		var body batchSubmitRequest
+		json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Scope.Channels) != 2 {
+			t.Errorf("channels len = %d", len(body.Scope.Channels))
+		}
+		if body.IsDeleted != 0 {
+			t.Errorf("is_deleted = %d, want 0", body.IsDeleted)
+		}
+		w.Header().Set("X-Request-Id", "rid-1")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(batchSubmitResponse{TaskID: "ost_abc", RequestID: "rid-1"})
+	}))
+	defer srv.Close()
+
+	c := NewOctoSearchBatchClient(srv.URL, "tok123")
+	taskID, err := c.Submit(context.Background(), []string{"a@b", "grp1"}, 100, 200)
+	if err != nil {
+		t.Fatalf("Submit err: %v", err)
+	}
+	if taskID != "ost_abc" {
+		t.Errorf("taskID = %q, want ost_abc", taskID)
+	}
+}
+
+func TestSubmit_BaseURLTrailingSlashTrimmed(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(batchSubmitResponse{TaskID: "x"})
+	}))
+	defer srv.Close()
+
+	c := NewOctoSearchBatchClient(srv.URL+"/", "t") // trailing slash
+	if _, err := c.Submit(context.Background(), []string{"c"}, 1, 2); err != nil {
+		t.Fatalf("Submit err: %v", err)
+	}
+	if gotPath != "/v1/messages/batch" {
+		t.Errorf("path = %q, want /v1/messages/batch (no // doubling)", gotPath)
+	}
+}
+
+func TestSubmit_TypedErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		wantErr error
+	}{
+		{"400", http.StatusBadRequest, ErrBadRequest},
+		{"401", http.StatusUnauthorized, ErrUnauthorized},
+		{"404", http.StatusNotFound, ErrTaskNotFound},
+		{"413", http.StatusRequestEntityTooLarge, ErrSingleTaskTooLarge},
+		{"422", 422, ErrTimeRangeTooLong},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				w.Write([]byte(`{"error_code":"x"}`))
+			}))
+			defer srv.Close()
+			c := NewOctoSearchBatchClient(srv.URL, "t")
+			_, err := c.Submit(context.Background(), []string{"a"}, 1, 2)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Submit %s: err = %v, want errors.Is(%v)", tc.name, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSubmit_413NotRetried(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+	}))
+	defer srv.Close()
+	c := NewOctoSearchBatchClient(srv.URL, "t")
+	_, err := c.Submit(context.Background(), []string{"a"}, 1, 2)
+	if !errors.Is(err, ErrSingleTaskTooLarge) {
+		t.Fatalf("err = %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("4xx must not retry: got %d calls, want 1", n)
+	}
+}
+
+func TestSubmit_500RetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(batchSubmitResponse{TaskID: "ost_ok"})
+	}))
+	defer srv.Close()
+
+	// shrink backoff for the test by cancelling-free fast path: 500 backoff is
+	// ~1s,2s — acceptable for a unit test (<5s). Use a generous ctx.
+	c := NewOctoSearchBatchClient(srv.URL, "t")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	taskID, err := c.Submit(ctx, []string{"a"}, 1, 2)
+	if err != nil {
+		t.Fatalf("Submit err after retries: %v", err)
+	}
+	if taskID != "ost_ok" {
+		t.Errorf("taskID = %q", taskID)
+	}
+	if n := atomic.LoadInt32(&calls); n != 3 {
+		t.Errorf("calls = %d, want 3 (2 fails + 1 ok)", n)
+	}
+}
+
+func TestSubmit_500ExhaustsRetries(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := NewOctoSearchBatchClient(srv.URL, "t")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := c.Submit(ctx, []string{"a"}, 1, 2)
+	if err == nil {
+		t.Fatal("want error after exhausting retries")
+	}
+	// 5xx exhaustion must NOT be a typed sentinel (caller isolates it).
+	if errors.Is(err, ErrBadRequest) || errors.Is(err, ErrUnauthorized) {
+		t.Errorf("5xx exhaustion should be plain error, got %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != maxServerRetries+1 {
+		t.Errorf("calls = %d, want %d", n, maxServerRetries+1)
+	}
+}
+
+func TestPoll_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/messages/batch/ost_1" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(BatchStatus{
+			Status:      "completed",
+			ActualCount: 5,
+			Parts:       []Part{{URL: "u", SHA256: "s", ChannelIDs: []string{"a"}, MessageCount: 5}},
+		})
+	}))
+	defer srv.Close()
+	c := NewOctoSearchBatchClient(srv.URL, "t")
+	st, err := c.Poll(context.Background(), "ost_1")
+	if err != nil {
+		t.Fatalf("Poll err: %v", err)
+	}
+	if st.Status != "completed" || !st.IsTerminal() || st.ActualCount != 5 {
+		t.Errorf("status = %+v", st)
+	}
+	if len(st.Parts) != 1 || st.Parts[0].MessageCount != 5 {
+		t.Errorf("parts = %+v", st.Parts)
+	}
+}
+
+func TestBatchStatus_IsTerminal(t *testing.T) {
+	terminal := []string{"completed", "partial", "failed", "cancelled"}
+	nonTerminal := []string{"queued", "running", ""}
+	for _, s := range terminal {
+		if !(&BatchStatus{Status: s}).IsTerminal() {
+			t.Errorf("%q should be terminal", s)
+		}
+	}
+	for _, s := range nonTerminal {
+		if (&BatchStatus{Status: s}).IsTerminal() {
+			t.Errorf("%q should NOT be terminal", s)
+		}
+	}
+}
+
+func TestDelete_Idempotent(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusNotFound} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("method = %s", r.Method)
+			}
+			w.WriteHeader(status)
+		}))
+		c := NewOctoSearchBatchClient(srv.URL, "t")
+		if err := c.Delete(context.Background(), "ost_x"); err != nil {
+			t.Errorf("Delete on %d should be nil, got %v", status, err)
+		}
+		srv.Close()
+	}
+}
+
+func TestDownloadAndParse_Success(t *testing.T) {
+	rows := []BatchMessageRow{
+		{MessageSeq: 1, FromUID: "u1", ChannelID: "a@b", Timestamp: 100, Payload: "hi"},
+		{MessageSeq: 2, FromUID: "u2", ChannelID: "a@b", Timestamp: 200, Payload: "yo"},
+	}
+	gz, sum := gzipRows(t, rows)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(gz)
+	}))
+	defer srv.Close()
+
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	got, err := c.DownloadAndParse(context.Background(), []Part{{URL: srv.URL, SHA256: sum}})
+	if err != nil {
+		t.Fatalf("DownloadAndParse err: %v", err)
+	}
+	if len(got) != 2 || got[0].Payload != "hi" || got[1].MessageSeq != 2 {
+		t.Errorf("rows = %+v", got)
+	}
+}
+
+func TestDownloadAndParse_BadPartSkipped(t *testing.T) {
+	goodRows := []BatchMessageRow{{MessageSeq: 1, ChannelID: "a", Payload: "ok"}}
+	goodGz, goodSum := gzipRows(t, goodRows)
+	badGz, _ := gzipRows(t, []BatchMessageRow{{MessageSeq: 9, Payload: "bad"}})
+
+	goodSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(goodGz) }))
+	defer goodSrv.Close()
+	badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(badGz) }))
+	defer badSrv.Close()
+
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	// bad part declares a wrong sha256 -> skipped; good part survives.
+	parts := []Part{
+		{URL: badSrv.URL, SHA256: "deadbeef"},
+		{URL: goodSrv.URL, SHA256: goodSum},
+	}
+	got, err := c.DownloadAndParse(context.Background(), parts)
+	if err != nil {
+		t.Fatalf("partial bad should return nil err, got %v", err)
+	}
+	if len(got) != 1 || got[0].Payload != "ok" {
+		t.Errorf("want only good rows, got %+v", got)
+	}
+}
+
+func TestDownloadAndParse_AllBadReturnsError(t *testing.T) {
+	badGz, _ := gzipRows(t, []BatchMessageRow{{MessageSeq: 1}})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(badGz) }))
+	defer srv.Close()
+
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	parts := []Part{{URL: srv.URL, SHA256: "wronghash"}}
+	_, err := c.DownloadAndParse(context.Background(), parts)
+	if err == nil {
+		t.Fatal("all-parts-bad must return error, not silent empty")
+	}
+}
+
+func TestDownloadAndParse_EmptyPartsNil(t *testing.T) {
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	got, err := c.DownloadAndParse(context.Background(), nil)
+	if err != nil || got != nil {
+		t.Errorf("empty parts -> (nil,nil), got (%v,%v)", got, err)
+	}
+}
+
+func TestDownloadAndParse_MissingSHA256ReturnsError(t *testing.T) {
+	rows := []BatchMessageRow{{MessageSeq: 1, Payload: "x"}}
+	gz, _ := gzipRows(t, rows)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(gz) }))
+	defer srv.Close()
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	_, err := c.DownloadAndParse(context.Background(), []Part{{URL: srv.URL}}) // no SHA256
+	if err == nil {
+		t.Fatal("missing sha256 must return error")
+	}
+}
+
+// TestFetchPartBytes_DisablesTransparentGzip verifies the part GET sends
+// "Accept-Encoding: identity" so Go's default Transport never adds gzip and
+// never transparently decompresses the response. Our part objects are gzip
+// *payloads* and sha256 is computed over the raw gzip bytes; if the transport
+// auto-decompressed a Content-Encoding: gzip response, ReadAll would yield
+// decompressed ndjson, sha256 would never match, and parseGzipNDJSON would fail.
+func TestFetchPartBytes_DisablesTransparentGzip(t *testing.T) {
+	rows := []BatchMessageRow{{MessageSeq: 1, ChannelID: "a", Payload: "ok"}}
+	gz, sum := gzipRows(t, rows)
+
+	var gotAccEnc string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccEnc = r.Header.Get("Accept-Encoding")
+		// Mimic an object store that tags the gzip object at the HTTP layer.
+		// With identity requested, Go must NOT auto-decompress; raw gz reaches us.
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Write(gz)
+	}))
+	defer srv.Close()
+
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	got, err := c.DownloadAndParse(context.Background(), []Part{{URL: srv.URL, SHA256: sum}})
+	if err != nil {
+		t.Fatalf("DownloadAndParse err (transparent gzip likely re-enabled): %v", err)
+	}
+	if gotAccEnc != "identity" {
+		t.Errorf("Accept-Encoding = %q, want \"identity\" (transparent gzip must be disabled)", gotAccEnc)
+	}
+	if len(got) != 1 || got[0].Payload != "ok" {
+		t.Errorf("rows = %+v", got)
+	}
+}
+
+// TestDownloadPart_MessageCountMismatchIsBadPart verifies the data-contract
+// check: when the manifest declares message_count but the part's actual row
+// count differs, the part is treated as corrupt. A single such part (after
+// retries) makes DownloadAndParse surface an error rather than silently return
+// a short result.
+func TestDownloadPart_MessageCountMismatchIsBadPart(t *testing.T) {
+	rows := []BatchMessageRow{
+		{MessageSeq: 1, ChannelID: "a", Payload: "x"},
+		{MessageSeq: 2, ChannelID: "a", Payload: "y"},
+	}
+	gz, sum := gzipRows(t, rows) // actually 2 rows
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(gz) }))
+	defer srv.Close()
+
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	// Manifest lies: claims 3 rows but the file holds 2 -> corrupt part.
+	parts := []Part{{URL: srv.URL, SHA256: sum, MessageCount: 3}}
+	_, err := c.DownloadAndParse(context.Background(), parts)
+	if err == nil {
+		t.Fatal("message_count mismatch (sole part) must return error, not a short silent result")
+	}
+}
+
+// TestDownloadPart_MessageCountMismatchKeepsGoodSibling verifies B+ isolation:
+// a row-count-mismatched part is skipped, but a healthy sibling part's rows are
+// still returned (we do NOT fail the whole batch on one bad part).
+func TestDownloadPart_MessageCountMismatchKeepsGoodSibling(t *testing.T) {
+	goodRows := []BatchMessageRow{{MessageSeq: 1, ChannelID: "a", Payload: "ok"}}
+	goodGz, goodSum := gzipRows(t, goodRows)
+	badRows := []BatchMessageRow{{MessageSeq: 9, ChannelID: "b", Payload: "bad"}}
+	badGz, badSum := gzipRows(t, badRows) // file has 1 row...
+
+	goodSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(goodGz) }))
+	defer goodSrv.Close()
+	badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(badGz) }))
+	defer badSrv.Close()
+
+	c := NewOctoSearchBatchClient("http://unused", "t")
+	parts := []Part{
+		{URL: badSrv.URL, SHA256: badSum, MessageCount: 5}, // ...but manifest claims 5 -> bad, skipped
+		{URL: goodSrv.URL, SHA256: goodSum, MessageCount: 1},
+	}
+	got, err := c.DownloadAndParse(context.Background(), parts)
+	if err != nil {
+		t.Fatalf("one mismatched + one good should return nil err, got %v", err)
+	}
+	if len(got) != 1 || got[0].Payload != "ok" {
+		t.Errorf("want only good sibling rows preserved, got %+v", got)
+	}
+}
+
+func TestParseGzipNDJSON_SkipsBlankLines(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	fmt.Fprint(gw, `{"message_seq":1,"payload":"a"}`+"\n\n"+`{"message_seq":2,"payload":"b"}`+"\n")
+	gw.Close()
+	rows, err := parseGzipNDJSON(buf.Bytes())
+	if err != nil {
+		t.Fatalf("parse err: %v", err)
+	}
+	if len(rows) != 2 || rows[1].MessageSeq != 2 {
+		t.Errorf("rows = %+v", rows)
+	}
+}
+
+// TestBackoffDelay_503Spacing verifies backoff branches on the real HTTP status
+// code (not on string-matching "503" in the error text). 503 must be spaced
+// >=min503Backoff even on early attempts; 500 follows plain exponential backoff.
+func TestBackoffDelay_503Spacing(t *testing.T) {
+	// attempt 0 for 503: base (1s) < 10s, so it must be lifted to min503Backoff.
+	d := backoffDelay(0, http.StatusServiceUnavailable)
+	if d < min503Backoff {
+		t.Errorf("503 attempt0 delay = %v, want >= %v", d, min503Backoff)
+	}
+
+	// attempt 0 for 500: plain exponential base, must stay well under the 503 floor.
+	d = backoffDelay(0, http.StatusInternalServerError)
+	if d >= min503Backoff {
+		t.Errorf("500 attempt0 delay = %v, want < %v", d, min503Backoff)
+	}
+
+	// A transport error (status 0) must NOT be treated as 503.
+	d = backoffDelay(0, 0)
+	if d >= min503Backoff {
+		t.Errorf("status0 attempt0 delay = %v, want < %v (must not match 503)", d, min503Backoff)
+	}
+
+	// Guard against the old string-match bug: a 500 whose body happened to
+	// contain "503" must not be spaced like a 503. We exercise this at the
+	// status level — backoffDelay no longer sees the error string at all.
+	d = backoffDelay(1, http.StatusInternalServerError) // base<<1 = 2s
+	if d >= min503Backoff {
+		t.Errorf("500 attempt1 delay = %v, want < %v", d, min503Backoff)
+	}
+}

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -217,7 +217,7 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
 		//
-		// §4.4-2 system back-fill of submitted_at (Blocker-1): the meta completion gate
+		// System back-fill of submitted_at: the meta completion gate
 		// requires submitted_at IS NOT NULL, but the personal worker only sets
 		// ParticipantCompleted/WorkerStatus=Completed -- it never writes submitted_at
 		// (the only manual writer is /submit). A scheduled multi-person task driven by the
@@ -258,7 +258,7 @@ func (p *Processor) backfillScheduledSubmittedAt(taskID int64, pr *model.Persona
 			Scan(&status).Error; err != nil {
 			return err
 		}
-		// Confirmed gate (口径同 meta totalAccepted): skip Pending/Declined.
+		// Use the same accepted-participant gate as meta aggregation.
 		if status == model.ParticipantPending || status == model.ParticipantDeclined {
 			return nil
 		}
@@ -284,7 +284,8 @@ func (p *Processor) backfillScheduledSubmittedAt(taskID int64, pr *model.Persona
 func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *model.SummaryParticipant, errMsg string) {
 	sanitized := sanitizeErrorForUser(errMsg)
 
-	// 🔴 Blocker-3 fix: self-heal vs terminal failure.
+	// Retryable personal failures are returned to Pending; exhausted attempts are
+	// marked terminal for that participant.
 	//
 	// The old markPersonalFailed unconditionally set worker_status=Failed and reset the
 	// participant to Accepted. But the retry scanner (scanStuckPersonalTasks) only
@@ -294,7 +295,7 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	// does NOT propagate task-level failure, so meta would wait forever for a submit that
 	// never comes -> task stuck until the lease times out.
 	//
-	// New behavior (P0, AUTO path):
+	// Retry behavior:
 	//   - retry_count < WorkerMaxRetry: increment retry_count and set worker_status back
 	//     to Pending (participant stays Accepted). scanStuckPersonalTasks' M3 sweep (and
 	//     the AUTO dispatch path) then naturally re-runs it -- a transient failure heals.
@@ -304,7 +305,7 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	//       * multi-person: Decline the failed participant so it drops out of meta's
 	//         totalAccepted (status NOT IN Pending,Declined), letting the remaining
 	//         members aggregate; then kick meta to re-evaluate. This keeps the existing
-	//         meta gate intact (no confirmed_set change -- that is P1 scope).
+	//         meta gate intact.
 	maxRetry := p.cfg.WorkerMaxRetry
 	if maxRetry < 1 {
 		maxRetry = 1
@@ -501,7 +502,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 	messages, intentResult, err := pipeline.ResolveAndFetchMessagesForPersonal(
 		ctx, userID, nil, nil, specifiedSources, task.Title,
 		task.TimeRangeStart, task.TimeRangeEnd,
-		p.imDB, toolCallFn, llmFn,
+		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn,
 		p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency,
 		channelScopeOpts,
 	)

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
@@ -28,6 +30,7 @@ type Processor struct {
 	pool       *WorkerPool
 	llm        *service.LLMClient
 	cfg        *config.Config
+	octoClient *service.OctoSearchBatchClient // Chat-message content source.
 	stopCh     chan struct{}
 	triggerCh  chan model.WorkerTriggerRequest
 	meta       *MetaProcessor
@@ -45,17 +48,62 @@ type Processor struct {
 
 // NewProcessor creates a new task processor.
 func NewProcessor(db, imDB *gorm.DB, pool *WorkerPool, llm *service.LLMClient, cfg *config.Config) *Processor {
+	octoClient, err := newOctoSearchClientForBackend(cfg)
+	if err != nil {
+		log.Fatalf("[processor] %v", err)
+	}
 	p := &Processor{
-		db:        db,
-		imDB:      imDB,
-		pool:      pool,
-		llm:       llm,
-		cfg:       cfg,
-		stopCh:    make(chan struct{}),
-		triggerCh: make(chan model.WorkerTriggerRequest, 100),
+		db:         db,
+		imDB:       imDB,
+		pool:       pool,
+		llm:        llm,
+		cfg:        cfg,
+		octoClient: octoClient,
+		stopCh:     make(chan struct{}),
+		triggerCh:  make(chan model.WorkerTriggerRequest, 100),
 	}
 	p.meta = NewMetaProcessor(p)
 	return p
+}
+
+func newOctoSearchClientForBackend(cfg *config.Config) (*service.OctoSearchBatchClient, error) {
+	backend := strings.ToLower(strings.TrimSpace(cfg.MessageFetchBackend))
+	if backend == "" {
+		backend = "batch"
+	}
+	switch backend {
+	case "batch":
+		if cfg.OctoSearchURL == "" || cfg.OctoSearchToken == "" {
+			return nil, fmt.Errorf("OCTO_SEARCH_URL / OCTO_SEARCH_TOKEN are required when MESSAGE_FETCH_BACKEND=batch")
+		}
+		if err := validateOctoSearchURL(cfg.OctoSearchURL); err != nil {
+			return nil, fmt.Errorf("invalid OCTO_SEARCH_URL: %w", err)
+		}
+		return service.NewOctoSearchBatchClient(cfg.OctoSearchURL, cfg.OctoSearchToken), nil
+	case "mysql":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("invalid MESSAGE_FETCH_BACKEND %q (want batch or mysql)", cfg.MessageFetchBackend)
+	}
+}
+
+func validateOctoSearchURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+	if u.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+	for _, segment := range strings.Split(strings.Trim(u.Path, "/"), "/") {
+		if segment == "v1" {
+			return fmt.Errorf("must be base URL without /v1")
+		}
+	}
+	return nil
 }
 
 // TriggerCh returns the channel for worker trigger requests.
@@ -313,9 +361,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 	} else {
 		isScheduledMultiPerson := task.TriggerType == model.TriggerScheduled
 
-		// 🔴 P0 dispatch-deadlock fix.
+		// Scheduled dispatch must not depend on the deadline-refresh CAS.
 		//
-		// ROOT CAUSE: the AUTO scheduled multi-person dispatch (Blocker-1) used to sit
+		// The AUTO scheduled multi-person dispatch used to sit
 		// BEHIND a "refresh processing_deadline" CAS (WHERE status=Processing). When that
 		// CAS returned RowsAffected==0 the code logged "status changed (likely cancelled),
 		// skipping dispatch" and RETURNED -- without dispatching anyone AND without putting
@@ -328,7 +376,7 @@ func (p *Processor) processTask(task model.SummaryTask) {
 		// scanStuckTasks revive (deadline lapse / timezone-vs-wallclock skew across
 		// processes), a second worker replica, or a stale reload struct racing the row.
 		// Treating "CAS missed" as "give up, leave it Processing" is the defect -- the
-		// dispatch logic itself is correct, it was just fatally gated.
+		// dispatch logic itself is correct; it was gated by the CAS.
 		//
 		// FIX (direction A + B): for EVERY scheduled multi-person task (AUTO *and*
 		// CONFIRM), decide+dispatch on the MAIN path up front (idempotent:
@@ -338,9 +386,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 		// AFTER dispatch and a miss never strands the task. For the MANUAL (non-scheduled)
 		// multi-person path we keep the original guarded CAS, but a miss re-reads the real
 		// status and only returns on a genuine terminal/changed state -- otherwise it
-		// falls through, and the异常 path resets to Pending instead of leaving the task pinned in Processing.
+		// falls through, and the abnormal path resets to Pending instead of leaving the task pinned in Processing.
 		//
-		// 🔴 P1 EXPERIENCE FIX (why this branch now covers CONFIRM, not just AUTO):
+		// This branch covers scheduled CONFIRM rounds as well as AUTO rounds:
 		// A scheduled CONFIRM task (confirm_policy=1/2) reaches the processor with its
 		// participants ALREADY materialized as confirmed Accepted members --
 		// buildScheduledTaskParticipantsConfirm only writes rows for members who already
@@ -349,7 +397,7 @@ func (p *Processor) processTask(task model.SummaryTask) {
 		// confirmation" left to do at processor time -- the round is already locked to its
 		// confirmed roster. Previously these CONFIRM rounds fell into the non-dispatch
 		// "participants pending confirm" branch and only got picked up ~5 min later by
-		// scanStuckPersonalTasks, so users stared at "生成中" for minutes. Driving dispatch here is SAFE because:
+		// scanStuckPersonalTasks, so users stayed on the in-progress state for minutes. Driving dispatch here is SAFE because:
 		//   1. scheduledAutoDispatchTargets is idempotent -- it selects ONLY
 		//      status==Accepted AND pr.worker_status==Pending, so in-flight/finished
 		//      personals are never re-dispatched, and unconfirmed members do not exist as
@@ -372,8 +420,8 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			}
 
 			// Best-effort deadline refresh so scanStuckTasks does not revive us while the
-			// personal workers run. A miss here is NOT fatal: dispatch already happened,
-			// and re-claim is idempotent. We only need to ensure we don't闷 in Processing
+			// personal workers run. A miss here is acceptable: dispatch already happened,
+			// and re-claim is idempotent. We only need to ensure we do not stay in Processing
 			// with nothing in flight, so on a miss we re-read the real status.
 			casResult := p.db.Model(&model.SummaryTask{}).
 				Where("id = ? AND status = ?", task.ID, model.StatusProcessing).
@@ -402,10 +450,10 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			return
 		}
 
-		// Manual (non-scheduled) multi-person (CONFIRM / human-confirm, P1): Creator
+		// Manual (non-scheduled) multi-person (CONFIRM / human-confirm): Creator
 		// already triggered by the API handler; other participants remain WaitingConfirm
 		// until they accept. We must NOT blindly dispatch everyone here. Keep the guarded
-		// deadline-refresh CAS, but make a miss non-fatal and never leave the task pinned
+		// deadline-refresh CAS, but make a miss recoverable and never leave the task pinned
 		// in Processing. (Scheduled CONFIRM rounds never reach this branch -- they take
 		// the active-dispatch path above, because their roster is already confirmed.)
 		casResult := p.db.Model(&model.SummaryTask{}).
@@ -432,7 +480,7 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			case model.StatusProcessing:
 				// We still own it (a benign racing deadline write). Fall through to the waiting-for-confirm path below.
 			default:
-				// Bounced to Pending/WaitingConfirm by a concurrent revive. Do NOT闷 in
+				// Bounced to Pending/WaitingConfirm by a concurrent revive. Do NOT stay in
 				// Processing: let the next claim handle it. (No dispatch here -- CONFIRM
 				// participants must still confirm.)
 				log.Printf("[processor] task %d no longer Processing (status=%d), deferring to next claim", task.ID, cur.Status)
@@ -451,17 +499,17 @@ func (p *Processor) processTask(task model.SummaryTask) {
 }
 
 // scheduleConfirmPolicyIsAuto reports whether the task's bound schedule uses the
-// AUTO confirm policy (confirm_policy==0, the存量单人 default). The confirm policy
+// AUTO confirm policy (confirm_policy==0, the legacy single-person default). The confirm policy
 // lives on summary_schedule, not summary_task, so it is read via task.ScheduleID.
 //
 // Default is FALSE (NOT auto) on every uncertain path -- safe side. Only an
 // explicitly read schedule.confirm_policy == SchedConfirmAuto returns true.
-// Rationale: returning true on uncertainty would全量 dispatch a task that may be
+// Rationale: returning true on uncertainty would dispatch all participants for a task that may be
 // CONFIRM, firing personal workers without the required human confirmation and
 // breaking the manual-confirm semantics. Failing closed (no auto-dispatch) is
 // recoverable -- the task waits / the 5-minute stuck scan can still pick up a
 // genuinely AUTO run -- whereas failing open mis-triggers CONFIRM tasks. So both
-// ScheduleID==nil and a failed lookup return false. (P0 AUTO tasks always carry a
+// ScheduleID==nil and a failed lookup return false. (AUTO tasks always carry a
 // ScheduleID, bound at claim time, so the normal AUTO path is unaffected.)
 func (p *Processor) scheduleConfirmPolicyIsAuto(task model.SummaryTask) bool {
 	if task.ScheduleID == nil {
@@ -651,7 +699,7 @@ func (p *Processor) executePipeline(task model.SummaryTask) error {
 	messages, _, err = pipeline.ResolveAndFetchMessagesForPersonal(
 		ctx, task.CreatorID, participantUIDs, participantNames, specifiedSources, task.Title,
 		task.TimeRangeStart, task.TimeRangeEnd,
-		p.imDB, toolCallFn, llmFn, p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency,
+		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn, p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency,
 		channelScopeOpts,
 	)
 	timing.Observe(task.TaskNo, "fetch_messages", fetchStart)

--- a/internal/worker/processor_url_test.go
+++ b/internal/worker/processor_url_test.go
@@ -1,0 +1,75 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+)
+
+func TestValidateOctoSearchURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "cluster http", raw: "http://octo-search-batch:8080"},
+		{name: "cluster https", raw: "https://octo-search-batch:8443"},
+		{name: "trailing slash", raw: "http://octo-search-batch:8080/"},
+		{name: "missing scheme", raw: "octo-search-batch:8080", wantErr: true},
+		{name: "missing host", raw: "http://", wantErr: true},
+		{name: "unsupported scheme", raw: "ftp://octo-search-batch:8080", wantErr: true},
+		{name: "with v1 path", raw: "http://octo-search-batch:8080/v1", wantErr: true},
+		{name: "with nested v1 path", raw: "http://octo-search-batch:8080/api/v1", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOctoSearchURL(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateOctoSearchURL(%q) error = %v, wantErr %v", tt.raw, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewOctoSearchClientForBackend(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantNil bool
+		wantErr bool
+	}{
+		{
+			name:    "batch creates client",
+			cfg:     &config.Config{MessageFetchBackend: "batch", OctoSearchURL: "http://octo-search-batch:8080", OctoSearchToken: "tok"},
+			wantNil: false,
+		},
+		{
+			name:    "batch requires url and token",
+			cfg:     &config.Config{MessageFetchBackend: "batch"},
+			wantNil: true,
+			wantErr: true,
+		},
+		{
+			name:    "mysql does not need octo config",
+			cfg:     &config.Config{MessageFetchBackend: "mysql"},
+			wantNil: true,
+		},
+		{
+			name:    "unknown backend",
+			cfg:     &config.Config{MessageFetchBackend: "other"},
+			wantNil: true,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := newOctoSearchClientForBackend(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if (client == nil) != tt.wantNil {
+				t.Fatalf("client nil = %v, wantNil %v", client == nil, tt.wantNil)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Switch the personal summary pipeline's Layer 4 message fetching from a direct per-channel MySQL scan to the octo-search-batch service.

## Why

`ResolveAndFetchMessagesForPersonal` used `FetchMessagesFromChannel`, which scanned MySQL directly per channel. This coupled the summary worker to the message-store DB schema and scaled poorly on large/active channels.

## What changed

- Add `OctoSearchBatchClient` (submit / poll / download) with sha256 + message_count part integrity checks and bad-part isolation.
- Add the `fetchViaBatch` orchestration layer and wire it into Layer 4, replacing the per-channel MySQL loop.
- Add `OCTO_SEARCH_URL` / `OCTO_SEARCH_TOKEN` config; the worker fails fast on startup if either is missing, so it never silently falls back to MySQL.
- Downstream processing (mutual-activity filter, post-retrieval narrowing, summary / map-reduce / citation) is unchanged.
- `FetchMessagesFromChannel` is kept temporarily for MySQL-vs-batch content reconciliation; it will be removed once test-env reconciliation passes.

## Testing

- `gofmt` clean on all changed files.
- `CGO_ENABLED=0 go test ./...` green across all packages (config / middleware / model / pipeline / service / timing / tokenizer / worker), including the rewritten archive tests and the fetchViaBatch orchestration tests.
- Default CGO-mode full test run is blocked only by a pre-existing local `libtokenizers` linking issue in `internal/tokenizer` / `internal/worker`, unrelated to this change.

## Impact / risk

- Behavior change is limited to the data source of Layer 4. Requires `OCTO_SEARCH_URL` / `OCTO_SEARCH_TOKEN` to be set in the deployment env; missing config makes the worker fail to start by design.
- End-to-end MySQL-vs-batch content reconciliation is to be run in the test environment before removing the legacy MySQL path.

Closes #123
