### PR TITLE
feat(notify): task-terminal notification via summary-assistant bot

### DIFF
--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
@@ -90,12 +91,33 @@ func main() {
 	// Start worker pool
 	pool := worker.NewWorkerPool(cfg.WorkerMaxConcurrent)
 
+	// Build the terminal-state IM-bot notifier (OCT-4). Disabled unless
+	// SUMMARY_NOTIFY_ENABLED=true; a nil deliverer / disabled config makes
+	// OnTaskTerminal a no-op, so it is always safe to wire.
+	var notifier *notify.Notifier
+	if cfg.NotifyEnabled {
+		if cfg.OctoAPIURL == "" || cfg.SummaryBotToken == "" {
+			log.Printf("[worker] SUMMARY_NOTIFY_ENABLED=true but OCTO_API_URL / SUMMARY_BOT_TOKEN missing; notifications disabled")
+		} else {
+			deliverer := notify.NewHTTPDeliverer(cfg.OctoAPIURL, cfg.SummaryBotToken)
+			notifier = notify.New(summaryDB, deliverer, notify.Config{
+				Enabled:     true,
+				WebBaseURL:  cfg.SummaryWebBaseURL,
+				MaxAttempts: cfg.MaxNotifyAttempts,
+				QuietStart:  cfg.NotifyQuietStart,
+				QuietEnd:    cfg.NotifyQuietEnd,
+			})
+			log.Printf("[worker] terminal-state notifications ENABLED")
+		}
+	}
+
 	// Start processor (polling loop)
 	proc := worker.NewProcessor(summaryDB, imDB, pool, llm, cfg)
+	proc.SetNotifier(notifier)
 	go proc.Run()
 
 	// Start scheduler (cron jobs)
-	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays, cfg.FeatureTeamSchedule)
+	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays, cfg.FeatureTeamSchedule, notifier)
 
 	// Start internal HTTP server for worker-trigger
 	hub := ws.NewHub(summaryDB)

--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -148,7 +148,6 @@ func main() {
 			// imDB 为 nil / 查不到时 buildText 优雅降级回不带空间名的旧文案。
 			notifier = notify.New(summaryDB, imDB, deliverer, notify.Config{
 				Enabled:     true,
-				WebBaseURL:  cfg.SummaryWebBaseURL,
 				MaxAttempts: cfg.MaxNotifyAttempts,
 				QuietStart:  cfg.NotifyQuietStart,
 				QuietEnd:    cfg.NotifyQuietEnd,

--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -16,7 +17,40 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/worker"
+	"gorm.io/gorm"
 )
+
+// summaryNotificationRobotID 是「总结助手」系统 bot 的固定 UID，与 octo-server 的
+// pkg/space.SummaryNotificationBotUID 一致（单一真源在 server 侧）。summary 与 server
+// 共享同一 MySQL `im` 库，这里硬编码该常量字符串用于从 robot 表查 bot_token。
+const summaryNotificationRobotID = "summary_notification"
+
+// resolveSummaryBotToken 解析通知 bot 的 bot_token（OCT-5 / 方案 D：共享 DB）。
+//
+// 优先级：
+//  1. 若 env SUMMARY_BOT_TOKEN（envToken）非空则直接用之（向后兼容旧部署）；
+//  2. 为空才从共享 IM 库查 robot 表。server 首启动时会自动生成强随机 token 写入
+//     该表（见 octo-server modules/robot/api.go ensureSummaryBotToken）。
+//
+// 启动顺序竞态修复：本函数现在作为 HTTPDeliverer 的 lazy tokenFn 使用，在每次投递前
+// 被调用（带非空值缓存），不再在启动时用其返回值决定 disable。拿到空（未生成 /
+// 表无行）返回 error，让本次投递失败走既有 best-effort，下次再查；不 panic。
+//
+// imDB 为 nil 防护：imDB==nil 时直接返回空 + error，不解引空指针 panic。
+func resolveSummaryBotToken(envToken string, imDB *gorm.DB) (string, error) {
+	if envToken != "" {
+		return envToken, nil
+	}
+	if imDB == nil {
+		return "", fmt.Errorf("resolveSummaryBotToken: imDB is nil and env SUMMARY_BOT_TOKEN empty")
+	}
+	var token string
+	// 参照 main.go SetUserNameResolver 里的 imDB.Raw(...).Scan(...) 用法。
+	if err := imDB.Raw("SELECT bot_token FROM robot WHERE robot_id = ? LIMIT 1", summaryNotificationRobotID).Scan(&token).Error; err != nil {
+		return "", fmt.Errorf("resolveSummaryBotToken: query robot.bot_token: %w", err)
+	}
+	return token, nil
+}
 
 func main() {
 	cfg := config.Load()
@@ -96,18 +130,30 @@ func main() {
 	// OnTaskTerminal a no-op, so it is always safe to wire.
 	var notifier *notify.Notifier
 	if cfg.NotifyEnabled {
-		if cfg.OctoAPIURL == "" || cfg.SummaryBotToken == "" {
-			log.Printf("[worker] SUMMARY_NOTIFY_ENABLED=true but OCTO_API_URL / SUMMARY_BOT_TOKEN missing; notifications disabled")
+		// OCT-5 / 方案 D（共享 DB）+ 启动顺序竞态修复：bot_token 不再靠 env 写死/注入，
+		// 也不再在启动时一次性固化。server 首启动时自动生成强随机 token 写入共享 IM 库的
+		// robot 表；summary 这边优先用 env SUMMARY_BOT_TOKEN（向后兼容），为空才从 IM 库查。
+		//
+		// 关键：OCTO_API_URL 非空时总是装配 notifier，不再因启动时 token 空而 disable。
+		// token 改为 HTTPDeliverer 首次投递时 lazy 解析 + 缓存；若 worker 先于 server 起，
+		// 启动时拿不到 token 也不再永久禁用，server 后写了 token 后后续投递自动恢复。
+		if cfg.OctoAPIURL == "" {
+			log.Printf("[worker] SUMMARY_NOTIFY_ENABLED=true but OCTO_API_URL missing; notifications disabled")
 		} else {
-			deliverer := notify.NewHTTPDeliverer(cfg.OctoAPIURL, cfg.SummaryBotToken)
-			notifier = notify.New(summaryDB, deliverer, notify.Config{
+			tokenFn := func() (string, error) {
+				return resolveSummaryBotToken(cfg.SummaryBotToken, imDB)
+			}
+			deliverer := notify.NewHTTPDelivererWithTokenFunc(cfg.OctoAPIURL, tokenFn)
+			// imDB（共享 IM 库）注入用于在通知文本中解析空间名（只读查 space 表）；
+			// imDB 为 nil / 查不到时 buildText 优雅降级回不带空间名的旧文案。
+			notifier = notify.New(summaryDB, imDB, deliverer, notify.Config{
 				Enabled:     true,
 				WebBaseURL:  cfg.SummaryWebBaseURL,
 				MaxAttempts: cfg.MaxNotifyAttempts,
 				QuietStart:  cfg.NotifyQuietStart,
 				QuietEnd:    cfg.NotifyQuietEnd,
 			})
-			log.Printf("[worker] terminal-state notifications ENABLED")
+			log.Printf("[worker] terminal-state notifications ENABLED (bot token resolved lazily on first delivery; survives server-started-after-worker race)")
 		}
 	}
 

--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -152,7 +152,7 @@ func main() {
 				MaxAttempts: cfg.MaxNotifyAttempts,
 				QuietStart:  cfg.NotifyQuietStart,
 				QuietEnd:    cfg.NotifyQuietEnd,
-			})
+			}).WithErrorSanitizer(worker.SanitizeErrorForUser)
 			log.Printf("[worker] terminal-state notifications ENABLED (bot token resolved lazily on first delivery; survives server-started-after-worker race)")
 		}
 	}

--- a/internal/api/handler/regenerate_test.go
+++ b/internal/api/handler/regenerate_test.go
@@ -32,6 +32,7 @@ func setupRegenerateDB(t *testing.T) *gorm.DB {
 		&model.PersonalResult{},
 		&model.SummaryResult{},
 		&model.SummaryChunk{},
+		&model.SummaryNotification{},
 	)
 	return db
 }
@@ -101,6 +102,16 @@ func seedCompletedTask(t *testing.T, db *gorm.DB) (taskID int64, participantID i
 		ChunkIndex:   0,
 		ChunkSummary: "old chunk",
 		TokenUsed:    50,
+	})
+
+	// Prior terminal-state notification rows: a 'sent' completed row that would
+	// otherwise survive Regenerate and silently suppress the re-run's delivery.
+	db.Create(&model.SummaryNotification{
+		TaskID:       task.ID,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "creator1",
+		Status:       model.NotifyStatusSent,
+		SentAt:       &now,
 	})
 
 	return task.ID, participant.ID, pr.ID
@@ -193,6 +204,13 @@ func TestRegenerate_ResetsAllAssociatedData(t *testing.T) {
 	db.Model(&model.SummaryChunk{}).Where("task_id = ?", taskID).Count(&chunkCount)
 	if chunkCount != 0 {
 		t.Errorf("summary_chunk count: want 0, got %d", chunkCount)
+	}
+
+	// Verify SummaryNotification cleared (re-arms delivery for the re-run).
+	var notifCount int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", taskID).Count(&notifCount)
+	if notifCount != 0 {
+		t.Errorf("summary_notification count: want 0, got %d", notifCount)
 	}
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -971,6 +971,11 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		}).Error; err != nil {
 			return err
 		}
+		// Regenerate must re-arm notification delivery: clear all prior rows so
+		// OnTaskTerminal re-claims fresh instead of hitting sent/failed dedup rows.
+		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryNotification{}).Error; err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,10 +119,6 @@ type Config struct {
 	// against octo-server. SECRET: read from env only, never printed/logged and
 	// never written to summary_notification.last_error.
 	SummaryBotToken string
-	// SummaryWebBaseURL is the base URL used to build the result link in a
-	// success notification (e.g. https://host/summary/<task_no>). When empty the
-	// success notification omits the link.
-	SummaryWebBaseURL string
 	// MaxNotifyAttempts caps same-row retries for a single (task_id, notify_kind)
 	// notification before it is left in status='failed'. Default 3.
 	MaxNotifyAttempts int
@@ -200,7 +196,6 @@ func Load() *Config {
 
 		NotifyEnabled:     envBool("SUMMARY_NOTIFY_ENABLED", false),
 		SummaryBotToken:   envStr("SUMMARY_BOT_TOKEN", ""),
-		SummaryWebBaseURL: envStr("SUMMARY_WEB_BASE_URL", ""),
 		MaxNotifyAttempts: envInt("MAX_NOTIFY_ATTEMPTS", 3),
 		NotifyQuietStart:  envStr("SUMMARY_NOTIFY_QUIET_START", ""),
 		NotifyQuietEnd:    envStr("SUMMARY_NOTIFY_QUIET_END", ""),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	CharsPerTokenCJK          int
 	CharsPerTokenASCII        int
 
-	// Worker trigger URL (API → Worker)
+	// Worker trigger URL (API -> Worker)
 	WorkerTriggerURL string
 
 	// Candidate search query limit (-1 = no limit, >0 = use as SQL LIMIT)
@@ -108,6 +108,30 @@ type Config struct {
 	SkipMapReduceThreshold int    // Skip Map-Reduce threshold (tokens), env SKIP_MAP_REDUCE_THRESHOLD
 	KimiAPIKey             string // Kimi API key for exact token counting, env KIMI_API_KEY
 	TokenizerHTTPTimeout   int    // HTTP timeout for tokenizer API calls, env TOKENIZER_HTTP_TIMEOUT
+
+	// --- OCT-4 task-terminal notification (delivery to the IM bot) ---
+
+	// NotifyEnabled is the master switch for delivering a terminal-state
+	// notification (Completed / Failed) back to the task creator via the IM bot.
+	// Default OFF so the feature can be dark-launched.
+	NotifyEnabled bool
+	// SummaryBotToken authenticates the bot sendMessage / ensureFriend calls
+	// against octo-server. SECRET: read from env only, never printed/logged and
+	// never written to summary_notification.last_error.
+	SummaryBotToken string
+	// SummaryWebBaseURL is the base URL used to build the result link in a
+	// success notification (e.g. https://host/summary/<task_no>). When empty the
+	// success notification omits the link.
+	SummaryWebBaseURL string
+	// MaxNotifyAttempts caps same-row retries for a single (task_id, notify_kind)
+	// notification before it is left in status='failed'. Default 3.
+	MaxNotifyAttempts int
+	// NotifyQuietStart / NotifyQuietEnd define an optional quiet window
+	// ("HH:MM"). When both are set the window SUPPRESSES scheduled-task
+	// notifications only (on-demand/manual tasks are never suppressed). Empty =
+	// disabled (default).
+	NotifyQuietStart string
+	NotifyQuietEnd   string
 }
 
 func Load() *Config {
@@ -162,6 +186,7 @@ func Load() *Config {
 
 		ToolCallTimeout: envInt("TOOL_CALL_TIMEOUT", 30),
 
+		// keep upstream main default (true, #112)
 		FeatureTeamSchedule: envBool("FEATURE_TEAM_SCHEDULE", true),
 
 		EnableIntentShortcut: envBool("ENABLE_INTENT_SHORTCUT", true),
@@ -172,6 +197,13 @@ func Load() *Config {
 		SkipMapReduceThreshold: envInt("SKIP_MAP_REDUCE_THRESHOLD", 0),
 		KimiAPIKey:             envStr("KIMI_API_KEY", ""),
 		TokenizerHTTPTimeout:   envInt("TOKENIZER_HTTP_TIMEOUT", 10),
+
+		NotifyEnabled:     envBool("SUMMARY_NOTIFY_ENABLED", false),
+		SummaryBotToken:   envStr("SUMMARY_BOT_TOKEN", ""),
+		SummaryWebBaseURL: envStr("SUMMARY_WEB_BASE_URL", ""),
+		MaxNotifyAttempts: envInt("MAX_NOTIFY_ATTEMPTS", 3),
+		NotifyQuietStart:  envStr("SUMMARY_NOTIFY_QUIET_START", ""),
+		NotifyQuietEnd:    envStr("SUMMARY_NOTIFY_QUIET_END", ""),
 	}
 }
 

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -1,0 +1,38 @@
+package model
+
+import "time"
+
+// Notification kind constants (summary_notification.notify_kind).
+// Leader 拍板选 A：failed/completed 各发一次（UNIQUE(task_id, notify_kind)）。
+const (
+	NotifyKindCompleted = "completed"
+	NotifyKindFailed    = "failed"
+)
+
+// Notification status constants (summary_notification.status).
+const (
+	NotifyStatusPending = "pending" // 抢占式插入后的初始态
+	NotifyStatusSent    = "sent"    // 投递成功（HTTP 2xx）
+	NotifyStatusFailed  = "failed"  // 重试耗尽，终态失败
+)
+
+// SummaryNotification is the dedup / idempotency state machine row for a single
+// terminal-state notification. It lives in the summary DB (never the IM DB).
+//
+// The UNIQUE(task_id, notify_kind) key is the preemptive-insert lock: the first
+// writer INSERTs status='pending' and wins; a duplicate-key error means another
+// run already owns this (task, kind) so the current run skips. A row is NEVER
+// DELETEd — failed deliveries stay as status='failed' with last_error for audit.
+type SummaryNotification struct {
+	ID           int64      `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID       int64      `gorm:"column:task_id;not null;uniqueIndex:uk_task_kind,priority:1" json:"task_id"`
+	NotifyKind   string     `gorm:"column:notify_kind;type:varchar(16);not null;uniqueIndex:uk_task_kind,priority:2" json:"notify_kind"`
+	Status       string     `gorm:"column:status;type:varchar(16);not null;default:'pending'" json:"status"`
+	AttemptCount int        `gorm:"column:attempt_count;not null;default:0" json:"attempt_count"`
+	LastError    *string    `gorm:"column:last_error;type:varchar(500)" json:"last_error"`
+	CreatedAt    time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt    time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+	SentAt       *time.Time `gorm:"column:sent_at" json:"sent_at"`
+}
+
+func (SummaryNotification) TableName() string { return "summary_notification" }

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -19,14 +19,17 @@ const (
 // SummaryNotification is the dedup / idempotency state machine row for a single
 // terminal-state notification. It lives in the summary DB (never the IM DB).
 //
-// The UNIQUE(task_id, notify_kind) key is the preemptive-insert lock: the first
-// writer INSERTs status='pending' and wins; a duplicate-key error means another
-// run already owns this (task, kind) so the current run skips. A row is NEVER
+// The UNIQUE(task_id, notify_kind, recipient_uid) key is the per-recipient
+// preemptive-insert lock: the first writer INSERTs status='pending' for a given
+// (task, kind, uid) and wins; a duplicate-key error means that recipient is
+// already owned so the current run skips it. by-person tasks fan out to one row
+// per recipient, so each person is deduped/retried independently. A row is NEVER
 // DELETEd — failed deliveries stay as status='failed' with last_error for audit.
 type SummaryNotification struct {
 	ID           int64      `gorm:"primaryKey;autoIncrement" json:"id"`
-	TaskID       int64      `gorm:"column:task_id;not null;uniqueIndex:uk_task_kind,priority:1" json:"task_id"`
-	NotifyKind   string     `gorm:"column:notify_kind;type:varchar(16);not null;uniqueIndex:uk_task_kind,priority:2" json:"notify_kind"`
+	TaskID       int64      `gorm:"column:task_id;not null;uniqueIndex:uk_task_kind_uid,priority:1" json:"task_id"`
+	NotifyKind   string     `gorm:"column:notify_kind;type:varchar(16);not null;uniqueIndex:uk_task_kind_uid,priority:2" json:"notify_kind"`
+	RecipientUID string     `gorm:"column:recipient_uid;type:varchar(64);not null;default:'';uniqueIndex:uk_task_kind_uid,priority:3" json:"recipient_uid"`
 	Status       string     `gorm:"column:status;type:varchar(16);not null;default:'pending'" json:"status"`
 	AttemptCount int        `gorm:"column:attempt_count;not null;default:0" json:"attempt_count"`
 	LastError    *string    `gorm:"column:last_error;type:varchar(500)" json:"last_error"`

--- a/internal/notify/client.go
+++ b/internal/notify/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,7 +35,19 @@ type Deliverer interface {
 	// ensureFriend whitelist side — sendMessage.channel_id stays a bare uid.
 	EnsureFriend(ctx context.Context, spaceID, targetUID string) error
 	// SendMessage posts a bot message to the resolved channel.
-	SendMessage(ctx context.Context, msg SendMessageRequest) error
+	//
+	// spaceID (SummaryTask.SpaceID) is required so octo-server can inject the
+	// authoritative payload.space_id for a system-bot DM. octo-server
+	// fail-closes on system-bot DMs: it STRIPS any client-supplied
+	// payload.space_id and instead trusts only the value it resolves itself.
+	// The single worker-controllable input on that resolution path is the
+	// HTTP request header `X-Space-ID`: for a system-bot DM, when
+	// CheckMembership(spaceID, recipientUID)=true (the recipient is an active
+	// member of the space — the case here), octo-server adopts the header and
+	// uses it to inject the authoritative payload.space_id. Without the header
+	// the message is filtered out / unopenable. The header is only attached
+	// when spaceID is non-empty (empty → no header, preserving compatibility).
+	SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error
 }
 
 // SendMessageRequest is the body of POST {OCTO_API_URL}/v1/bot/sendMessage.
@@ -66,20 +79,76 @@ func payloadHasOBOReserved(payload map[string]any) bool {
 }
 
 // HTTPDeliverer is the production Deliverer talking to octo-server's bot API.
+//
+// 启动顺序竞态修复（OCT-5 / 方案 D）：token 不再在构造时固化。容器编排不保证
+// summary-worker 与 octo-server 的启动先后；若 worker 先起、server 尚未
+// ensureSummaryBotToken 写库，启动时查库会拿到空 token。旧实现会就此把 notifier
+// 永久 disable，即便 server 之后写了 token 也不恢复，必须人工重启 worker。
+//
+// 现在 HTTPDeliverer 持有一个 tokenFn（token provider），在每次投递前 lazy 解析
+// token，并把「首次拿到的非空 token」缓存住（见 cachedToken）。空值不缓存，下次
+// 再查，因此 server 晚起后写了 token，worker 能在后续投递中自动恢复，无需重启。
 type HTTPDeliverer struct {
 	baseURL string
-	token   string
+	tokenFn func() (string, error)
 	client  *http.Client
+
+	// token 缓存：只缓存「非空成功值」。一旦缓存命中即不再调用 tokenFn。
+	cacheMu     sync.RWMutex
+	cachedToken string
 }
 
-// NewHTTPDeliverer builds a Deliverer. token is the SUMMARY_BOT_TOKEN secret —
-// it is stored only in memory and only ever placed in the Authorization header.
+// NewHTTPDeliverer builds a Deliverer from a fixed token. token is the
+// SUMMARY_BOT_TOKEN secret — it is stored only in memory and only ever placed in
+// the Authorization header.
+//
+// 向后兼容：保留旧签名。内部包成一个返回固定 token 的 tokenFn。固定 token 为空时
+// 仍会在投递时报错（best-effort 失败处理吞掉），不再 panic、不会永久禁用。
 func NewHTTPDeliverer(baseURL, token string) *HTTPDeliverer {
+	return NewHTTPDelivererWithTokenFunc(baseURL, func() (string, error) {
+		return token, nil
+	})
+}
+
+// NewHTTPDelivererWithTokenFunc builds a Deliverer that lazily resolves the bot
+// token via tokenFn on each post (with non-empty-value caching). This is the
+// path that survives the startup-order race: assemble the notifier even when the
+// token is not yet available, and let it resolve once octo-server has written it
+// into the shared IM DB.
+func NewHTTPDelivererWithTokenFunc(baseURL string, tokenFn func() (string, error)) *HTTPDeliverer {
 	return &HTTPDeliverer{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		token:   token,
+		tokenFn: tokenFn,
 		client:  &http.Client{Timeout: 10 * time.Second},
 	}
+}
+
+// resolveToken returns the bot token, preferring the cached non-empty value and
+// otherwise invoking tokenFn. A non-empty success is cached; empty values and
+// errors are NOT cached so a late-starting server can still be picked up later.
+func (d *HTTPDeliverer) resolveToken() (string, error) {
+	d.cacheMu.RLock()
+	cached := d.cachedToken
+	d.cacheMu.RUnlock()
+	if cached != "" {
+		return cached, nil
+	}
+
+	if d.tokenFn == nil {
+		return "", fmt.Errorf("no bot token provider configured")
+	}
+	token, err := d.tokenFn()
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", fmt.Errorf("bot token unavailable (empty); not yet provisioned by octo-server")
+	}
+
+	d.cacheMu.Lock()
+	d.cachedToken = token
+	d.cacheMu.Unlock()
+	return token, nil
 }
 
 func (d *HTTPDeliverer) EnsureFriend(ctx context.Context, spaceID, targetUID string) error {
@@ -87,18 +156,37 @@ func (d *HTTPDeliverer) EnsureFriend(ctx context.Context, spaceID, targetUID str
 		"target_uid": targetUID,
 		"space_id":   spaceID,
 	}
-	return d.post(ctx, "/v1/bot/ensureFriend", body)
+	// octo-server resolves the authoritative space from the X-Space-ID header
+	// for a system bot; attach it (only when known) so ensureFriend builds the
+	// space-scoped whitelist against the same authoritative space as the send.
+	return d.post(ctx, "/v1/bot/ensureFriend", body, spaceHeader(spaceID))
 }
 
-func (d *HTTPDeliverer) SendMessage(ctx context.Context, msg SendMessageRequest) error {
+func (d *HTTPDeliverer) SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error {
 	if payloadHasOBOReserved(msg.Payload) {
 		// Defensive: never let an OBO reserved field leak into a bot message.
 		return fmt.Errorf("sendMessage payload contains forbidden OBO reserved field")
 	}
-	return d.post(ctx, "/v1/bot/sendMessage", msg)
+	// octo-server STRIPS client payload.space_id for a system-bot DM and trusts
+	// only the value it resolves from the X-Space-ID header (adopted when the
+	// recipient is an active member of that space). Attach the header — without
+	// it the message is filtered out. Only when spaceID is non-empty.
+	return d.post(ctx, "/v1/bot/sendMessage", msg, spaceHeader(spaceID))
 }
 
-func (d *HTTPDeliverer) post(ctx context.Context, path string, body any) error {
+// spaceHeader returns the X-Space-ID header map for a non-empty (trimmed)
+// spaceID, or nil when empty so post attaches no header (compat with the
+// empty-SpaceID path). octo-server TrimSpace's the value, but we also avoid
+// introducing any surrounding whitespace ourselves.
+func spaceHeader(spaceID string) map[string]string {
+	spaceID = strings.TrimSpace(spaceID)
+	if spaceID == "" {
+		return nil
+	}
+	return map[string]string{"X-Space-ID": spaceID}
+}
+
+func (d *HTTPDeliverer) post(ctx context.Context, path string, body any, headers map[string]string) error {
 	raw, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("marshal %s body: %w", path, err)
@@ -107,8 +195,19 @@ func (d *HTTPDeliverer) post(ctx context.Context, path string, body any) error {
 	if err != nil {
 		return fmt.Errorf("build %s request: %w", path, err)
 	}
+	token, err := d.resolveToken()
+	if err != nil {
+		// Lazy resolve failed (token not yet provisioned by octo-server). Fail
+		// this delivery so the existing best-effort failure handling kicks in;
+		// do NOT panic and do NOT permanently disable the notifier — a later
+		// post will retry resolution and recover once the server writes it.
+		return fmt.Errorf("%s: resolve bot token: %w", path, err)
+	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+d.token)
+	req.Header.Set("Authorization", "Bearer "+token)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := d.client.Do(req)
 	if err != nil {

--- a/internal/notify/client.go
+++ b/internal/notify/client.go
@@ -1,0 +1,127 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Channel type values on the IM-bot wire protocol (sendMessage.channel_type).
+// These are the octo-server bot API values, NOT model.OriginChannel* — see
+// resolveTarget for the mapping. 1=DM, 2=Group, 5=Thread.
+const (
+	WireChannelDM     = 1
+	WireChannelGroup  = 2
+	WireChannelThread = 5
+)
+
+// Deliverer is the bot-side transport: establish the bot<->user relationship and
+// post a message. It is an interface so the trigger/state-machine logic can be
+// unit-tested without a live octo-server (联调阶段对齐真实契约).
+type Deliverer interface {
+	// EnsureFriend establishes the bot<->user relationship so a DM is deliverable.
+	// Idempotent; must be a no-op error when already friends. Called BEFORE send.
+	//
+	// spaceID (SummaryTask.SpaceID) is required so octo-server can build the
+	// space-prefixed IM whitelist channel (s{spaceID}_{uid}); under multi-Space
+	// deployments the whitelist is attached to the space-prefixed channel,
+	// otherwise the DM is silently dropped. The space prefix is used ONLY on the
+	// ensureFriend whitelist side — sendMessage.channel_id stays a bare uid.
+	EnsureFriend(ctx context.Context, spaceID, targetUID string) error
+	// SendMessage posts a bot message to the resolved channel.
+	SendMessage(ctx context.Context, msg SendMessageRequest) error
+}
+
+// SendMessageRequest is the body of POST {OCTO_API_URL}/v1/bot/sendMessage.
+// The payload carries ONLY text (+ result link / failure reason already folded
+// into text by the caller). It MUST NOT carry any OBO reserved fields
+// (__obo_*/obo_*/actual_sender_uid) — this is a first-class bot message.
+type SendMessageRequest struct {
+	ChannelID   string         `json:"channel_id"`
+	ChannelType int            `json:"channel_type"`
+	Payload     map[string]any `json:"payload"`
+}
+
+// oboReservedKeys are the OBO markers that must never appear in a bot payload.
+var oboReservedKeys = map[string]struct{}{
+	"actual_sender_uid": {},
+}
+
+func payloadHasOBOReserved(payload map[string]any) bool {
+	for k := range payload {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "__obo_") || strings.HasPrefix(lk, "obo_") {
+			return true
+		}
+		if _, ok := oboReservedKeys[lk]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// HTTPDeliverer is the production Deliverer talking to octo-server's bot API.
+type HTTPDeliverer struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+// NewHTTPDeliverer builds a Deliverer. token is the SUMMARY_BOT_TOKEN secret —
+// it is stored only in memory and only ever placed in the Authorization header.
+func NewHTTPDeliverer(baseURL, token string) *HTTPDeliverer {
+	return &HTTPDeliverer{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (d *HTTPDeliverer) EnsureFriend(ctx context.Context, spaceID, targetUID string) error {
+	body := map[string]string{
+		"target_uid": targetUID,
+		"space_id":   spaceID,
+	}
+	return d.post(ctx, "/v1/bot/ensureFriend", body)
+}
+
+func (d *HTTPDeliverer) SendMessage(ctx context.Context, msg SendMessageRequest) error {
+	if payloadHasOBOReserved(msg.Payload) {
+		// Defensive: never let an OBO reserved field leak into a bot message.
+		return fmt.Errorf("sendMessage payload contains forbidden OBO reserved field")
+	}
+	return d.post(ctx, "/v1/bot/sendMessage", msg)
+}
+
+func (d *HTTPDeliverer) post(ctx context.Context, path string, body any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal %s body: %w", path, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+d.token)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		// Never include req body / token in the error.
+		return fmt.Errorf("%s request failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	// Read a bounded slice of the response for diagnostics; the token lives only
+	// in the request header and is never echoed back, so this snippet is safe.
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return fmt.Errorf("%s returned HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(snippet)))
+}

--- a/internal/notify/client.go
+++ b/internal/notify/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,14 @@ import (
 	"sync"
 	"time"
 )
+
+// ErrTokenNotYetProvisioned marks the narrow startup-race case where the bot
+// token row is not yet written by octo-server. Callers use errors.Is on the
+// wrapped chain to divert delivery into a no-budget-consumed retry path
+// (see Notifier.markDeferred) instead of counting it as a normal HTTP failure.
+// Any other tokenFn error (real DB failure, etc.) is deliberately NOT this
+// sentinel and follows the standard failure/attempt_count accounting.
+var ErrTokenNotYetProvisioned = errors.New("bot token not yet provisioned")
 
 // Channel type values on the IM-bot wire protocol (sendMessage.channel_type).
 // These are the octo-server bot API values, NOT model.OriginChannel* — see
@@ -142,7 +151,9 @@ func (d *HTTPDeliverer) resolveToken() (string, error) {
 		return "", err
 	}
 	if token == "" {
-		return "", fmt.Errorf("bot token unavailable (empty); not yet provisioned by octo-server")
+		// Sentinel-wrapped so upstream can errors.Is this specific startup-race
+		// case and retry without consuming attempt budget (markDeferred).
+		return "", fmt.Errorf("bot token unavailable (empty); not yet provisioned by octo-server: %w", ErrTokenNotYetProvisioned)
 	}
 
 	d.cacheMu.Lock()

--- a/internal/notify/dupkey.go
+++ b/internal/notify/dupkey.go
@@ -1,0 +1,37 @@
+package notify
+
+import (
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// isDuplicateKey reports whether err is a unique-constraint violation on the
+// summary_notification UNIQUE(task_id, notify_kind) key. It is driver-agnostic:
+//   - gorm v2 surfaces gorm.ErrDuplicatedKey for known drivers;
+//   - MySQL (go-sql-driver) reports "Error 1062" / "Duplicate entry";
+//   - SQLite (used by the unit tests) reports "UNIQUE constraint failed".
+//
+// We match all three so the preemptive-insert dedup works in prod and in tests.
+func isDuplicateKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "duplicate entry"):
+		return true
+	case strings.Contains(msg, "error 1062"):
+		return true
+	case strings.Contains(msg, "unique constraint failed"):
+		return true
+	case strings.Contains(msg, "constraint failed: unique"):
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -236,10 +237,7 @@ func (n *Notifier) markSent(taskID int64, kind string) {
 
 func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
 	now := n.now()
-	le := sanitize(cause.Error())
-	if len(le) > 480 {
-		le = le[:480]
-	}
+	le := truncateForLastError(sanitize(cause.Error()))
 	if err := n.db.Model(&model.SummaryNotification{}).
 		Where("task_id = ? AND notify_kind = ?", taskID, kind).
 		Updates(map[string]any{
@@ -344,6 +342,179 @@ func atoiBounded(s string, lo, hi int) (int, error) {
 		return 0, errors.New("out of range")
 	}
 	return n, nil
+}
+
+// SweepInterval is the recommended cron cadence for Notifier.Sweep. Exposed
+// so callers (cmd/summary-worker) don't have to pick a magic interval.
+const SweepInterval = 60 * time.Second
+
+// PendingLease is how long a 'pending' row may sit without progress before
+// Sweep reclaims it. The worker's synchronous delivery path uses a 15s HTTP
+// timeout (see deliver), so anything over ~1 min must mean the worker crashed
+// between claim and markSent/markFailed, OR markFailed itself failed (e.g.
+// the byte-truncation utf8 wedge that truncateForLastError now prevents — kept
+// as belt-and-suspenders for any other write error).
+const PendingLease = 5 * time.Minute
+
+// sweepBatchSize caps how many candidate rows Sweep handles per tick so a
+// degraded octo-server cannot pile up a single sweep beyond the cron cadence.
+const sweepBatchSize = 50
+
+// Sweep is the background recovery pass invoked by the scheduler cron. It
+// looks for two classes of rows that the synchronous worker path cannot
+// recover on its own:
+//
+//   - status='failed' AND attempt_count<MaxAttempts: a transient delivery
+//     blip dropped the message; retry budget remains but no fresh
+//     OnTaskTerminal hook will fire on its own (terminal callbacks are
+//     one-shot per task transition). Without this sweep, MaxAttempts is
+//     effectively 1 for the common path.
+//   - status='pending' AND updated_at<now-PendingLease: a worker crashed (or
+//     a write failed) between claim and the markSent/markFailed write.
+//     Without this sweep the row would sit at 'pending' forever and the
+//     dedup claim would keep skipping the (task, kind) pair.
+//
+// Both branches use the existing atomic CAS (claimRetry / claimPending) so a
+// concurrent OnTaskTerminal cannot double-send: only the runner whose UPDATE
+// flips the row to pending (RowsAffected==1) proceeds.
+//
+// Sweep is best-effort: any per-row error is logged and the loop continues.
+// It is safe to call when the notifier is disabled (returns immediately).
+func (n *Notifier) Sweep(ctx context.Context) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+	n.sweepRetryFailed(ctx)
+	n.sweepStalePending(ctx)
+}
+
+// sweepRetryFailed re-attempts delivery for rows stuck at status='failed'
+// with retry budget remaining.
+func (n *Notifier) sweepRetryFailed(ctx context.Context) {
+	var rows []model.SummaryNotification
+	if err := n.db.
+		Where("status = ? AND attempt_count < ?", model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Order("updated_at ASC").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		log.Printf("[notify] sweep: query failed rows: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		won, err := n.claimRetry(row.TaskID, row.NotifyKind)
+		if err != nil {
+			log.Printf("[notify] sweep: task=%d kind=%s claimRetry: %v", row.TaskID, row.NotifyKind, err)
+			continue
+		}
+		if !won {
+			continue // another runner won, or budget exhausted concurrently
+		}
+		n.redeliver(row.TaskID, row.NotifyKind)
+	}
+}
+
+// sweepStalePending reclaims rows stuck at status='pending' past the lease
+// (worker died or a write step failed between claim and markSent/markFailed).
+func (n *Notifier) sweepStalePending(ctx context.Context) {
+	cutoff := n.now().Add(-PendingLease)
+	var rows []model.SummaryNotification
+	if err := n.db.
+		Where("status = ? AND updated_at < ? AND attempt_count < ?",
+			model.NotifyStatusPending, cutoff, n.cfg.MaxAttempts).
+		Order("updated_at ASC").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		log.Printf("[notify] sweep: query pending rows: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		won, err := n.claimStalePending(row.TaskID, row.NotifyKind, cutoff)
+		if err != nil {
+			log.Printf("[notify] sweep: task=%d kind=%s claimStalePending: %v", row.TaskID, row.NotifyKind, err)
+			continue
+		}
+		if !won {
+			continue
+		}
+		log.Printf("[notify] sweep: reclaimed stale pending row task=%d kind=%s", row.TaskID, row.NotifyKind)
+		n.redeliver(row.TaskID, row.NotifyKind)
+	}
+}
+
+// claimStalePending atomically refreshes a stale 'pending' row's updated_at
+// so exactly one sweeper wins the right to redeliver it. Guarded on
+// status='pending' AND updated_at<cutoff so concurrent sweepers race and only
+// the row flipped by RowsAffected==1 proceeds.
+func (n *Notifier) claimStalePending(taskID int64, kind string, cutoff time.Time) (bool, error) {
+	now := n.now()
+	res := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ? AND updated_at < ?",
+			taskID, kind, model.NotifyStatusPending, cutoff).
+		Update("updated_at", now)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// redeliver performs one delivery attempt for a row whose retry slot we just
+// won (claimRetry or claimStalePending). It reloads the SummaryTask so the
+// message reflects the durable terminal-state row, then mirrors the
+// build+deliver+persist sequence from OnTaskTerminal. Any failure persists
+// via markFailed and is left for the next sweep tick or until budget runs out.
+func (n *Notifier) redeliver(taskID int64, kind string) {
+	var task model.SummaryTask
+	if err := n.db.First(&task, taskID).Error; err != nil {
+		// Task row gone (extremely unusual: rows are never deleted in the
+		// happy path). Treat as a permanent delivery failure so attempt_count
+		// advances and the row eventually leaves the retry set.
+		n.markFailed(taskID, kind, fmt.Errorf("reload task %d: %w", taskID, err))
+		return
+	}
+	target, ok := resolveTarget(task)
+	if !ok {
+		n.markFailed(taskID, kind, errors.New("no deliverable target on reload"))
+		return
+	}
+	errMsg := ""
+	if task.ErrorMessage != nil {
+		errMsg = *task.ErrorMessage
+	}
+	text := n.buildText(task, kind, errMsg)
+	if deliverErr := n.deliver(target, text); deliverErr != nil {
+		n.markFailed(taskID, kind, deliverErr)
+		log.Printf("[notify] sweep: task=%d kind=%s delivery failed: %v", taskID, kind, sanitize(deliverErr.Error()))
+		return
+	}
+	n.markSent(taskID, kind)
+	log.Printf("[notify] sweep: task=%d kind=%s delivered via retry", taskID, kind)
+}
+
+// truncateForLastError caps an error string for the VARCHAR(500) last_error
+// column. It enforces both a byte cap (≤480 bytes, leaving utf8mb4 headroom)
+// AND a rune boundary so a multi-byte codepoint is never sliced through the
+// middle — MySQL strict mode rejects invalid UTF-8 with Error 1366, which
+// would leave the notification row stuck in 'pending' (no sweep / no retry).
+func truncateForLastError(s string) string {
+	const maxBytes = 480
+	if len(s) <= maxBytes {
+		return s
+	}
+	s = s[:maxBytes]
+	// Back off until the tail is a valid UTF-8 sequence. utf8.ValidString runs
+	// over the whole string, but the only way a prefix becomes invalid is a
+	// truncated trailing rune (at most 3 bytes for utf8mb4-safe runes), so this
+	// loop terminates in ≤3 iterations.
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 // sanitize strips any accidental Bearer token / Authorization material from an

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -101,10 +101,23 @@ func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg str
 		return
 	}
 	if !claimed {
-		// Either another run owns it, or it is already sent / exhausted.
+		// First-delivery is serialized by the unique INSERT, but the retry
+		// decision must ALSO be atomic: two runners firing in the same tick
+		// (markPersonalFailed notify + scanStuckTasks reload-and-notify on the
+		// same task) would otherwise both read the same failed row, both see
+		// budget remaining, and both deliver, sending duplicate failure DMs.
+		// claimRetry does an atomic CAS UPDATE; only the runner that flips the
+		// row to pending (RowsAffected==1) proceeds, the loser skips.
 		if row != nil && row.Status == model.NotifyStatusFailed && row.AttemptCount < n.cfg.MaxAttempts {
-			// A previous attempt failed but still has retry budget: retry on this row.
-			log.Printf("[notify] task=%d kind=%s: retrying failed row (attempt %d/%d)", task.ID, kind, row.AttemptCount, n.cfg.MaxAttempts)
+			won, e := n.claimRetry(task.ID, kind)
+			if e != nil {
+				log.Printf("[notify] task=%d kind=%s: claimRetry failed: %v", task.ID, kind, e)
+				return
+			}
+			if !won {
+				return
+			}
+			log.Printf("[notify] task=%d kind=%s: retrying failed row (won retry slot)", task.ID, kind)
 		} else {
 			return
 		}
@@ -162,6 +175,26 @@ func (n *Notifier) claim(taskID int64, kind string) (bool, *model.SummaryNotific
 		return false, &existing, nil
 	}
 	return false, nil, err
+}
+
+// claimRetry atomically reclaims a failed (task, kind) row for one more
+// delivery attempt. It flips status failed->pending in a single conditional
+// UPDATE guarded on status=failed AND attempt_count<MaxAttempts, so concurrent
+// runners race on the row and exactly one gets RowsAffected==1. Returns
+// won=true only for that single winner; losers skip to avoid duplicate sends.
+func (n *Notifier) claimRetry(taskID int64, kind string) (bool, error) {
+	now := n.now()
+	res := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ? AND attempt_count < ?",
+			taskID, kind, model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Updates(map[string]any{
+			"status":     model.NotifyStatusPending,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
 }
 
 func (n *Notifier) deliver(target deliveryTarget, text string) error {

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -39,7 +39,6 @@ import (
 // decoupled and trivially testable.
 type Config struct {
 	Enabled     bool
-	WebBaseURL  string
 	MaxAttempts int
 	QuietStart  string // "HH:MM" or ""
 	QuietEnd    string // "HH:MM" or ""
@@ -358,8 +357,25 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 		default:
 			b.WriteString("你的总结已生成完成。")
 		}
-		if link := n.resultLink(task); link != "" {
-			fmt.Fprintf(&b, "\n查看结果：%s", link)
+		// 追加有用的元信息（全部 best-effort，查不到/为零的行直接跳过，绝不阻断通知）：
+		// - 时间范围：本次总结覆盖的聊天区间；
+		// - 参与成员：多人任务的成员数（单人任务无意义，省略）；
+		// - 消息数量：本次总结处理的消息条数；
+		// - 生成时间：结果产出的本地时间。
+		// 之前这里追加的是「查看结果：<link>」外链，但该链接与前端真实入口
+		// （WKApp 内部路由 /summary/detail?taskId=）三重错位、根本打不开，已移除。
+		if tr := formatTimeRange(task); tr != "" {
+			fmt.Fprintf(&b, "\n时间范围：%s", tr)
+		}
+		meta := n.resultMeta(task)
+		if cnt := n.participantCount(task); cnt > 0 {
+			fmt.Fprintf(&b, "\n参与成员：%d 人", cnt)
+		}
+		if meta.msgCount > 0 {
+			fmt.Fprintf(&b, "\n消息数量：%d 条", meta.msgCount)
+		}
+		if !meta.generatedAt.IsZero() {
+			fmt.Fprintf(&b, "\n生成时间：%s", timezone.In(meta.generatedAt).Format("2006-01-02 15:04"))
 		}
 		return b.String()
 	case model.NotifyKindFailed:
@@ -416,12 +432,64 @@ func (n *Notifier) resolveSpaceName(task model.SummaryTask) string {
 }
 
 // resultLink builds the result URL from the configured base. Empty base → no link.
-func (n *Notifier) resultLink(task model.SummaryTask) string {
-	base := strings.TrimRight(strings.TrimSpace(n.cfg.WebBaseURL), "/")
-	if base == "" || task.TaskNo == "" {
+// notifyResultMeta carries the best-effort metadata pulled from summary_result
+// for a completed task's notification text. Zero values mean "unknown / omit".
+type notifyResultMeta struct {
+	generatedAt time.Time
+	msgCount    int
+}
+
+// resultMeta best-effort loads the completed task's summary_result row for the
+// generation time + processed message count shown in the success notification.
+// It degrades gracefully: nil db, query error, or no row all yield the zero
+// value so buildText simply omits those lines. Never panics, never blocks.
+func (n *Notifier) resultMeta(task model.SummaryTask) notifyResultMeta {
+	if n == nil || n.db == nil {
+		return notifyResultMeta{}
+	}
+	var row struct {
+		GeneratedAt   time.Time
+		TotalMsgCount int
+	}
+	// Latest version wins if a result was regenerated. Read-only single row.
+	if err := n.db.Raw(
+		"SELECT generated_at, total_msg_count FROM summary_result WHERE task_id = ? ORDER BY version DESC, id DESC LIMIT 1",
+		task.ID,
+	).Scan(&row).Error; err != nil {
+		log.Printf("[notify] task=%d: resultMeta query failed: %v", task.ID, err)
+		return notifyResultMeta{}
+	}
+	return notifyResultMeta{generatedAt: row.GeneratedAt, msgCount: row.TotalMsgCount}
+}
+
+// participantCount best-effort counts the participants of a by-person task for
+// the "参与成员：N 人" line. Returns 0 (line omitted) for single-person tasks,
+// nil db, or a query error. Read-only; never panics, never blocks.
+func (n *Notifier) participantCount(task model.SummaryTask) int {
+	if n == nil || n.db == nil {
+		return 0
+	}
+	var cnt int64
+	if err := n.db.Raw(
+		"SELECT COUNT(*) FROM summary_participant WHERE task_id = ?",
+		task.ID,
+	).Scan(&cnt).Error; err != nil {
+		log.Printf("[notify] task=%d: participantCount query failed: %v", task.ID, err)
+		return 0
+	}
+	return int(cnt)
+}
+
+// formatTimeRange renders the chat window a summary covers as
+// "YYYY-MM-DD HH:MM ~ YYYY-MM-DD HH:MM" in the local timezone. Returns "" when
+// either bound is zero so buildText omits the line.
+func formatTimeRange(task model.SummaryTask) string {
+	if task.TimeRangeStart.IsZero() || task.TimeRangeEnd.IsZero() {
 		return ""
 	}
-	return base + "/summary/" + task.TaskNo
+	start := timezone.In(task.TimeRangeStart).Format("2006-01-02 15:04")
+	end := timezone.In(task.TimeRangeEnd).Format("2006-01-02 15:04")
+	return start + " ~ " + end
 }
 
 // inQuietWindow reports whether t (Asia/Shanghai) falls inside the configured

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -112,16 +112,49 @@ func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg str
 		return
 	}
 
-	target, ok := resolveTarget(task)
-	if !ok {
+	// completed fans out to every recipient (participants ∪ creator for a
+	// by-person task, else just the creator). failed goes ONLY to the creator to
+	// avoid broadcasting a failure to participants who never asked. Each recipient
+	// runs the claim/deliver/mark state machine on its own (task, kind, uid) row,
+	// so one recipient's failure never blocks another's.
+	var targets []deliveryTarget
+	if kind == model.NotifyKindFailed {
+		if t, ok := n.creatorTarget(task); ok {
+			targets = []deliveryTarget{t}
+		}
+	} else {
+		// A participant-lookup error must NOT degrade to a creator-only "success":
+		// that would fake-deliver to the creator, never build participant rows,
+		// and hide the miss from the sweep. Skip this run and let the next
+		// OnTaskTerminal trigger / sweep retry a full resolve.
+		resolved, err := n.resolveTargets(task)
+		if err != nil {
+			log.Printf("[notify] task=%d kind=%s: resolveTargets failed, skipping (will retry on next trigger/sweep): %v", task.ID, kind, err)
+			return
+		}
+		targets = resolved
+	}
+	if len(targets) == 0 {
 		log.Printf("[notify] task=%d kind=%s: no deliverable target (empty creator), skipping", task.ID, kind)
 		return
 	}
 
-	// 1) Preemptive unique insert — claim the right to deliver this (task, kind).
-	claimed, row, err := n.claim(task.ID, kind)
+	for _, target := range targets {
+		n.deliverToRecipient(task, kind, errMsg, target)
+	}
+}
+
+// deliverToRecipient runs the per-recipient claim/deliver/mark state machine for
+// a single (task, kind, recipient_uid). Extracted from OnTaskTerminal so the
+// by-person fan-out drives it once per recipient; each call is fully independent
+// (its own dedup row, retry budget, and failure handling).
+func (n *Notifier) deliverToRecipient(task model.SummaryTask, kind, errMsg string, target deliveryTarget) {
+	uid := target.TargetUID
+
+	// 1) Preemptive unique insert — claim the right to deliver this (task, kind, uid).
+	claimed, row, err := n.claim(task.ID, kind, uid)
 	if err != nil {
-		log.Printf("[notify] task=%d kind=%s: claim failed: %v", task.ID, kind, err)
+		log.Printf("[notify] task=%d kind=%s uid=%s: claim failed: %v", task.ID, kind, uid, err)
 		return
 	}
 	if !claimed {
@@ -133,15 +166,15 @@ func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg str
 		// claimRetry does an atomic CAS UPDATE; only the runner that flips the
 		// row to pending (RowsAffected==1) proceeds, the loser skips.
 		if row != nil && row.Status == model.NotifyStatusFailed && row.AttemptCount < n.cfg.MaxAttempts {
-			won, e := n.claimRetry(task.ID, kind)
+			won, e := n.claimRetry(task.ID, kind, uid)
 			if e != nil {
-				log.Printf("[notify] task=%d kind=%s: claimRetry failed: %v", task.ID, kind, e)
+				log.Printf("[notify] task=%d kind=%s uid=%s: claimRetry failed: %v", task.ID, kind, uid, e)
 				return
 			}
 			if !won {
 				return
 			}
-			log.Printf("[notify] task=%d kind=%s: retrying failed row (won retry slot)", task.ID, kind)
+			log.Printf("[notify] task=%d kind=%s uid=%s: retrying failed row (won retry slot)", task.ID, kind, uid)
 		} else {
 			return
 		}
@@ -153,18 +186,18 @@ func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg str
 
 	// 3) Persist outcome.
 	if deliverErr == nil {
-		n.markSent(task.ID, kind)
-		log.Printf("[notify] task=%d kind=%s delivered to channel_type=%d", task.ID, kind, target.ChannelType)
+		n.markSent(task.ID, kind, uid)
+		log.Printf("[notify] task=%d kind=%s uid=%s delivered to channel_type=%d", task.ID, kind, uid, target.ChannelType)
 		return
 	}
 	// Startup-race: token 尚未 provisioned。Keep pending 且不消耗 attempt 预算，让下轮 Sweep 立即重试。
 	if errors.Is(deliverErr, ErrTokenNotYetProvisioned) {
-		n.markDeferred(task.ID, kind, deliverErr)
-		log.Printf("[notify] task=%d kind=%s deferred (token not yet provisioned)", task.ID, kind)
+		n.markDeferred(task.ID, kind, uid, deliverErr)
+		log.Printf("[notify] task=%d kind=%s uid=%s deferred (token not yet provisioned)", task.ID, kind, uid)
 		return
 	}
-	n.markFailed(task.ID, kind, deliverErr)
-	log.Printf("[notify] task=%d kind=%s delivery failed: %v", task.ID, kind, sanitize(deliverErr.Error()))
+	n.markFailed(task.ID, kind, uid, deliverErr)
+	log.Printf("[notify] task=%d kind=%s uid=%s delivery failed: %v", task.ID, kind, uid, sanitize(deliverErr.Error()))
 }
 
 func kindForStatus(status int) (string, bool) {
@@ -181,25 +214,26 @@ func kindForStatus(status int) (string, bool) {
 // claim attempts the preemptive INSERT. Returns claimed=true when this run won
 // the (task, kind) slot. When the row already exists, claimed=false and the
 // existing row is returned so the caller can decide whether retry budget remains.
-func (n *Notifier) claim(taskID int64, kind string) (bool, *model.SummaryNotification, error) {
+func (n *Notifier) claim(taskID int64, kind, uid string) (bool, *model.SummaryNotification, error) {
 	now := n.now()
 	row := &model.SummaryNotification{
 		TaskID:       taskID,
 		NotifyKind:   kind,
+		RecipientUID: uid,
 		Status:       model.NotifyStatusPending,
 		AttemptCount: 0,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
-	// Plain Create: the UNIQUE(task_id, notify_kind) constraint rejects a
-	// duplicate with an error we treat as "someone else owns it".
+	// Plain Create: the UNIQUE(task_id, notify_kind, recipient_uid) constraint
+	// rejects a duplicate with an error we treat as "this recipient is owned".
 	err := n.db.Create(row).Error
 	if err == nil {
 		return true, row, nil
 	}
 	if isDuplicateKey(err) {
 		var existing model.SummaryNotification
-		if e := n.db.Where("task_id = ? AND notify_kind = ?", taskID, kind).First(&existing).Error; e != nil {
+		if e := n.db.Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).First(&existing).Error; e != nil {
 			return false, nil, e
 		}
 		return false, &existing, nil
@@ -212,11 +246,11 @@ func (n *Notifier) claim(taskID int64, kind string) (bool, *model.SummaryNotific
 // UPDATE guarded on status=failed AND attempt_count<MaxAttempts, so concurrent
 // runners race on the row and exactly one gets RowsAffected==1. Returns
 // won=true only for that single winner; losers skip to avoid duplicate sends.
-func (n *Notifier) claimRetry(taskID int64, kind string) (bool, error) {
+func (n *Notifier) claimRetry(taskID int64, kind, uid string) (bool, error) {
 	now := n.now()
 	res := n.db.Model(&model.SummaryNotification{}).
-		Where("task_id = ? AND notify_kind = ? AND status = ? AND attempt_count < ?",
-			taskID, kind, model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ? AND status = ? AND attempt_count < ?",
+			taskID, kind, uid, model.NotifyStatusFailed, n.cfg.MaxAttempts).
 		Updates(map[string]any{
 			"status":     model.NotifyStatusPending,
 			"updated_at": now,
@@ -314,10 +348,10 @@ func (n *Notifier) recipientIsActiveMember(taskID uint, spaceID, uid string) boo
 	return count > 0
 }
 
-func (n *Notifier) markSent(taskID int64, kind string) {
+func (n *Notifier) markSent(taskID int64, kind, uid string) {
 	now := n.now()
 	if err := n.db.Model(&model.SummaryNotification{}).
-		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).
 		Updates(map[string]any{
 			"status":        model.NotifyStatusSent,
 			"sent_at":       now,
@@ -325,22 +359,22 @@ func (n *Notifier) markSent(taskID int64, kind string) {
 			"attempt_count": gorm.Expr("attempt_count + 1"),
 			"last_error":    nil,
 		}).Error; err != nil {
-		log.Printf("[notify] task=%d kind=%s: markSent failed: %v", taskID, kind, err)
+		log.Printf("[notify] task=%d kind=%s uid=%s: markSent failed: %v", taskID, kind, uid, err)
 	}
 }
 
-func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
+func (n *Notifier) markFailed(taskID int64, kind, uid string, cause error) {
 	now := n.now()
 	le := truncateForLastError(sanitize(cause.Error()))
 	if err := n.db.Model(&model.SummaryNotification{}).
-		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).
 		Updates(map[string]any{
 			"status":        model.NotifyStatusFailed,
 			"updated_at":    now,
 			"attempt_count": gorm.Expr("attempt_count + 1"),
 			"last_error":    le,
 		}).Error; err != nil {
-		log.Printf("[notify] task=%d kind=%s: markFailed failed: %v", taskID, kind, err)
+		log.Printf("[notify] task=%d kind=%s uid=%s: markFailed failed: %v", taskID, kind, uid, err)
 	}
 }
 
@@ -358,19 +392,19 @@ func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
 // will pick the row up again via the stale-pending branch. That extra retry
 // inside one tick is intentional — the whole point is not to wait — and
 // correctness is preserved by the existing atomic CAS in claimStalePending.
-func (n *Notifier) markDeferred(taskID int64, kind string, cause error) {
+func (n *Notifier) markDeferred(taskID int64, kind, uid string, cause error) {
 	le := truncateForLastError(sanitize(cause.Error()))
 	// Backdate past PendingLease so next Sweep tick's sweepStalePending picks
 	// it up immediately instead of waiting the full ~5min lease.
 	stale := n.now().Add(-PendingLease - time.Second)
 	if err := n.db.Model(&model.SummaryNotification{}).
-		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).
 		Updates(map[string]any{
 			"status":     model.NotifyStatusPending,
 			"updated_at": stale,
 			"last_error": le,
 		}).Error; err != nil {
-		log.Printf("[notify] task=%d kind=%s: markDeferred failed: %v", taskID, kind, err)
+		log.Printf("[notify] task=%d kind=%s uid=%s: markDeferred failed: %v", taskID, kind, uid, err)
 	}
 }
 
@@ -640,15 +674,15 @@ func (n *Notifier) sweepRetryFailed(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		won, err := n.claimRetry(row.TaskID, row.NotifyKind)
+		won, err := n.claimRetry(row.TaskID, row.NotifyKind, row.RecipientUID)
 		if err != nil {
-			log.Printf("[notify] sweep: task=%d kind=%s claimRetry: %v", row.TaskID, row.NotifyKind, err)
+			log.Printf("[notify] sweep: task=%d kind=%s uid=%s claimRetry: %v", row.TaskID, row.NotifyKind, row.RecipientUID, err)
 			continue
 		}
 		if !won {
 			continue // another runner won, or budget exhausted concurrently
 		}
-		n.redeliver(row.TaskID, row.NotifyKind)
+		n.redeliver(row.TaskID, row.NotifyKind, row.RecipientUID)
 	}
 }
 
@@ -670,16 +704,16 @@ func (n *Notifier) sweepStalePending(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		won, err := n.claimStalePending(row.TaskID, row.NotifyKind, cutoff)
+		won, err := n.claimStalePending(row.TaskID, row.NotifyKind, row.RecipientUID, cutoff)
 		if err != nil {
-			log.Printf("[notify] sweep: task=%d kind=%s claimStalePending: %v", row.TaskID, row.NotifyKind, err)
+			log.Printf("[notify] sweep: task=%d kind=%s uid=%s claimStalePending: %v", row.TaskID, row.NotifyKind, row.RecipientUID, err)
 			continue
 		}
 		if !won {
 			continue
 		}
-		log.Printf("[notify] sweep: reclaimed stale pending row task=%d kind=%s", row.TaskID, row.NotifyKind)
-		n.redeliver(row.TaskID, row.NotifyKind)
+		log.Printf("[notify] sweep: reclaimed stale pending row task=%d kind=%s uid=%s", row.TaskID, row.NotifyKind, row.RecipientUID)
+		n.redeliver(row.TaskID, row.NotifyKind, row.RecipientUID)
 	}
 }
 
@@ -687,11 +721,11 @@ func (n *Notifier) sweepStalePending(ctx context.Context) {
 // so exactly one sweeper wins the right to redeliver it. Guarded on
 // status='pending' AND updated_at<cutoff so concurrent sweepers race and only
 // the row flipped by RowsAffected==1 proceeds.
-func (n *Notifier) claimStalePending(taskID int64, kind string, cutoff time.Time) (bool, error) {
+func (n *Notifier) claimStalePending(taskID int64, kind, uid string, cutoff time.Time) (bool, error) {
 	now := n.now()
 	res := n.db.Model(&model.SummaryNotification{}).
-		Where("task_id = ? AND notify_kind = ? AND status = ? AND updated_at < ?",
-			taskID, kind, model.NotifyStatusPending, cutoff).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ? AND status = ? AND updated_at < ?",
+			taskID, kind, uid, model.NotifyStatusPending, cutoff).
 		Update("updated_at", now)
 	if res.Error != nil {
 		return false, res.Error
@@ -701,21 +735,22 @@ func (n *Notifier) claimStalePending(taskID int64, kind string, cutoff time.Time
 
 // redeliver performs one delivery attempt for a row whose retry slot we just
 // won (claimRetry or claimStalePending). It reloads the SummaryTask so the
-// message reflects the durable terminal-state row, then mirrors the
+// message reflects the durable terminal-state row, then rebuilds the target for
+// THIS recipient_uid (not blindly the creator) and mirrors the
 // build+deliver+persist sequence from OnTaskTerminal. Any failure persists
 // via markFailed and is left for the next sweep tick or until budget runs out.
-func (n *Notifier) redeliver(taskID int64, kind string) {
+func (n *Notifier) redeliver(taskID int64, kind, uid string) {
 	var task model.SummaryTask
 	if err := n.db.First(&task, taskID).Error; err != nil {
 		// Task row gone (extremely unusual: rows are never deleted in the
 		// happy path). Treat as a permanent delivery failure so attempt_count
 		// advances and the row eventually leaves the retry set.
-		n.markFailed(taskID, kind, fmt.Errorf("reload task %d: %w", taskID, err))
+		n.markFailed(taskID, kind, uid, fmt.Errorf("reload task %d: %w", taskID, err))
 		return
 	}
-	target, ok := resolveTarget(task)
+	target, ok := targetForUID(task, uid)
 	if !ok {
-		n.markFailed(taskID, kind, errors.New("no deliverable target on reload"))
+		n.markFailed(taskID, kind, uid, errors.New("no deliverable target on reload"))
 		return
 	}
 	errMsg := ""
@@ -727,16 +762,16 @@ func (n *Notifier) redeliver(taskID int64, kind string) {
 		// Startup-race in the sweep path: same treatment as OnTaskTerminal —
 		// keep pending, don't burn budget, let the next tick pick it up.
 		if errors.Is(deliverErr, ErrTokenNotYetProvisioned) {
-			n.markDeferred(taskID, kind, deliverErr)
-			log.Printf("[notify] sweep: task=%d kind=%s deferred (token not yet provisioned)", taskID, kind)
+			n.markDeferred(taskID, kind, uid, deliverErr)
+			log.Printf("[notify] sweep: task=%d kind=%s uid=%s deferred (token not yet provisioned)", taskID, kind, uid)
 			return
 		}
-		n.markFailed(taskID, kind, deliverErr)
-		log.Printf("[notify] sweep: task=%d kind=%s delivery failed: %v", taskID, kind, sanitize(deliverErr.Error()))
+		n.markFailed(taskID, kind, uid, deliverErr)
+		log.Printf("[notify] sweep: task=%d kind=%s uid=%s delivery failed: %v", taskID, kind, uid, sanitize(deliverErr.Error()))
 		return
 	}
-	n.markSent(taskID, kind)
-	log.Printf("[notify] sweep: task=%d kind=%s delivered via retry", taskID, kind)
+	n.markSent(taskID, kind, uid)
+	log.Printf("[notify] sweep: task=%d kind=%s uid=%s delivered via retry", taskID, kind, uid)
 }
 
 // truncateForLastError caps an error string for the VARCHAR(500) last_error

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,345 @@
+// Package notify delivers a one-shot terminal-state notification (Completed /
+// Failed) for a summary task back to the task creator through the octo-server IM
+// bot. It is invoked by the worker AFTER a task's terminal status is durably
+// committed to the summary DB.
+//
+// Design (OCT-4, approved plan):
+//   - Dedup / idempotency via a summary_notification row keyed
+//     UNIQUE(task_id, notify_kind). The first writer INSERTs status='pending'
+//     and wins the right to deliver; a duplicate-key error means another run
+//     already owns this (task, kind), so we skip. Rows are NEVER deleted.
+//     completed and failed are independent kinds (Leader 拍板选 A：各发一次).
+//   - On HTTP success: UPDATE status='sent', sent_at=now.
+//   - On HTTP failure: UPDATE status='failed', last_error, attempt_count+1, with
+//     bounded same-row retries (MaxNotifyAttempts). The SECRET token is never
+//     written to last_error.
+//   - Cancelled tasks are not notified (the caller never calls OnTaskTerminal
+//     for Cancelled).
+//   - Optional quiet window suppresses SCHEDULED-task notifications only;
+//     on-demand (manual) tasks are never suppressed, and suppression drops the
+//     notification for this run (no 顺延).
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/gorm"
+)
+
+// Config is the subset of application config the notifier needs. It is passed
+// explicitly (rather than importing internal/config) so the package stays
+// decoupled and trivially testable.
+type Config struct {
+	Enabled     bool
+	WebBaseURL  string
+	MaxAttempts int
+	QuietStart  string // "HH:MM" or ""
+	QuietEnd    string // "HH:MM" or ""
+}
+
+// Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
+type Notifier struct {
+	db        *gorm.DB
+	deliverer Deliverer
+	cfg       Config
+	now       func() time.Time // injectable clock for tests
+}
+
+// New builds a Notifier. A nil deliverer or Enabled=false makes OnTaskTerminal a
+// no-op, so callers can wire it unconditionally.
+func New(db *gorm.DB, deliverer Deliverer, cfg Config) *Notifier {
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 3
+	}
+	return &Notifier{
+		db:        db,
+		deliverer: deliverer,
+		cfg:       cfg,
+		now:       timezone.Now,
+	}
+}
+
+// OnTaskTerminal is the single entry point the worker calls right AFTER a task
+// reaches a terminal status (Completed / Failed) durably in the DB. errMsg is
+// the task's ErrorMessage for a Failed task (ignored for Completed). It is
+// best-effort: a delivery failure is logged and persisted, never propagated to
+// the worker's completion path.
+func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg string) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+
+	kind, ok := kindForStatus(status)
+	if !ok {
+		// Cancelled / non-terminal: never notify.
+		return
+	}
+
+	// Quiet window suppresses SCHEDULED notifications only (按需任务永不抑制).
+	if task.TriggerType == model.TriggerScheduled && n.inQuietWindow(n.now()) {
+		log.Printf("[notify] task=%d kind=%s suppressed by quiet window (scheduled)", task.ID, kind)
+		return
+	}
+
+	target, ok := resolveTarget(task)
+	if !ok {
+		log.Printf("[notify] task=%d kind=%s: no deliverable target (empty creator), skipping", task.ID, kind)
+		return
+	}
+
+	// 1) Preemptive unique insert — claim the right to deliver this (task, kind).
+	claimed, row, err := n.claim(task.ID, kind)
+	if err != nil {
+		log.Printf("[notify] task=%d kind=%s: claim failed: %v", task.ID, kind, err)
+		return
+	}
+	if !claimed {
+		// Either another run owns it, or it is already sent / exhausted.
+		if row != nil && row.Status == model.NotifyStatusFailed && row.AttemptCount < n.cfg.MaxAttempts {
+			// A previous attempt failed but still has retry budget: retry on this row.
+			log.Printf("[notify] task=%d kind=%s: retrying failed row (attempt %d/%d)", task.ID, kind, row.AttemptCount, n.cfg.MaxAttempts)
+		} else {
+			return
+		}
+	}
+
+	// 2) Build + deliver.
+	text := n.buildText(task, kind, errMsg)
+	deliverErr := n.deliver(target, text)
+
+	// 3) Persist outcome.
+	if deliverErr == nil {
+		n.markSent(task.ID, kind)
+		log.Printf("[notify] task=%d kind=%s delivered to channel_type=%d", task.ID, kind, target.ChannelType)
+		return
+	}
+	n.markFailed(task.ID, kind, deliverErr)
+	log.Printf("[notify] task=%d kind=%s delivery failed: %v", task.ID, kind, sanitize(deliverErr.Error()))
+}
+
+func kindForStatus(status int) (string, bool) {
+	switch status {
+	case model.StatusCompleted:
+		return model.NotifyKindCompleted, true
+	case model.StatusFailed:
+		return model.NotifyKindFailed, true
+	default:
+		return "", false
+	}
+}
+
+// claim attempts the preemptive INSERT. Returns claimed=true when this run won
+// the (task, kind) slot. When the row already exists, claimed=false and the
+// existing row is returned so the caller can decide whether retry budget remains.
+func (n *Notifier) claim(taskID int64, kind string) (bool, *model.SummaryNotification, error) {
+	now := n.now()
+	row := &model.SummaryNotification{
+		TaskID:       taskID,
+		NotifyKind:   kind,
+		Status:       model.NotifyStatusPending,
+		AttemptCount: 0,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	// Plain Create: the UNIQUE(task_id, notify_kind) constraint rejects a
+	// duplicate with an error we treat as "someone else owns it".
+	err := n.db.Create(row).Error
+	if err == nil {
+		return true, row, nil
+	}
+	if isDuplicateKey(err) {
+		var existing model.SummaryNotification
+		if e := n.db.Where("task_id = ? AND notify_kind = ?", taskID, kind).First(&existing).Error; e != nil {
+			return false, nil, e
+		}
+		return false, &existing, nil
+	}
+	return false, nil, err
+}
+
+func (n *Notifier) deliver(target deliveryTarget, text string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// DM 可达前置：先 ensureFriend（幂等，带 space_id 供 server 拼 s{spaceID}_{uid}
+	// 白名单 channel），再 sendMessage.
+	if target.TargetUID != "" {
+		if err := n.deliverer.EnsureFriend(ctx, target.SpaceID, target.TargetUID); err != nil {
+			return fmt.Errorf("ensureFriend: %w", err)
+		}
+	}
+	msg := SendMessageRequest{
+		ChannelID:   target.ChannelID,
+		ChannelType: target.ChannelType,
+		Payload:     map[string]any{"text": text},
+	}
+	if err := n.deliverer.SendMessage(ctx, msg); err != nil {
+		return fmt.Errorf("sendMessage: %w", err)
+	}
+	return nil
+}
+
+func (n *Notifier) markSent(taskID int64, kind string) {
+	now := n.now()
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Updates(map[string]any{
+			"status":        model.NotifyStatusSent,
+			"sent_at":       now,
+			"updated_at":    now,
+			"attempt_count": gorm.Expr("attempt_count + 1"),
+			"last_error":    nil,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s: markSent failed: %v", taskID, kind, err)
+	}
+}
+
+func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
+	now := n.now()
+	le := sanitize(cause.Error())
+	if len(le) > 480 {
+		le = le[:480]
+	}
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Updates(map[string]any{
+			"status":        model.NotifyStatusFailed,
+			"updated_at":    now,
+			"attempt_count": gorm.Expr("attempt_count + 1"),
+			"last_error":    le,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s: markFailed failed: %v", taskID, kind, err)
+	}
+}
+
+// buildText composes the user-facing notification body. Success carries the
+// result link (when a base URL is configured); failure carries the sanitized
+// error message.
+func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string {
+	title := strings.TrimSpace(task.Title)
+	switch kind {
+	case model.NotifyKindCompleted:
+		var b strings.Builder
+		if title != "" {
+			fmt.Fprintf(&b, "你的总结「%s」已生成完成。", title)
+		} else {
+			b.WriteString("你的总结已生成完成。")
+		}
+		if link := n.resultLink(task); link != "" {
+			fmt.Fprintf(&b, "\n查看结果：%s", link)
+		}
+		return b.String()
+	case model.NotifyKindFailed:
+		var b strings.Builder
+		if title != "" {
+			fmt.Fprintf(&b, "你的总结「%s」生成失败。", title)
+		} else {
+			b.WriteString("你的总结生成失败。")
+		}
+		if reason := strings.TrimSpace(errMsg); reason != "" {
+			fmt.Fprintf(&b, "\n失败原因：%s", reason)
+		}
+		return b.String()
+	default:
+		return ""
+	}
+}
+
+// resultLink builds the result URL from the configured base. Empty base → no link.
+func (n *Notifier) resultLink(task model.SummaryTask) string {
+	base := strings.TrimRight(strings.TrimSpace(n.cfg.WebBaseURL), "/")
+	if base == "" || task.TaskNo == "" {
+		return ""
+	}
+	return base + "/summary/" + task.TaskNo
+}
+
+// inQuietWindow reports whether t (Asia/Shanghai) falls inside the configured
+// quiet window. Disabled (returns false) unless both bounds parse as "HH:MM".
+// Supports wrap-around windows (e.g. 22:00-07:00).
+func (n *Notifier) inQuietWindow(t time.Time) bool {
+	start, ok1 := parseHHMM(n.cfg.QuietStart)
+	end, ok2 := parseHHMM(n.cfg.QuietEnd)
+	if !ok1 || !ok2 || start == end {
+		return false
+	}
+	cur := t.Hour()*60 + t.Minute()
+	if start < end {
+		return cur >= start && cur < end
+	}
+	// Wrap-around (overnight) window.
+	return cur >= start || cur < end
+}
+
+// parseHHMM parses "HH:MM" into minutes-of-day. Returns ok=false on any malformed input.
+func parseHHMM(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return 0, false
+	}
+	h, err1 := atoiBounded(parts[0], 0, 23)
+	m, err2 := atoiBounded(parts[1], 0, 59)
+	if err1 != nil || err2 != nil {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+func atoiBounded(s string, lo, hi int) (int, error) {
+	n := 0
+	if s == "" {
+		return 0, errors.New("empty")
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, errors.New("non-digit")
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n < lo || n > hi {
+		return 0, errors.New("out of range")
+	}
+	return n, nil
+}
+
+// sanitize strips any accidental Bearer token / Authorization material from an
+// error string before it is persisted to last_error or logged. Defense in
+// depth: the deliverer already keeps the token out of errors. It scans forward
+// and advances past each rewritten marker so the inserted "Bearer [REDACTED]"
+// is never re-matched (which would loop forever).
+func sanitize(s string) string {
+	const marker = "bearer "
+	const redacted = "Bearer [REDACTED]"
+	var b strings.Builder
+	lower := strings.ToLower(s)
+	for {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			b.WriteString(s)
+			break
+		}
+		b.WriteString(s[:idx])
+		b.WriteString(redacted)
+		rest := s[idx+len(marker):]
+		end := strings.IndexAny(rest, " \n\t")
+		if end < 0 {
+			// Token runs to end of string; drop it entirely.
+			break
+		}
+		// Keep the delimiter and everything after; continue scanning the tail.
+		s = rest[end:]
+		lower = strings.ToLower(s)
+	}
+	return b.String()
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -48,19 +48,23 @@ type Config struct {
 // Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
 type Notifier struct {
 	db        *gorm.DB
+	imDB      *gorm.DB // shared IM DB, read-only; used to resolve space names. May be nil.
 	deliverer Deliverer
 	cfg       Config
 	now       func() time.Time // injectable clock for tests
 }
 
 // New builds a Notifier. A nil deliverer or Enabled=false makes OnTaskTerminal a
-// no-op, so callers can wire it unconditionally.
-func New(db *gorm.DB, deliverer Deliverer, cfg Config) *Notifier {
+// no-op, so callers can wire it unconditionally. imDB is the shared IM DB used
+// (read-only) to resolve the space name for notification text; it may be nil, in
+// which case the text gracefully degrades to the space-less wording.
+func New(db *gorm.DB, imDB *gorm.DB, deliverer Deliverer, cfg Config) *Notifier {
 	if cfg.MaxAttempts < 1 {
 		cfg.MaxAttempts = 3
 	}
 	return &Notifier{
 		db:        db,
+		imDB:      imDB,
 		deliverer: deliverer,
 		cfg:       cfg,
 		now:       timezone.Now,
@@ -202,6 +206,18 @@ func (n *Notifier) deliver(target deliveryTarget, text string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
+	// Light guard against the silent-success trap: for a system-bot DM, if the
+	// recipient is NOT an active member of this Space, octo-server strips space_id
+	// but still returns 200 — the message is then dropped and the user silently
+	// gets nothing while we would mark it "sent". Detect provable non-membership
+	// here and fail the delivery explicitly instead. (nil imDB / query error =>
+	// allowed; server still enforces.)
+	if target.TargetUID != "" && target.SpaceID != "" &&
+		!n.recipientIsActiveMember(0, target.SpaceID, target.TargetUID) {
+		return fmt.Errorf("recipient %s is not an active member of space %s; "+
+			"server would strip space_id and drop the notification", target.TargetUID, target.SpaceID)
+	}
+
 	// DM 可达前置：先 ensureFriend（幂等，带 space_id 供 server 拼 s{spaceID}_{uid}
 	// 白名单 channel），再 sendMessage.
 	if target.TargetUID != "" {
@@ -209,15 +225,68 @@ func (n *Notifier) deliver(target deliveryTarget, text string) error {
 			return fmt.Errorf("ensureFriend: %w", err)
 		}
 	}
+	// octo-server identifies a plain-text bot message by its ContentType enum
+	// (type=1=Text) carrying the body in "content"; a bare {"text":...} payload is
+	// not recognized and renders as an empty/unopenable message. Send the
+	// server-recognized shape instead.
+	//
+	// summary is registered as a system bot, so its messages must carry space_id:
+	// octo-server's filterPersonMessagesBySpace drops a system-bot message whose
+	// payload has an empty space_id (it would otherwise be unopenable in the UI).
+	// Include space_id only when known, to hit the "exact match keep" branch and
+	// avoid regressing the empty-SpaceID case.
+	payload := map[string]any{"type": 1, "content": text}
+	if target.SpaceID != "" {
+		payload["space_id"] = target.SpaceID
+	}
 	msg := SendMessageRequest{
 		ChannelID:   target.ChannelID,
 		ChannelType: target.ChannelType,
-		Payload:     map[string]any{"text": text},
+		Payload:     payload,
 	}
-	if err := n.deliverer.SendMessage(ctx, msg); err != nil {
+	if err := n.deliverer.SendMessage(ctx, target.SpaceID, msg); err != nil {
 		return fmt.Errorf("sendMessage: %w", err)
 	}
 	return nil
+}
+
+// recipientIsActiveMember reports whether uid is an active member (status=1) of
+// an active Space (status=1), mirroring octo-server's space.CheckMembership.
+//
+// Why this matters: for a system-bot DM, octo-server only adopts the X-Space-ID
+// header (and thus injects the authoritative payload.space_id) when the
+// RECIPIENT is an active member of that Space. If they are not, the server
+// STRIPS space_id yet still returns 200 — the message is then dropped by
+// filterPersonMessagesBySpace and the user silently never sees it, while the
+// worker would otherwise record it as "sent". Pre-checking here turns that
+// silent loss into an explicit delivery failure (retried/visible), instead of a
+// false success.
+//
+// Conservative failure mode: on a nil imDB or a query error we return true
+// (do NOT block delivery) — the server-side CheckMembership still guards
+// correctness; this pre-check only exists to avoid the silent-success trap when
+// we can cheaply prove non-membership.
+func (n *Notifier) recipientIsActiveMember(taskID uint, spaceID, uid string) bool {
+	if n == nil || n.imDB == nil {
+		return true // cannot check → don't block; server still enforces.
+	}
+	spaceID = strings.TrimSpace(spaceID)
+	uid = strings.TrimSpace(uid)
+	if spaceID == "" || uid == "" {
+		return true // nothing to check against; leave existing behavior.
+	}
+	var count int
+	err := n.imDB.Raw(
+		"SELECT COUNT(*) FROM space_member sm "+
+			"INNER JOIN space s ON s.space_id = sm.space_id AND s.status = 1 "+
+			"WHERE sm.uid = ? AND sm.space_id = ? AND sm.status = 1",
+		uid, spaceID,
+	).Scan(&count).Error
+	if err != nil {
+		log.Printf("[notify] task=%d: recipientIsActiveMember(space=%s,uid=%s) query failed: %v; allowing delivery", taskID, spaceID, uid, err)
+		return true // fail-open: don't turn a transient DB error into a drop.
+	}
+	return count > 0
 }
 
 func (n *Notifier) markSent(taskID int64, kind string) {
@@ -255,12 +324,18 @@ func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
 // error message.
 func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string {
 	title := strings.TrimSpace(task.Title)
+	space := n.resolveSpaceName(task)
 	switch kind {
 	case model.NotifyKindCompleted:
 		var b strings.Builder
-		if title != "" {
+		switch {
+		case space != "" && title != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结「%s」已生成完成。", space, title)
+		case space != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结已生成完成。", space)
+		case title != "":
 			fmt.Fprintf(&b, "你的总结「%s」已生成完成。", title)
-		} else {
+		default:
 			b.WriteString("你的总结已生成完成。")
 		}
 		if link := n.resultLink(task); link != "" {
@@ -269,9 +344,14 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 		return b.String()
 	case model.NotifyKindFailed:
 		var b strings.Builder
-		if title != "" {
+		switch {
+		case space != "" && title != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结「%s」生成失败。", space, title)
+		case space != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结生成失败。", space)
+		case title != "":
 			fmt.Fprintf(&b, "你的总结「%s」生成失败。", title)
-		} else {
+		default:
 			b.WriteString("你的总结生成失败。")
 		}
 		if reason := strings.TrimSpace(errMsg); reason != "" {
@@ -281,6 +361,27 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 	default:
 		return ""
 	}
+}
+
+// resolveSpaceName looks up the human-readable space name for the task's
+// SpaceID from the shared IM DB (read-only). It is best-effort and degrades
+// gracefully: a nil imDB, empty SpaceID, query error, or no row all yield ""
+// so buildText falls back to the space-less wording. It never panics and never
+// blocks delivery — any error is swallowed (logged only).
+func (n *Notifier) resolveSpaceName(task model.SummaryTask) string {
+	if n == nil || n.imDB == nil {
+		return ""
+	}
+	spaceID := strings.TrimSpace(task.SpaceID)
+	if spaceID == "" {
+		return ""
+	}
+	var name string
+	if err := n.imDB.Raw("SELECT name FROM space WHERE space_id = ? LIMIT 1", spaceID).Scan(&name).Error; err != nil {
+		log.Printf("[notify] task=%d: resolveSpaceName(space_id=%s) failed: %v", task.ID, spaceID, err)
+		return ""
+	}
+	return strings.TrimSpace(name)
 }
 
 // resultLink builds the result URL from the configured base. Empty base → no link.

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -149,12 +149,18 @@ func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg str
 
 	// 2) Build + deliver.
 	text := n.buildText(task, kind, errMsg)
-	deliverErr := n.deliver(target, text)
+	deliverErr := n.deliver(task.ID, target, text)
 
 	// 3) Persist outcome.
 	if deliverErr == nil {
 		n.markSent(task.ID, kind)
 		log.Printf("[notify] task=%d kind=%s delivered to channel_type=%d", task.ID, kind, target.ChannelType)
+		return
+	}
+	// Startup-race: token 尚未 provisioned。Keep pending 且不消耗 attempt 预算，让下轮 Sweep 立即重试。
+	if errors.Is(deliverErr, ErrTokenNotYetProvisioned) {
+		n.markDeferred(task.ID, kind, deliverErr)
+		log.Printf("[notify] task=%d kind=%s deferred (token not yet provisioned)", task.ID, kind)
 		return
 	}
 	n.markFailed(task.ID, kind, deliverErr)
@@ -221,7 +227,7 @@ func (n *Notifier) claimRetry(taskID int64, kind string) (bool, error) {
 	return res.RowsAffected == 1, nil
 }
 
-func (n *Notifier) deliver(target deliveryTarget, text string) error {
+func (n *Notifier) deliver(taskID int64, target deliveryTarget, text string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -232,7 +238,7 @@ func (n *Notifier) deliver(target deliveryTarget, text string) error {
 	// here and fail the delivery explicitly instead. (nil imDB / query error =>
 	// allowed; server still enforces.)
 	if target.TargetUID != "" && target.SpaceID != "" &&
-		!n.recipientIsActiveMember(0, target.SpaceID, target.TargetUID) {
+		!n.recipientIsActiveMember(uint(taskID), target.SpaceID, target.TargetUID) {
 		return fmt.Errorf("recipient %s is not an active member of space %s; "+
 			"server would strip space_id and drop the notification", target.TargetUID, target.SpaceID)
 	}
@@ -335,6 +341,36 @@ func (n *Notifier) markFailed(taskID int64, kind string, cause error) {
 			"last_error":    le,
 		}).Error; err != nil {
 		log.Printf("[notify] task=%d kind=%s: markFailed failed: %v", taskID, kind, err)
+	}
+}
+
+// markDeferred handles the narrow "infra not yet ready" case (bot token not
+// provisioned by octo-server). Row stays 'pending', attempt_count is NOT
+// incremented, and updated_at is BACKDATED past PendingLease so the very next
+// sweepStalePending tick reclaims it — no budget burned, no ~5min lease wait.
+// last_error records the reason for operator visibility.
+//
+// Concurrency: same single-row UPDATE contract as markFailed/markSent, so a
+// racing sweepStalePending can still CAS-refresh updated_at without corruption.
+//
+// Note: because Sweep runs sweepRetryFailed BEFORE sweepStalePending in the
+// same tick, if a retry hits the sentinel and defers here, the very same tick
+// will pick the row up again via the stale-pending branch. That extra retry
+// inside one tick is intentional — the whole point is not to wait — and
+// correctness is preserved by the existing atomic CAS in claimStalePending.
+func (n *Notifier) markDeferred(taskID int64, kind string, cause error) {
+	le := truncateForLastError(sanitize(cause.Error()))
+	// Backdate past PendingLease so next Sweep tick's sweepStalePending picks
+	// it up immediately instead of waiting the full ~5min lease.
+	stale := n.now().Add(-PendingLease - time.Second)
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ?", taskID, kind).
+		Updates(map[string]any{
+			"status":     model.NotifyStatusPending,
+			"updated_at": stale,
+			"last_error": le,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s: markDeferred failed: %v", taskID, kind, err)
 	}
 }
 
@@ -687,7 +723,14 @@ func (n *Notifier) redeliver(taskID int64, kind string) {
 		errMsg = *task.ErrorMessage
 	}
 	text := n.buildText(task, kind, errMsg)
-	if deliverErr := n.deliver(target, text); deliverErr != nil {
+	if deliverErr := n.deliver(taskID, target, text); deliverErr != nil {
+		// Startup-race in the sweep path: same treatment as OnTaskTerminal —
+		// keep pending, don't burn budget, let the next tick pick it up.
+		if errors.Is(deliverErr, ErrTokenNotYetProvisioned) {
+			n.markDeferred(taskID, kind, deliverErr)
+			log.Printf("[notify] sweep: task=%d kind=%s deferred (token not yet provisioned)", taskID, kind)
+			return
+		}
 		n.markFailed(taskID, kind, deliverErr)
 		log.Printf("[notify] sweep: task=%d kind=%s delivery failed: %v", taskID, kind, sanitize(deliverErr.Error()))
 		return

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -47,11 +47,12 @@ type Config struct {
 
 // Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
 type Notifier struct {
-	db        *gorm.DB
-	imDB      *gorm.DB // shared IM DB, read-only; used to resolve space names. May be nil.
-	deliverer Deliverer
-	cfg       Config
-	now       func() time.Time // injectable clock for tests
+	db             *gorm.DB
+	imDB           *gorm.DB // shared IM DB, read-only; used to resolve space names. May be nil.
+	deliverer      Deliverer
+	cfg            Config
+	now            func() time.Time    // injectable clock for tests
+	errorSanitizer func(string) string // single render-point sanitizer for failure reasons (see WithErrorSanitizer)
 }
 
 // New builds a Notifier. A nil deliverer or Enabled=false makes OnTaskTerminal a
@@ -69,6 +70,25 @@ func New(db *gorm.DB, imDB *gorm.DB, deliverer Deliverer, cfg Config) *Notifier 
 		cfg:       cfg,
 		now:       timezone.Now,
 	}
+}
+
+// WithErrorSanitizer wires a single-render-point sanitizer for failure-reason
+// strings. It MUST be set in production: buildText runs every failure reason
+// (whether arriving via the synchronous OnTaskTerminal path OR the
+// sweep/redeliver path that reloads task.ErrorMessage raw from DB) through this
+// sanitizer before composing the user DM. The canonical implementation lives in
+// internal/worker.SanitizeErrorForUser (whitelist-maps LLM/timeout/chunk errors
+// to safe Chinese strings, everything else → "AI 处理失败，请稍后重试").
+//
+// If left nil, buildText falls back to a hardcoded safe string for any
+// non-empty failure reason — never leaks raw err.Error() to the user DM.
+// See PR#113 Jerry-Xin/OctoBoooot R3 blocker: sanitizing only at the worker
+// call sites left the sweep redeliver path renderring raw DSN/IP/stack.
+func (n *Notifier) WithErrorSanitizer(fn func(string) string) *Notifier {
+	if n != nil {
+		n.errorSanitizer = fn
+	}
+	return n
 }
 
 // OnTaskTerminal is the single entry point the worker calls right AFTER a task
@@ -354,8 +374,19 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 		default:
 			b.WriteString("你的总结生成失败。")
 		}
+		// Single render-point sanitization: every failure reason — whether arriving
+		// via the synchronous worker path (OnTaskTerminal) or the sweep/redeliver
+		// path that reloads task.ErrorMessage raw from DB — is scrubbed here before
+		// it can reach the user DM. See WithErrorSanitizer / PR#113 R3.
 		if reason := strings.TrimSpace(errMsg); reason != "" {
-			fmt.Fprintf(&b, "\n失败原因：%s", reason)
+			safe := reason
+			if n.errorSanitizer != nil {
+				safe = n.errorSanitizer(reason)
+			} else {
+				// Defensive: never leak raw internals if no sanitizer wired.
+				safe = "AI 处理失败，请稍后重试"
+			}
+			fmt.Fprintf(&b, "\n失败原因：%s", safe)
 		}
 		return b.String()
 	default:

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -313,12 +313,13 @@ func TestQuietWindow_OutsideWindowDelivers(t *testing.T) {
 }
 
 func TestResolveTarget_DMFallbackForAllOrigins(t *testing.T) {
+	n := newTestNotifier(setupNotifyTestDB(t), &fakeDeliverer{}, Config{Enabled: true})
 	origins := []int{model.OriginChannelGlobal, model.OriginChannelDM, model.OriginChannelGroup, model.OriginChannelThread}
 	for _, o := range origins {
 		task := baseTask(1, model.TriggerManual)
 		task.OriginChannelType = o
 		task.OriginChannelID = "origin-chan"
-		tgt, ok := resolveTarget(task)
+		tgt, ok := n.creatorTarget(task)
 		if !ok {
 			t.Fatalf("origin %d: expected resolvable target", o)
 		}
@@ -329,10 +330,15 @@ func TestResolveTarget_DMFallbackForAllOrigins(t *testing.T) {
 }
 
 func TestResolveTarget_EmptyCreatorUnresolvable(t *testing.T) {
+	n := newTestNotifier(setupNotifyTestDB(t), &fakeDeliverer{}, Config{Enabled: true})
 	task := baseTask(1, model.TriggerManual)
 	task.CreatorID = ""
-	if _, ok := resolveTarget(task); ok {
+	if _, ok := n.creatorTarget(task); ok {
 		t.Fatalf("empty creator must be unresolvable")
+	}
+	// resolveTargets for a non-by-person task with empty creator yields no target.
+	if tgts, err := n.resolveTargets(task); err != nil || len(tgts) != 0 {
+		t.Fatalf("empty creator non-by-person must yield no targets/no err, got %d err=%v", len(tgts), err)
 	}
 }
 
@@ -541,11 +547,12 @@ func TestSweep_ReclaimsStalePendingRow(t *testing.T) {
 	// Inject a stale pending row directly: updated_at well past the lease.
 	stale := n.now().Add(-2 * PendingLease)
 	if err := db.Create(&model.SummaryNotification{
-		TaskID:     203,
-		NotifyKind: model.NotifyKindCompleted,
-		Status:     model.NotifyStatusPending,
-		CreatedAt:  stale,
-		UpdatedAt:  stale,
+		TaskID:       203,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "user-1",
+		Status:       model.NotifyStatusPending,
+		CreatedAt:    stale,
+		UpdatedAt:    stale,
 	}).Error; err != nil {
 		t.Fatalf("seed stale pending: %v", err)
 	}
@@ -578,11 +585,12 @@ func TestSweep_DoesNotReclaimFreshPendingRow(t *testing.T) {
 
 	fresh := n.now() // just claimed
 	if err := db.Create(&model.SummaryNotification{
-		TaskID:     204,
-		NotifyKind: model.NotifyKindCompleted,
-		Status:     model.NotifyStatusPending,
-		CreatedAt:  fresh,
-		UpdatedAt:  fresh,
+		TaskID:       204,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "user-1",
+		Status:       model.NotifyStatusPending,
+		CreatedAt:    fresh,
+		UpdatedAt:    fresh,
 	}).Error; err != nil {
 		t.Fatalf("seed fresh pending: %v", err)
 	}
@@ -1369,10 +1377,10 @@ func TestBuildText_NilSanitizerFallsBackToSafeString(t *testing.T) {
 // 之后返回 nil；SendMessage 记录调用次数并成功。用于模拟 token 未 provisioned
 // 的启动窗口以及之后 octo-server 回填后的恢复过程。
 type deferredDeliverer struct {
-	mu           sync.Mutex
-	failCount    int // 还需失败几次
-	ensureCalls  int
-	sendCalls    int
+	mu          sync.Mutex
+	failCount   int // 还需失败几次
+	ensureCalls int
+	sendCalls   int
 }
 
 func (d *deferredDeliverer) EnsureFriend(ctx context.Context, spaceID, uid string) error {
@@ -1514,5 +1522,294 @@ func TestOnTaskTerminal_NonSentinelErrorStillConsumesBudget(t *testing.T) {
 	}
 	if row.AttemptCount != 1 {
 		t.Fatalf("non-sentinel error must increment attempt_count, got %d", row.AttemptCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// by-person 多目标逐人 DM (feat/notify-delivery)
+//
+// completed：给「所有 participant ∪ 发起者 CreatorID」并集去重后逐人各发一条 DM。
+// failed：只发发起者一人（不群发，避免噪音）。
+// 非 by-person：成功/失败都只回退发起者单 DM（保持现状语义）。
+// 幂等：每个收件人独立去重（三元键 task_id+notify_kind+recipient_uid），重试只
+// 重发失败的那个人。
+// ---------------------------------------------------------------------------
+
+// setupByPersonDB 在通知库上追加 summary_participant 表，供 resolveTargets 查参与人。
+func setupByPersonDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := setupNotifyTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryParticipant{}); err != nil {
+		t.Fatalf("automigrate participant: %v", err)
+	}
+	return db
+}
+
+func seedParticipants(t *testing.T, db *gorm.DB, taskID int64, uids ...string) {
+	t.Helper()
+	for _, uid := range uids {
+		if err := db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: uid}).Error; err != nil {
+			t.Fatalf("seed participant %s: %v", uid, err)
+		}
+	}
+}
+
+func sentUIDs(d *fakeDeliverer) map[string]int {
+	got := make(map[string]int)
+	for _, c := range d.sendCalls {
+		got[c.ChannelID]++
+	}
+	return got
+}
+
+func byPersonTask(id int64) model.SummaryTask {
+	task := baseTask(id, model.TriggerManual)
+	task.SummaryMode = model.ModeByPerson
+	return task
+}
+
+// (a) by-person + 发起者不在 participant 里 → completed 每人各一条、发起者也收到、去重无重复。
+func TestOnTaskTerminal_ByPerson_CompletedFansOutToAllPlusCreator(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1001) // creator=user-1
+	seedParticipants(t, db, 1001, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	want := map[string]int{"p-a": 1, "p-b": 1, "user-1": 1}
+	if len(d.sendCalls) != 3 {
+		t.Fatalf("expected 3 sends (2 participants + creator), got %d (%v)", len(d.sendCalls), got)
+	}
+	for uid, c := range want {
+		if got[uid] != c {
+			t.Fatalf("expected uid %s to receive %d DM, got %d (all=%v)", uid, c, got[uid], got)
+		}
+	}
+	// One row per (task, completed, uid) — three distinct recipient_uids.
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND notify_kind = ?", 1001, model.NotifyKindCompleted).Count(&cnt)
+	if cnt != 3 {
+		t.Fatalf("expected 3 notification rows (one per recipient), got %d", cnt)
+	}
+}
+
+// (a-dedup) 发起者同时也是 participant → 并集去重，只发一条给发起者。
+func TestOnTaskTerminal_ByPerson_CreatorAlsoParticipant_Deduped(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1002) // creator=user-1
+	seedParticipants(t, db, 1002, "user-1", "p-x")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (deduped creator+participant), got %d (%v)", len(d.sendCalls), got)
+	}
+	if got["user-1"] != 1 || got["p-x"] != 1 {
+		t.Fatalf("expected exactly one DM each to user-1 and p-x, got %v", got)
+	}
+}
+
+// (b) failed 时只有发起者收到（participant 不收）。
+func TestOnTaskTerminal_ByPerson_FailedOnlyCreator(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1003) // creator=user-1
+	seedParticipants(t, db, 1003, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 1 || got["user-1"] != 1 {
+		t.Fatalf("failed must go ONLY to creator, got %d sends (%v)", len(d.sendCalls), got)
+	}
+	// No participant row should exist for the failed kind.
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND notify_kind = ? AND recipient_uid <> ?", 1003, model.NotifyKindFailed, "user-1").Count(&cnt)
+	if cnt != 0 {
+		t.Fatalf("failed must not create participant rows, got %d", cnt)
+	}
+}
+
+// (c) 非 by-person → completed 和 failed 都只发发起者。
+func TestOnTaskTerminal_NonByPerson_OnlyCreatorBothKinds(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	// Even if participant rows exist, a non-by-person task must ignore them.
+	seedParticipants(t, db, 1004, "p-a", "p-b")
+	task := baseTask(1004, model.TriggerManual) // SummaryMode != ModeByPerson
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 2 || got["user-1"] != 2 {
+		t.Fatalf("non-by-person must send only to creator (completed+failed), got %d sends (%v)", len(d.sendCalls), got)
+	}
+}
+
+// (d) 三元去重键幂等：同 (task,kind,uid) 重复触发只发一次；不同 uid 各自独立。
+func TestOnTaskTerminal_ByPerson_PerRecipientIdempotent(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1005) // creator=user-1
+	seedParticipants(t, db, 1005, "p-a", "p-b")
+
+	// Fire three times: dedup must collapse to exactly one DM per recipient.
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 3 {
+		t.Fatalf("dedup: expected 3 sends total across 3 recipients, got %d (%v)", len(d.sendCalls), got)
+	}
+	for _, uid := range []string{"p-a", "p-b", "user-1"} {
+		if got[uid] != 1 {
+			t.Fatalf("dedup: uid %s must receive exactly 1 DM, got %d (%v)", uid, got[uid], got)
+		}
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 1005).Count(&cnt)
+	if cnt != 3 {
+		t.Fatalf("dedup: expected 3 rows (one per uid), got %d", cnt)
+	}
+}
+
+// (d-independent) 一个收件人 fail、其余成功：重试只重发失败的那个人，不重发已成功的人。
+func TestOnTaskTerminal_ByPerson_OneFailsOthersUnaffected(t *testing.T) {
+	db := setupByPersonDB(t)
+	// First send fails (sendErrOnce), subsequent succeed. The failed recipient
+	// gets status=failed with budget; a second OnTaskTerminal must retry ONLY
+	// that recipient and leave the already-sent ones alone.
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip on first recipient")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := byPersonTask(1006) // creator=user-1
+	seedParticipants(t, db, 1006, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // one of the three fails once
+
+	var failedRows int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND status = ?", 1006, model.NotifyStatusFailed).Count(&failedRows)
+	if failedRows != 1 {
+		t.Fatalf("expected exactly 1 recipient failed on first pass, got %d", failedRows)
+	}
+	var sentRows int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND status = ?", 1006, model.NotifyStatusSent).Count(&sentRows)
+	if sentRows != 2 {
+		t.Fatalf("expected 2 recipients sent on first pass, got %d", sentRows)
+	}
+
+	sendsAfterFirst := len(d.sendCalls) // 3 (2 ok + 1 failed attempt)
+
+	// Second pass: only the failed recipient should be retried (one more send);
+	// the two already-sent recipients must be skipped (dedup).
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	if len(d.sendCalls) != sendsAfterFirst+1 {
+		t.Fatalf("retry must resend ONLY the failed recipient (+1 send); before=%d after=%d", sendsAfterFirst, len(d.sendCalls))
+	}
+	var allSent int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND status = ?", 1006, model.NotifyStatusSent).Count(&allSent)
+	if allSent != 3 {
+		t.Fatalf("after retry all 3 recipients must be sent, got %d", allSent)
+	}
+}
+
+// (e) 单人（非 by-person）fail-before/pass-after 不回归：首投失败→标 failed，
+// 预算内二次触发重试成功。等价于历史单目标语义在新签名下不变。
+func TestOnTaskTerminal_SinglePerson_FailBeforePassAfter(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(1007, model.TriggerManual) // single-person
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	var row model.SummaryNotification
+	db.Where("task_id = ? AND recipient_uid = ?", 1007, "user-1").First(&row)
+	if row.Status != model.NotifyStatusFailed || row.AttemptCount != 1 {
+		t.Fatalf("fail-before: expected failed attempt=1, got status=%s attempt=%d", row.Status, row.AttemptCount)
+	}
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // retry succeeds
+	db.Where("task_id = ? AND recipient_uid = ?", 1007, "user-1").First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("pass-after: expected sent, got %s", row.Status)
+	}
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (fail + retry), got %d", len(d.sendCalls))
+	}
+}
+
+// (f) by-person 参与人查询出错时：绝不降级成「只发发起者的假成功」。
+// 之前 err 被静默吞掉 → 只 add(CreatorID) → 发起者被标 sent、participant 一行不建、
+// sweep 也发现不了，participant 永久漏发。修复后 resolveTargets 返回 err，
+// OnTaskTerminal 跳过整轮：不投递、不建任何行（尤其没有 creator 的 sent 行）。
+// 用一个缺 summary_participant 表的通知库触发真实查询错误（no such table）。
+func TestOnTaskTerminal_ByPerson_ParticipantQueryError_NoPartialSuccess(t *testing.T) {
+	// setupNotifyTestDB 只建 summary_notification，故意不建 summary_participant，
+	// 让 resolveTargets 的 Find(&parts) 真正报错（而非空结果）。
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := byPersonTask(1008) // creator=user-1, ModeByPerson
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	// fail-then-no-partial-success: 一条都不能发，尤其不能发给发起者。
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("participant query error must skip delivery entirely, got %d sends (%v)", len(d.sendCalls), sentUIDs(d))
+	}
+	// 一行都不能建：既不能有 creator 的 sent 行，也不能有任何 pending/failed 行。
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 1008).Count(&cnt)
+	if cnt != 0 {
+		t.Fatalf("participant query error must create NO notification rows (no fake creator success), got %d", cnt)
+	}
+	var creatorSent int64
+	db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND recipient_uid = ? AND status = ?", 1008, "user-1", model.NotifyStatusSent).
+		Count(&creatorSent)
+	if creatorSent != 0 {
+		t.Fatalf("must not produce a creator sent row on participant query error, got %d", creatorSent)
+	}
+}
+
+// (f-control) 参与人表存在且正常：新 (,, error) 签名不得回归多目标扇出。
+// 与 fail 用例对照，确认改动只在"查询出错"分支生效，正常路径依旧全绿。
+func TestOnTaskTerminal_ByPerson_ParticipantQueryOK_StillFansOut(t *testing.T) {
+	db := setupByPersonDB(t) // 建了 summary_participant 表
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := byPersonTask(1009) // creator=user-1
+	seedParticipants(t, db, 1009, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 3 {
+		t.Fatalf("normal path must still fan out to 3 recipients, got %d (%v)", len(d.sendCalls), got)
+	}
+	for _, uid := range []string{"p-a", "p-b", "user-1"} {
+		if got[uid] != 1 {
+			t.Fatalf("uid %s must receive exactly 1 DM, got %d (%v)", uid, got[uid], got)
+		}
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,349 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupNotifyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.SummaryNotification{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+// ensureCall records one EnsureFriend invocation.
+type ensureCall struct {
+	SpaceID string
+	UID     string
+}
+
+// fakeDeliverer records calls and can be told to fail.
+type fakeDeliverer struct {
+	mu          sync.Mutex
+	ensureCalls []ensureCall
+	sendCalls   []SendMessageRequest
+	failEnsure  error
+	failSend    error
+	sendErrOnce error // returned once then cleared (for retry tests)
+}
+
+func (f *fakeDeliverer) EnsureFriend(ctx context.Context, spaceID, uid string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureCalls = append(f.ensureCalls, ensureCall{SpaceID: spaceID, UID: uid})
+	return f.failEnsure
+}
+
+func (f *fakeDeliverer) SendMessage(ctx context.Context, msg SendMessageRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, msg)
+	if f.sendErrOnce != nil {
+		e := f.sendErrOnce
+		f.sendErrOnce = nil
+		return e
+	}
+	return f.failSend
+}
+
+func baseTask(id int64, trigger int) model.SummaryTask {
+	return model.SummaryTask{
+		ID:                id,
+		TaskNo:            "TST-1",
+		Title:             "今日群聊",
+		SpaceID:           "space-9",
+		CreatorID:         "user-1",
+		TriggerType:       trigger,
+		OriginChannelType: model.OriginChannelGlobal,
+	}
+}
+
+func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
+	n := New(db, d, cfg)
+	// Fixed clock at 10:00 Asia/Shanghai (outside the default quiet window).
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+	return n
+}
+
+func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	if len(d.ensureCalls) != 1 || d.ensureCalls[0].UID != "user-1" || d.ensureCalls[0].SpaceID != "space-9" {
+		t.Fatalf("expected ensureFriend(space-9, user-1), got %v", d.ensureCalls)
+	}
+	msg := d.sendCalls[0]
+	if msg.ChannelType != WireChannelDM || msg.ChannelID != "user-1" {
+		t.Fatalf("expected DM to user-1, got type=%d id=%s", msg.ChannelType, msg.ChannelID)
+	}
+	text, _ := msg.Payload["text"].(string)
+	if !strings.Contains(text, "今日群聊") || !strings.Contains(text, "https://app.example.com/summary/TST-1") {
+		t.Fatalf("completed text missing title/link: %q", text)
+	}
+	// OBO reserved fields must not be present.
+	if payloadHasOBOReserved(msg.Payload) {
+		t.Fatalf("payload leaked OBO reserved field: %v", msg.Payload)
+	}
+
+	var row model.SummaryNotification
+	db.Where("task_id = ? AND notify_kind = ?", 1, model.NotifyKindCompleted).First(&row)
+	if row.Status != model.NotifyStatusSent || row.SentAt == nil {
+		t.Fatalf("expected status=sent with sent_at, got status=%s sent_at=%v", row.Status, row.SentAt)
+	}
+}
+
+func TestOnTaskTerminal_FailedCarriesReason(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(2, model.TriggerManual), model.StatusFailed, "LLM timeout")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["text"].(string)
+	if !strings.Contains(text, "失败") || !strings.Contains(text, "LLM timeout") {
+		t.Fatalf("failed text missing reason: %q", text)
+	}
+}
+
+func TestOnTaskTerminal_DedupSameKindSendsOnce(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(3, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // duplicate
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // duplicate
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected exactly 1 send after 3 calls (dedup), got %d", len(d.sendCalls))
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 3).Count(&cnt)
+	if cnt != 1 {
+		t.Fatalf("expected exactly 1 notification row, got %d", cnt)
+	}
+}
+
+func TestOnTaskTerminal_CompletedAndFailedAreIndependent(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(4, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (completed + failed), got %d", len(d.sendCalls))
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 4).Count(&cnt)
+	if cnt != 2 {
+		t.Fatalf("expected 2 notification rows, got %d", cnt)
+	}
+}
+
+func TestOnTaskTerminal_CancelledNeverNotifies(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(5, model.TriggerManual), model.StatusCancelled, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("cancelled must not notify, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestOnTaskTerminal_DisabledIsNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: false})
+
+	n.OnTaskTerminal(baseTask(6, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("disabled must be no-op, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestOnTaskTerminal_FailureMarksFailedWithRetryBudget(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("network down: Bearer secret-token-123 leaked")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(7, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 7).First(&row)
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("expected status=failed, got %s", row.Status)
+	}
+	if row.AttemptCount != 1 {
+		t.Fatalf("expected attempt_count=1, got %d", row.AttemptCount)
+	}
+	if row.LastError == nil {
+		t.Fatalf("expected last_error set")
+	}
+	// SECRET must never be persisted to last_error.
+	if strings.Contains(*row.LastError, "secret-token-123") {
+		t.Fatalf("last_error leaked the bearer token: %q", *row.LastError)
+	}
+	if !strings.Contains(*row.LastError, "[REDACTED]") {
+		t.Fatalf("expected token redaction marker, got %q", *row.LastError)
+	}
+
+	// Second call has retry budget (1 < 3) and now succeeds.
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+	db.Where("task_id = ?", 7).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("expected retry to send, status=%s", row.Status)
+	}
+}
+
+func TestOnTaskTerminal_RetryBudgetExhausted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("always down")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 2})
+
+	task := baseTask(8, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 1
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 2 -> budget exhausted
+	sendsBefore := len(d.sendCalls)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // no budget -> must NOT send again
+
+	if len(d.sendCalls) != sendsBefore {
+		t.Fatalf("expected no further sends after budget exhausted; before=%d after=%d", sendsBefore, len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 8).First(&row)
+	if row.AttemptCount != 2 {
+		t.Fatalf("expected attempt_count capped at 2, got %d", row.AttemptCount)
+	}
+}
+
+func TestQuietWindow_SuppressesScheduledNotManual(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, d, Config{Enabled: true, QuietStart: "22:00", QuietEnd: "07:00"})
+	// Clock at 23:30 Asia/Shanghai (inside the overnight quiet window).
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 23, 30, 0, 0, timezone.Location()) }
+
+	// Scheduled task: suppressed.
+	n.OnTaskTerminal(baseTask(9, model.TriggerScheduled), model.StatusCompleted, "")
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("scheduled in quiet window must be suppressed, got %d sends", len(d.sendCalls))
+	}
+	// No row should be created when suppressed (we never claim).
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 9).Count(&cnt)
+	if cnt != 0 {
+		t.Fatalf("suppressed notification should not create a row, got %d", cnt)
+	}
+
+	// Manual task: never suppressed.
+	n.OnTaskTerminal(baseTask(10, model.TriggerManual), model.StatusCompleted, "")
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("manual task must not be suppressed, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestQuietWindow_OutsideWindowDelivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, QuietStart: "22:00", QuietEnd: "07:00"}) // clock 10:00 CST -> outside
+
+	n.OnTaskTerminal(baseTask(11, model.TriggerScheduled), model.StatusCompleted, "")
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("scheduled outside quiet window must deliver, got %d", len(d.sendCalls))
+	}
+}
+
+func TestResolveTarget_DMFallbackForAllOrigins(t *testing.T) {
+	origins := []int{model.OriginChannelGlobal, model.OriginChannelDM, model.OriginChannelGroup, model.OriginChannelThread}
+	for _, o := range origins {
+		task := baseTask(1, model.TriggerManual)
+		task.OriginChannelType = o
+		task.OriginChannelID = "origin-chan"
+		tgt, ok := resolveTarget(task)
+		if !ok {
+			t.Fatalf("origin %d: expected resolvable target", o)
+		}
+		if tgt.ChannelType != WireChannelDM || tgt.ChannelID != "user-1" || tgt.TargetUID != "user-1" {
+			t.Fatalf("origin %d: expected creator DM fallback, got %+v", o, tgt)
+		}
+	}
+}
+
+func TestResolveTarget_EmptyCreatorUnresolvable(t *testing.T) {
+	task := baseTask(1, model.TriggerManual)
+	task.CreatorID = ""
+	if _, ok := resolveTarget(task); ok {
+		t.Fatalf("empty creator must be unresolvable")
+	}
+}
+
+func TestParseHHMM(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"22:00", 22*60 + 0, true},
+		{"07:30", 7*60 + 30, true},
+		{"00:00", 0, true},
+		{"23:59", 23*60 + 59, true},
+		{"24:00", 0, false},
+		{"22", 0, false},
+		{"", 0, false},
+		{"aa:bb", 0, false},
+		{"12:60", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseHHMM(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("parseHHMM(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestPayloadHasOBOReserved(t *testing.T) {
+	if !payloadHasOBOReserved(map[string]any{"__obo_uid": "x"}) {
+		t.Errorf("expected __obo_ prefix detected")
+	}
+	if !payloadHasOBOReserved(map[string]any{"obo_sender": "x"}) {
+		t.Errorf("expected obo_ prefix detected")
+	}
+	if !payloadHasOBOReserved(map[string]any{"actual_sender_uid": "x"}) {
+		t.Errorf("expected actual_sender_uid detected")
+	}
+	if payloadHasOBOReserved(map[string]any{"text": "hello"}) {
+		t.Errorf("clean payload flagged as OBO")
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -83,6 +83,11 @@ func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
 	n := New(db, nil, d, cfg)
 	// Fixed clock at 10:00 Asia/Shanghai (outside the default quiet window).
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+	// Default test sanitizer is identity so existing tests can assert on the
+	// exact errMsg they pass in (e.g. "LLM timeout"). Production wires
+	// worker.SanitizeErrorForUser via WithErrorSanitizer; the dedicated R3
+	// regression tests below opt into that mapping explicitly.
+	n.errorSanitizer = func(s string) string { return s }
 	return n
 }
 
@@ -808,6 +813,9 @@ func TestBuildText_FailedIncludesSpaceAndReason(t *testing.T) {
 	}
 	d := &fakeDeliverer{}
 	n := New(db, imDB, d, Config{Enabled: true})
+	// Identity sanitizer: this test asserts space name + verbatim reason are
+	// composed together; it is not exercising the R3 scrub (covered separately).
+	n.errorSanitizer = func(s string) string { return s }
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
 
 	n.OnTaskTerminal(baseTask(302, model.TriggerManual), model.StatusFailed, "LLM timeout")
@@ -988,6 +996,90 @@ func TestRedeliver_PassesSpaceIDToSendMessage(t *testing.T) {
 	}
 }
 
+// --- R3 (PR#113 Jerry-Xin/OctoBoooot) — sweep redeliver MUST sanitize ---
+//
+// Regression test for the blocker reported on head fede1ab5: the sweep path
+// reloaded task.ErrorMessage raw from DB and rendered it into the user DM,
+// bypassing the worker-side SanitizeErrorForUser scrub applied only at
+// OnTaskTerminal call sites. We now sanitize at a single render point in
+// buildText, and the production wiring (cmd/summary-worker/main.go) injects
+// worker.SanitizeErrorForUser via WithErrorSanitizer. This test asserts that
+// the sanitizer is actually invoked on the sweep redeliver path — i.e. raw
+// internal substrings never reach the deliverer.
+func TestSweep_RedeliverSanitizesRawError(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	// Wire a strict sanitizer mimicking worker.SanitizeErrorForUser: anything
+	// containing raw markers maps to a fixed safe string. We can't import the
+	// worker package here (import cycle), so we cover the contract: the render
+	// point invokes the injected sanitizer, raw markers never reach the DM.
+	rawMarkers := []string{"dial tcp", "10.2.3.4", "postgres://", "goroutine", "secretpw"}
+	sanitizerCalls := 0
+	n.errorSanitizer = func(s string) string {
+		sanitizerCalls++
+		for _, m := range rawMarkers {
+			if strings.Contains(s, m) {
+				return "AI 处理失败，请稍后重试"
+			}
+		}
+		return s
+	}
+
+	// Raw err in the shape the reviewer flagged: DSN + IP + credential + stack head.
+	rawErr := "dial tcp 10.2.3.4:5432: connect: connection refused (dsn=postgres://user:secretpw@10.2.3.4:5432/db) goroutine 1 [running]"
+	task := baseTask(901, model.TriggerManual)
+	task.ErrorMessage = &rawErr
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// First call: synchronous path. Even on the immediate hop the new
+	// single-render-point sanitize runs, so the synchronous send (which fails
+	// once via sendErrOnce) must not leak the raw err either.
+	n.OnTaskTerminal(task, model.StatusFailed, rawErr)
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 901).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("precondition: expected failed after first send, got %s", row.Status)
+	}
+
+	// Sweep — this is the path that historically read task.ErrorMessage raw
+	// and rendered it unsanitized into the DM.
+	n.Sweep(context.Background())
+
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 send calls (1 initial fail + 1 sweep retry), got %d", len(d.sendCalls))
+	}
+	if sanitizerCalls < 2 {
+		t.Fatalf("sanitizer must be invoked on BOTH the synchronous AND the redeliver render; got calls=%d", sanitizerCalls)
+	}
+	for i, call := range d.sendCalls {
+		text, _ := call.Payload["content"].(string)
+		for _, m := range rawMarkers {
+			if strings.Contains(text, m) {
+				t.Fatalf("send #%d leaked raw marker %q into DM text:\n%s", i, m, text)
+			}
+		}
+		if !strings.Contains(text, "AI 处理失败，请稍后重试") {
+			t.Fatalf("send #%d missing safe failure reason; got:\n%s", i, text)
+		}
+	}
+
+	// Final state: sweep succeeded → sent.
+	db.Where("task_id = ?", 901).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("after sweep retry expected sent, got %s (attempts=%d)", row.Status, row.AttemptCount)
+	}
+}
+
 // TestHTTPDeliverer_SendMessage_SetsXSpaceIDHeader 用 httptest 起 server 捕获请求头，
 // 断言 SpaceID 非空时 sendMessage 请求带 X-Space-ID 头且值正确。这是真根因修复的
 // 核心断言：server 会 strip payload.space_id，只认这个头。
@@ -1160,5 +1252,35 @@ func TestDeliver_NilIMDB_AllowsDelivery(t *testing.T) {
 
 	if len(d.sendCalls) != 1 {
 		t.Fatalf("nil imDB: expected 1 send (fail-open), got %d", len(d.sendCalls))
+	}
+}
+
+// TestBuildText_NilSanitizerFallsBackToSafeString asserts the defensive
+// fallback: if Notifier is constructed without WithErrorSanitizer (production
+// misconfig), buildText still refuses to render raw err.Error() to the user
+// DM. This guards against future call sites accidentally forgetting the wiring.
+func TestBuildText_NilSanitizerFallsBackToSafeString(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	// Bypass newTestNotifier so we get a Notifier with nil errorSanitizer.
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	rawErr := "dial tcp 10.2.3.4: connect refused dsn=postgres://u:secretpw@h/db"
+	task := baseTask(902, model.TriggerManual)
+
+	n.OnTaskTerminal(task, model.StatusFailed, rawErr)
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	for _, m := range []string{"dial tcp", "10.2.3.4", "postgres://", "secretpw"} {
+		if strings.Contains(text, m) {
+			t.Fatalf("nil sanitizer must not leak raw marker %q to DM; text=%q", m, text)
+		}
+	}
+	if !strings.Contains(text, "AI 处理失败，请稍后重试") {
+		t.Fatalf("nil sanitizer fallback must render the safe default; text=%q", text)
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1548,9 +1548,21 @@ func setupByPersonDB(t *testing.T) *gorm.DB {
 func seedParticipants(t *testing.T, db *gorm.DB, taskID int64, uids ...string) {
 	t.Helper()
 	for _, uid := range uids {
-		if err := db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: uid}).Error; err != nil {
+		// Seed as an active (submitted) status so these fan-out/dedup/idempotency
+		// tests express "real participants who should receive the DM"; the default
+		// zero value is ParticipantPending, which resolveTargets now excludes.
+		if err := db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: uid, Status: model.ParticipantSubmitted}).Error; err != nil {
 			t.Fatalf("seed participant %s: %v", uid, err)
 		}
+	}
+}
+
+// seedParticipantStatus seeds one participant row with an explicit status,
+// so tests can exercise resolveTargets' pending/declined exclusion filter.
+func seedParticipantStatus(t *testing.T, db *gorm.DB, taskID int64, uid string, status int) {
+	t.Helper()
+	if err := db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: uid, Status: status}).Error; err != nil {
+		t.Fatalf("seed participant %s (status=%d): %v", uid, status, err)
 	}
 }
 
@@ -1811,5 +1823,48 @@ func TestOnTaskTerminal_ByPerson_ParticipantQueryOK_StillFansOut(t *testing.T) {
 		if got[uid] != 1 {
 			t.Fatalf("uid %s must receive exactly 1 DM, got %d (%v)", uid, got[uid], got)
 		}
+	}
+}
+
+// (g) by-person 状态过滤：resolveTargets 只 fan-out 真正参与的人。
+// pending(0)/declined(2) 成员绝不进扇出（不该收「总结完成」通知），
+// accepted(1)/submitted(5) 成员 + 发起者 CreatorID 必须在 targets 里。
+// 与生成阶段 (personal_processor.go) 排除 pending/declined 的口径对齐。
+// fail-before: 未加 status 过滤时全部 participant 都会被塞进 targets，
+// pending/declined 的断言会红；加过滤后变绿。
+func TestResolveTargets_ByPerson_ExcludesPendingAndDeclined(t *testing.T) {
+	db := setupByPersonDB(t)
+	n := newTestNotifier(db, &fakeDeliverer{}, Config{Enabled: true})
+
+	task := byPersonTask(1010) // creator=user-1, ModeByPerson
+	seedParticipantStatus(t, db, 1010, "p-pending", model.ParticipantPending)     // 0 -> excluded
+	seedParticipantStatus(t, db, 1010, "p-declined", model.ParticipantDeclined)   // 2 -> excluded
+	seedParticipantStatus(t, db, 1010, "p-accepted", model.ParticipantAccepted)   // 1 -> included
+	seedParticipantStatus(t, db, 1010, "p-submitted", model.ParticipantSubmitted) // 5 -> included
+
+	targets, err := n.resolveTargets(task)
+	if err != nil {
+		t.Fatalf("resolveTargets returned err: %v", err)
+	}
+
+	got := make(map[string]int)
+	for _, tgt := range targets {
+		got[tgt.TargetUID]++
+	}
+
+	// declined/pending must NOT be fanned out.
+	for _, uid := range []string{"p-pending", "p-declined"} {
+		if got[uid] != 0 {
+			t.Fatalf("uid %s (pending/declined) must be excluded from targets, got %d (all=%v)", uid, got[uid], got)
+		}
+	}
+	// accepted/submitted + creator must be present exactly once.
+	for _, uid := range []string{"p-accepted", "p-submitted", "user-1"} {
+		if got[uid] != 1 {
+			t.Fatalf("uid %s must appear exactly once in targets, got %d (all=%v)", uid, got[uid], got)
+		}
+	}
+	if len(targets) != 3 {
+		t.Fatalf("expected 3 targets (accepted + submitted + creator), got %d (%v)", len(targets), got)
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -3,8 +3,11 @@ package notify
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -38,6 +41,7 @@ type fakeDeliverer struct {
 	mu          sync.Mutex
 	ensureCalls []ensureCall
 	sendCalls   []SendMessageRequest
+	sendSpaceID []string // spaceID passed to each SendMessage (parallel to sendCalls)
 	failEnsure  error
 	failSend    error
 	sendErrOnce error // returned once then cleared (for retry tests)
@@ -50,10 +54,11 @@ func (f *fakeDeliverer) EnsureFriend(ctx context.Context, spaceID, uid string) e
 	return f.failEnsure
 }
 
-func (f *fakeDeliverer) SendMessage(ctx context.Context, msg SendMessageRequest) error {
+func (f *fakeDeliverer) SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sendCalls = append(f.sendCalls, msg)
+	f.sendSpaceID = append(f.sendSpaceID, spaceID)
 	if f.sendErrOnce != nil {
 		e := f.sendErrOnce
 		f.sendErrOnce = nil
@@ -75,7 +80,7 @@ func baseTask(id int64, trigger int) model.SummaryTask {
 }
 
 func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
-	n := New(db, d, cfg)
+	n := New(db, nil, d, cfg)
 	// Fixed clock at 10:00 Asia/Shanghai (outside the default quiet window).
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
 	return n
@@ -98,9 +103,17 @@ func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
 	if msg.ChannelType != WireChannelDM || msg.ChannelID != "user-1" {
 		t.Fatalf("expected DM to user-1, got type=%d id=%s", msg.ChannelType, msg.ChannelID)
 	}
-	text, _ := msg.Payload["text"].(string)
+	text, _ := msg.Payload["content"].(string)
 	if !strings.Contains(text, "今日群聊") || !strings.Contains(text, "https://app.example.com/summary/TST-1") {
 		t.Fatalf("completed text missing title/link: %q", text)
+	}
+	// octo-server recognizes a plain-text bot message by ContentType type=1 (Text)
+	// carrying "content"; a bare {"text":...} renders empty. Assert the wire shape.
+	if tp, _ := msg.Payload["type"].(int); tp != 1 {
+		t.Fatalf("expected payload type=1 (Text), got %v", msg.Payload["type"])
+	}
+	if _, ok := msg.Payload["text"]; ok {
+		t.Fatalf("payload must not carry legacy 'text' key, got %v", msg.Payload)
 	}
 	// OBO reserved fields must not be present.
 	if payloadHasOBOReserved(msg.Payload) {
@@ -124,7 +137,7 @@ func TestOnTaskTerminal_FailedCarriesReason(t *testing.T) {
 	if len(d.sendCalls) != 1 {
 		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
 	}
-	text, _ := d.sendCalls[0].Payload["text"].(string)
+	text, _ := d.sendCalls[0].Payload["content"].(string)
 	if !strings.Contains(text, "失败") || !strings.Contains(text, "LLM timeout") {
 		t.Fatalf("failed text missing reason: %q", text)
 	}
@@ -252,7 +265,7 @@ func TestOnTaskTerminal_RetryBudgetExhausted(t *testing.T) {
 func TestQuietWindow_SuppressesScheduledNotManual(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	d := &fakeDeliverer{}
-	n := New(db, d, Config{Enabled: true, QuietStart: "22:00", QuietEnd: "07:00"})
+	n := New(db, nil, d, Config{Enabled: true, QuietStart: "22:00", QuietEnd: "07:00"})
 	// Clock at 23:30 Asia/Shanghai (inside the overnight quiet window).
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 23, 30, 0, 0, timezone.Location()) }
 
@@ -576,9 +589,576 @@ func TestSweep_DoesNotReclaimFreshPendingRow(t *testing.T) {
 func TestSweep_DisabledIsNoop(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	d := &fakeDeliverer{}
-	n := New(db, d, Config{Enabled: false})
+	n := New(db, nil, d, Config{Enabled: false})
 	n.Sweep(context.Background()) // must not panic / not query
 	if len(d.sendCalls) != 0 {
 		t.Fatalf("disabled notifier sweep must be no-op")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTPDeliverer lazy-token tests (启动顺序竞态修复 / OCT-5)
+//
+// 这些测试验证：bot token 在投递时 lazy 解析（而非启动时固化），空值不缓存使得
+// server 晚起后能最终恢复，非空值缓存命中后不再调用 tokenFn，且 lazy 解析到的
+// token 确实出现在 Authorization 头里。
+// ---------------------------------------------------------------------------
+
+// TestHTTPDeliverer_LazyToken_EmptyThenNonEmpty_NotCachedRecovers 模拟 worker 先起、
+// server 晚写 token：tokenFn 首次返回空（投递失败），第二次返回非空（投递成功）。
+// 验证 deliverer 不缓存空值，第二次能拿到 token —— 即启动顺序竞态被修复，无需重启。
+func TestHTTPDeliverer_LazyToken_EmptyThenNonEmpty_NotCachedRecovers(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var calls int32
+	tokenFn := func() (string, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return "", nil // server 尚未写库
+		}
+		return "late-token", nil // server 已写库
+	}
+
+	d := NewHTTPDelivererWithTokenFunc(srv.URL, tokenFn)
+
+	// 首次投递：token 为空 → 应失败（best-effort 失败处理会吞掉），不 panic。
+	err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM})
+	if err == nil {
+		t.Fatalf("expected first delivery to fail because token is empty")
+	}
+
+	// 第二次投递：token 已可用 → 应成功，且不缓存上一次的空值。
+	if err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("expected second delivery to succeed after token became available, got: %v", err)
+	}
+	if gotAuth != "Bearer late-token" {
+		t.Fatalf("expected Authorization to carry lazily-resolved token, got %q", gotAuth)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected tokenFn called twice (empty not cached), got %d", got)
+	}
+}
+
+// TestHTTPDeliverer_LazyToken_AlwaysEmpty_FailsNoPanic 验证 tokenFn 持续返回空时，
+// post 返回错误而非 panic；上层 best-effort 失败处理负责吞掉。
+func TestHTTPDeliverer_LazyToken_AlwaysEmpty_FailsNoPanic(t *testing.T) {
+	tokenFn := func() (string, error) { return "", nil }
+	d := NewHTTPDelivererWithTokenFunc("http://127.0.0.1:0", tokenFn)
+
+	err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM})
+	if err == nil {
+		t.Fatalf("expected error when token stays empty")
+	}
+	// 再调一次仍应失败（空值不缓存、不永久禁用）。
+	if err := d.EnsureFriend(context.Background(), "s1", "u1"); err == nil {
+		t.Fatalf("expected error on EnsureFriend when token stays empty")
+	}
+}
+
+// TestHTTPDeliverer_LazyToken_TokenFnError_Propagates 验证 tokenFn 返回 error 时
+// 投递失败、错误传播，不缓存、不 panic（模拟 imDB 查询出错）。
+func TestHTTPDeliverer_LazyToken_TokenFnError_Propagates(t *testing.T) {
+	tokenFn := func() (string, error) { return "", errors.New("db down") }
+	d := NewHTTPDelivererWithTokenFunc("http://127.0.0.1:0", tokenFn)
+
+	err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM})
+	if err == nil {
+		t.Fatalf("expected error when tokenFn errors")
+	}
+}
+
+// TestHTTPDeliverer_LazyToken_NonEmptyCached_TokenFnNotReinvoked 验证缓存命中：
+// tokenFn 返回非空后被缓存，后续投递不再调用 tokenFn（用计数器断言）。
+func TestHTTPDeliverer_LazyToken_NonEmptyCached_TokenFnNotReinvoked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var calls int32
+	tokenFn := func() (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "cached-token", nil
+	}
+	d := NewHTTPDelivererWithTokenFunc(srv.URL, tokenFn)
+
+	for i := 0; i < 5; i++ {
+		if err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+			t.Fatalf("delivery %d failed: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected tokenFn invoked once (cached afterwards), got %d", got)
+	}
+}
+
+// TestHTTPDeliverer_BackwardCompat_FixedToken 验证旧构造 NewHTTPDeliverer 仍可用，
+// 固定 token 出现在 Authorization 头里（向后兼容）。
+func TestHTTPDeliverer_BackwardCompat_FixedToken(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDeliverer(srv.URL, "fixed-secret")
+	if err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("backward-compat delivery failed: %v", err)
+	}
+	if gotAuth != "Bearer fixed-secret" {
+		t.Fatalf("expected fixed token in Authorization, got %q", gotAuth)
+	}
+}
+
+// TestHTTPDeliverer_SendMessage_AttachesXSpaceIDHeader asserts the X-Space-ID
+// header carries the spaceID on the wire. octo-server STRIPS client
+// payload.space_id for a system-bot DM and only trusts the value resolved from
+// the X-Space-ID header (adopted when the recipient is an active member of that
+// space). Without this header the notification is filtered out as a system-bot
+// message with no space_id. Empty spaceID must NOT send the header.
+func TestHTTPDeliverer_SendMessage_AttachesXSpaceIDHeader(t *testing.T) {
+	var gotHeader string
+	var present bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Space-ID")
+		_, present = r.Header["X-Space-Id"] // canonical MIME key for X-Space-ID
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	d := NewHTTPDeliverer(srv.URL, "tok")
+
+	// non-empty spaceID → header present with that value.
+	if err := d.SendMessage(context.Background(), "space-9", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if !present || gotHeader != "space-9" {
+		t.Fatalf("expected X-Space-ID=space-9, present=%v got=%q", present, gotHeader)
+	}
+
+	// empty spaceID → header absent (avoid sending a meaningless/forgeable hint).
+	gotHeader, present = "", false
+	if err := d.SendMessage(context.Background(), "", SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if present {
+		t.Fatalf("expected no X-Space-ID header when spaceID empty, got %q", gotHeader)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PR#113 notify — payload wire shape + 「空间名 + 总结名称」文本
+// ---------------------------------------------------------------------------
+
+// setupIMTestDB builds an in-memory IM DB with just the `space` table that
+// resolveSpaceName reads (read-only raw SELECT). Schema is NOT owned by this
+// service — created here only to back the unit test.
+func setupIMTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE space (space_id TEXT PRIMARY KEY, name TEXT)").Error; err != nil {
+		t.Fatalf("create space table: %v", err)
+	}
+	return db
+}
+
+// TestBuildText_CompletedIncludesSpaceAndTitle 注入可控 imDB 让 resolveSpaceName
+// 返回已知空间名，断言成功文本同时含「空间「<名>」」与「总结「<Title>」」。
+func TestBuildText_CompletedIncludesSpaceAndTitle(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDB(t)
+	if err := imDB.Exec("INSERT INTO space (space_id, name) VALUES (?, ?)", "space-9", "研发一组").Error; err != nil {
+		t.Fatalf("seed space: %v", err)
+	}
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(301, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if !strings.Contains(text, "空间「研发一组」") {
+		t.Fatalf("completed text missing space name: %q", text)
+	}
+	if !strings.Contains(text, "总结「今日群聊」") {
+		t.Fatalf("completed text missing title: %q", text)
+	}
+	if !strings.Contains(text, "https://app.example.com/summary/TST-1") {
+		t.Fatalf("completed text missing link: %q", text)
+	}
+}
+
+// TestBuildText_FailedIncludesSpaceAndReason 断言失败文本含空间名 + 失败原因。
+func TestBuildText_FailedIncludesSpaceAndReason(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDB(t)
+	if err := imDB.Exec("INSERT INTO space (space_id, name) VALUES (?, ?)", "space-9", "研发一组").Error; err != nil {
+		t.Fatalf("seed space: %v", err)
+	}
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(302, model.TriggerManual), model.StatusFailed, "LLM timeout")
+
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if !strings.Contains(text, "空间「研发一组」") {
+		t.Fatalf("failed text missing space name: %q", text)
+	}
+	if !strings.Contains(text, "总结「今日群聊」") || !strings.Contains(text, "失败") {
+		t.Fatalf("failed text missing title/失败: %q", text)
+	}
+	if !strings.Contains(text, "LLM timeout") {
+		t.Fatalf("failed text missing reason: %q", text)
+	}
+}
+
+// TestBuildText_DegradesWhenIMDBNil 降级路径：imDB 为 nil 时退回不带空间名的旧文案。
+func TestBuildText_DegradesWhenIMDBNil(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(303, model.TriggerManual), model.StatusCompleted, "")
+
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "空间「") {
+		t.Fatalf("nil imDB must degrade to space-less wording, got %q", text)
+	}
+	if text != "你的总结「今日群聊」已生成完成。\n查看结果：https://app.example.com/summary/TST-1" {
+		t.Fatalf("degraded text mismatch: %q", text)
+	}
+}
+
+// TestBuildText_DegradesWhenSpaceNotFound 降级路径：imDB 在但查不到该 space_id，
+// 同样退回旧文案，且绝不阻断投递。
+func TestBuildText_DegradesWhenSpaceNotFound(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDB(t) // table exists but no matching row
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(304, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("delivery must not be blocked by missing space, got %d sends", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "空间「") {
+		t.Fatalf("missing space row must degrade to space-less wording, got %q", text)
+	}
+	if !strings.Contains(text, "你的总结「今日群聊」已生成完成。") {
+		t.Fatalf("degraded text mismatch: %q", text)
+	}
+}
+
+// TestResolveSpaceName_NilReceiverAndNilDB 直接覆盖 resolveSpaceName 的 nil 防护。
+func TestResolveSpaceName_NilReceiverAndNilDB(t *testing.T) {
+	var nilN *Notifier
+	if got := nilN.resolveSpaceName(baseTask(1, model.TriggerManual)); got != "" {
+		t.Fatalf("nil receiver must return empty, got %q", got)
+	}
+	n := New(setupNotifyTestDB(t), nil, &fakeDeliverer{}, Config{Enabled: true})
+	if got := n.resolveSpaceName(baseTask(1, model.TriggerManual)); got != "" {
+		t.Fatalf("nil imDB must return empty, got %q", got)
+	}
+	// Empty SpaceID short-circuits even with a live imDB.
+	n2 := New(setupNotifyTestDB(t), setupIMTestDB(t), &fakeDeliverer{}, Config{Enabled: true})
+	task := baseTask(1, model.TriggerManual)
+	task.SpaceID = ""
+	if got := n2.resolveSpaceName(task); got != "" {
+		t.Fatalf("empty space_id must return empty, got %q", got)
+	}
+}
+
+// --- space_id in payload (system-bot space filter fix) ---
+
+// TestDeliver_PayloadCarriesSpaceID_WhenKnown asserts the delivered payload
+// includes space_id when the target SpaceID is non-empty. Summary runs as a
+// system bot; octo-server's filterPersonMessagesBySpace drops a system-bot
+// message whose payload has an empty space_id, so it must be carried through.
+// fail-before: deliver previously built the payload without space_id, so this
+// key assertion would have failed.
+func TestDeliver_PayloadCarriesSpaceID_WhenKnown(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+
+	// baseTask carries SpaceID="space-9".
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	got, ok := d.sendCalls[0].Payload["space_id"]
+	if !ok {
+		t.Fatalf("payload must carry space_id when target.SpaceID is set, got %v", d.sendCalls[0].Payload)
+	}
+	if got != "space-9" {
+		t.Fatalf("expected space_id=space-9, got %v", got)
+	}
+}
+
+// TestDeliver_PayloadOmitsSpaceID_WhenEmpty asserts the payload does NOT
+// include a space_id key when the target SpaceID is empty, avoiding a
+// regression on the empty-SpaceID path.
+func TestDeliver_PayloadOmitsSpaceID_WhenEmpty(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+
+	task := baseTask(1, model.TriggerManual)
+	task.SpaceID = ""
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	if _, ok := d.sendCalls[0].Payload["space_id"]; ok {
+		t.Fatalf("payload must not carry space_id when target.SpaceID is empty, got %v", d.sendCalls[0].Payload)
+	}
+}
+
+// --- X-Space-ID header (system-bot DM fail-closed space resolution fix) ---
+//
+// 真根因：summary 是系统 bot，octo-server 对系统 bot 的 DM fail-closed：client 在
+// payload 里传的 space_id 一律被 strip，server 只认自己解析的权威 space_id。解析
+// 路径上 worker 唯一可控的输入是 HTTP 请求头 X-Space-ID —— 当接收人是该 space 活跃
+// 成员（CheckMembership=true）时 server 采纳该头并注入权威 payload.space_id。因此
+// worker 发 sendMessage / ensureFriend 必须带 X-Space-ID 头，光改 payload 无效。
+
+// TestDeliver_PassesSpaceIDToSendMessage 断言 deliver()（OnTaskTerminal 路径）把
+// target.SpaceID 透传给 Deliverer.SendMessage 的 spaceID 参数 —— 这是 X-Space-ID
+// 头值的来源。fail-before：旧 SendMessage 签名没有 spaceID 参数，无从透传。
+func TestDeliver_PassesSpaceIDToSendMessage(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	// baseTask carries SpaceID="space-9".
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendSpaceID) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendSpaceID))
+	}
+	if d.sendSpaceID[0] != "space-9" {
+		t.Fatalf("expected spaceID=space-9 passed to SendMessage, got %q", d.sendSpaceID[0])
+	}
+}
+
+// TestRedeliver_PassesSpaceIDToSendMessage 确认 redeliver（sweep 重投递）路径同样
+// 经过 deliver→SendMessage，因此也带上权威 spaceID。
+func TestRedeliver_PassesSpaceIDToSendMessage(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(401, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // first attempt fails, row -> failed
+
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.Sweep(context.Background()) // redeliver path
+
+	if len(d.sendSpaceID) != 2 {
+		t.Fatalf("expected 2 sends (initial + sweep redeliver), got %d", len(d.sendSpaceID))
+	}
+	for i, sid := range d.sendSpaceID {
+		if sid != "space-9" {
+			t.Fatalf("send #%d: expected spaceID=space-9 (redeliver must carry it too), got %q", i, sid)
+		}
+	}
+}
+
+// TestHTTPDeliverer_SendMessage_SetsXSpaceIDHeader 用 httptest 起 server 捕获请求头，
+// 断言 SpaceID 非空时 sendMessage 请求带 X-Space-ID 头且值正确。这是真根因修复的
+// 核心断言：server 会 strip payload.space_id，只认这个头。
+func TestHTTPDeliverer_SendMessage_SetsXSpaceIDHeader(t *testing.T) {
+	var gotSpace string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSpace = r.Header.Get("X-Space-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDeliverer(srv.URL, "tok")
+	if err := d.SendMessage(context.Background(), "space-9",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if gotSpace != "space-9" {
+		t.Fatalf("expected X-Space-ID=space-9, got %q", gotSpace)
+	}
+}
+
+// TestHTTPDeliverer_SendMessage_OmitsXSpaceIDHeader_WhenEmpty 断言 SpaceID 为空时
+// 不带 X-Space-ID 头（保持向后兼容，不引入空头）。
+func TestHTTPDeliverer_SendMessage_OmitsXSpaceIDHeader_WhenEmpty(t *testing.T) {
+	var present bool
+	var gotSpace string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = r.Header["X-Space-Id"] // canonical MIME key for X-Space-ID
+		gotSpace = r.Header.Get("X-Space-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDeliverer(srv.URL, "tok")
+	if err := d.SendMessage(context.Background(), "",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if present || gotSpace != "" {
+		t.Fatalf("expected NO X-Space-ID header when spaceID empty, got present=%v value=%q", present, gotSpace)
+	}
+}
+
+// TestHTTPDeliverer_SendMessage_TrimsXSpaceIDHeader 断言头值不带前后空格（即便调用
+// 方传入带空格的 spaceID，spaceHeader 也会 TrimSpace，避免引入脏值）。
+func TestHTTPDeliverer_SendMessage_TrimsXSpaceIDHeader(t *testing.T) {
+	var gotSpace string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSpace = r.Header.Get("X-Space-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDeliverer(srv.URL, "tok")
+	if err := d.SendMessage(context.Background(), "  space-9  ",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM}); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if gotSpace != "space-9" {
+		t.Fatalf("expected trimmed X-Space-ID=space-9, got %q", gotSpace)
+	}
+}
+
+// TestHTTPDeliverer_EnsureFriend_SetsXSpaceIDHeader 断言 ensureFriend 也带 X-Space-ID
+// 头（同一权威 space 解析路径），SpaceID 为空时不带。
+func TestHTTPDeliverer_EnsureFriend_SetsXSpaceIDHeader(t *testing.T) {
+	var gotSpace string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSpace = r.Header.Get("X-Space-ID")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewHTTPDeliverer(srv.URL, "tok")
+	if err := d.EnsureFriend(context.Background(), "space-9", "u1"); err != nil {
+		t.Fatalf("ensureFriend failed: %v", err)
+	}
+	if gotSpace != "space-9" {
+		t.Fatalf("expected X-Space-ID=space-9 on ensureFriend, got %q", gotSpace)
+	}
+
+	gotSpace = ""
+	if err := d.EnsureFriend(context.Background(), "", "u1"); err != nil {
+		t.Fatalf("ensureFriend (empty space) failed: %v", err)
+	}
+	if gotSpace != "" {
+		t.Fatalf("expected NO X-Space-ID header when spaceID empty, got %q", gotSpace)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 轻量防护：接收人非该 space 活跃成员时，deliver 应显式失败，而非静默「已发送」
+// （octo-server 对系统 bot DM 在接收人非成员时会 strip space_id 但仍返 200，
+// 导致消息被丢弃、用户看不到；worker 侧预检把静默丢失转成显式失败。）
+// ---------------------------------------------------------------------------
+
+// setupIMTestDBWithMembers 建带 space + space_member 两表的内存 IM 库，用于成员校验。
+func setupIMTestDBWithMembers(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE space (space_id TEXT PRIMARY KEY, name TEXT, status INTEGER)").Error; err != nil {
+		t.Fatalf("create space table: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE space_member (space_id TEXT, uid TEXT, status INTEGER)").Error; err != nil {
+		t.Fatalf("create space_member table: %v", err)
+	}
+	return db
+}
+
+// TestDeliver_ActiveMember_Delivers 接收人是活跃成员 → 正常投递。
+func TestDeliver_ActiveMember_Delivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDBWithMembers(t)
+	imDB.Exec("INSERT INTO space (space_id, name, status) VALUES (?,?,1)", "space-9", "研发一组")
+	imDB.Exec("INSERT INTO space_member (space_id, uid, status) VALUES (?,?,1)", "space-9", "user-1")
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(501, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("active member: expected 1 send, got %d", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	if err := db.Where("task_id=?", 501).First(&row).Error; err != nil {
+		t.Fatalf("load notification: %v", err)
+	}
+	if row.Status != "sent" {
+		t.Fatalf("active member: expected status=sent, got %q", row.Status)
+	}
+}
+
+// TestDeliver_NonMember_FailsNotSilentSent 接收人非活跃成员 → 不发送，记录 failed（非 sent）。
+func TestDeliver_NonMember_FailsNotSilentSent(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDBWithMembers(t)
+	imDB.Exec("INSERT INTO space (space_id, name, status) VALUES (?,?,1)", "space-9", "研发一组")
+	// user-1 有一行但 status=2（被降权/退出）→ 非活跃成员。
+	imDB.Exec("INSERT INTO space_member (space_id, uid, status) VALUES (?,?,2)", "space-9", "user-1")
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(502, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("non-member: expected 0 send (blocked), got %d", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	if err := db.Where("task_id=?", 502).First(&row).Error; err != nil {
+		t.Fatalf("load notification: %v", err)
+	}
+	if row.Status == "sent" {
+		t.Fatalf("non-member: notification wrongly marked sent (silent-success trap not closed)")
+	}
+}
+
+// TestDeliver_NilIMDB_AllowsDelivery imDB 为 nil → 无法校验 → 放行（不阻断，server 兜底）。
+func TestDeliver_NilIMDB_AllowsDelivery(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(503, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("nil imDB: expected 1 send (fail-open), got %d", len(d.sendCalls))
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -94,7 +94,7 @@ func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
 func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	d := &fakeDeliverer{}
-	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n := newTestNotifier(db, d, Config{Enabled: true})
 
 	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
 
@@ -109,8 +109,13 @@ func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
 		t.Fatalf("expected DM to user-1, got type=%d id=%s", msg.ChannelType, msg.ChannelID)
 	}
 	text, _ := msg.Payload["content"].(string)
-	if !strings.Contains(text, "今日群聊") || !strings.Contains(text, "https://app.example.com/summary/TST-1") {
-		t.Fatalf("completed text missing title/link: %q", text)
+	if !strings.Contains(text, "今日群聊") {
+		t.Fatalf("completed text missing title: %q", text)
+	}
+	// The unreachable WKApp-internal result link was removed (see notify.go
+	// buildText); success notifications must NOT carry a browser URL anymore.
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") {
+		t.Fatalf("completed text must not carry a result link anymore: %q", text)
 	}
 	// octo-server recognizes a plain-text bot message by ContentType type=1 (Text)
 	// carrying "content"; a bare {"text":...} renders empty. Assert the wire shape.
@@ -784,7 +789,7 @@ func TestBuildText_CompletedIncludesSpaceAndTitle(t *testing.T) {
 		t.Fatalf("seed space: %v", err)
 	}
 	d := &fakeDeliverer{}
-	n := New(db, imDB, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n := New(db, imDB, d, Config{Enabled: true})
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
 
 	n.OnTaskTerminal(baseTask(301, model.TriggerManual), model.StatusCompleted, "")
@@ -799,12 +804,75 @@ func TestBuildText_CompletedIncludesSpaceAndTitle(t *testing.T) {
 	if !strings.Contains(text, "总结「今日群聊」") {
 		t.Fatalf("completed text missing title: %q", text)
 	}
-	if !strings.Contains(text, "https://app.example.com/summary/TST-1") {
-		t.Fatalf("completed text missing link: %q", text)
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") {
+		t.Fatalf("completed text must not carry a result link anymore: %q", text)
 	}
 }
 
-// TestBuildText_FailedIncludesSpaceAndReason 断言失败文本含空间名 + 失败原因。
+// TestBuildText_CompletedIncludesRichMeta 验证成功通知追加的完整元信息：
+// 时间范围 + 参与成员数 + 消息数量 + 生成时间（替代已删除的不可达链接）。
+// 都是 best-effort，此处 seed 齐数据确认都渲染出来。
+func TestBuildText_CompletedIncludesRichMeta(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	// Seed the read-only source tables buildText best-effort queries.
+	if err := db.Exec("CREATE TABLE summary_result (id INTEGER PRIMARY KEY, task_id INTEGER, total_msg_count INTEGER, version INTEGER, generated_at DATETIME)").Error; err != nil {
+		t.Fatalf("create summary_result: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE summary_participant (id INTEGER PRIMARY KEY, task_id INTEGER)").Error; err != nil {
+		t.Fatalf("create summary_participant: %v", err)
+	}
+	gen := time.Date(2026, 6, 26, 9, 30, 0, 0, timezone.Location())
+	db.Exec("INSERT INTO summary_result (task_id, total_msg_count, version, generated_at) VALUES (?,?,?,?)", 601, 128, 1, gen)
+	db.Exec("INSERT INTO summary_participant (task_id) VALUES (?),(?),(?)", 601, 601, 601)
+
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	task := baseTask(601, model.TriggerManual)
+	task.TimeRangeStart = time.Date(2026, 6, 25, 0, 0, 0, 0, timezone.Location())
+	task.TimeRangeEnd = time.Date(2026, 6, 25, 23, 59, 0, 0, timezone.Location())
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	for _, want := range []string{
+		"已生成完成",
+		"时间范围：2026-06-25 00:00 ~ 2026-06-25 23:59",
+		"参与成员：3 人",
+		"消息数量：128 条",
+		"生成时间：2026-06-26 09:30",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("completed text missing %q; full text:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") {
+		t.Fatalf("completed text must not carry a link: %q", text)
+	}
+}
+
+// TestParticipantCount_SinglePersonOmitted 单人任务（无 participant 行）不渲染
+// 「参与成员」行；meta 表不存在时也优雅降级不崩。
+func TestParticipantCount_SinglePersonOmitted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(602, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send (best-effort must not block), got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "参与成员") {
+		t.Fatalf("single-person task must omit member line; got %q", text)
+	}
+}
 func TestBuildText_FailedIncludesSpaceAndReason(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	imDB := setupIMTestDB(t)
@@ -836,7 +904,7 @@ func TestBuildText_FailedIncludesSpaceAndReason(t *testing.T) {
 func TestBuildText_DegradesWhenIMDBNil(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	d := &fakeDeliverer{}
-	n := New(db, nil, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n := New(db, nil, d, Config{Enabled: true})
 	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
 
 	n.OnTaskTerminal(baseTask(303, model.TriggerManual), model.StatusCompleted, "")
@@ -845,7 +913,7 @@ func TestBuildText_DegradesWhenIMDBNil(t *testing.T) {
 	if strings.Contains(text, "空间「") {
 		t.Fatalf("nil imDB must degrade to space-less wording, got %q", text)
 	}
-	if text != "你的总结「今日群聊」已生成完成。\n查看结果：https://app.example.com/summary/TST-1" {
+	if text != "你的总结「今日群聊」已生成完成。" {
 		t.Fatalf("degraded text mismatch: %q", text)
 	}
 }
@@ -903,7 +971,7 @@ func TestResolveSpaceName_NilReceiverAndNilDB(t *testing.T) {
 func TestDeliver_PayloadCarriesSpaceID_WhenKnown(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	d := &fakeDeliverer{}
-	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n := newTestNotifier(db, d, Config{Enabled: true})
 
 	// baseTask carries SpaceID="space-9".
 	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
@@ -926,7 +994,7 @@ func TestDeliver_PayloadCarriesSpaceID_WhenKnown(t *testing.T) {
 func TestDeliver_PayloadOmitsSpaceID_WhenEmpty(t *testing.T) {
 	db := setupNotifyTestDB(t)
 	d := &fakeDeliverer{}
-	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://app.example.com"})
+	n := newTestNotifier(db, d, Config{Enabled: true})
 
 	task := baseTask(1, model.TriggerManual)
 	task.SpaceID = ""

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -345,5 +346,239 @@ func TestPayloadHasOBOReserved(t *testing.T) {
 	}
 	if payloadHasOBOReserved(map[string]any{"text": "hello"}) {
 		t.Errorf("clean payload flagged as OBO")
+	}
+}
+
+// --- B2 (PR#113 review P1-2) ---
+
+func TestMarkFailed_TruncatesAtRuneBoundary_NoUTF8Wedge(t *testing.T) {
+	// Reviewer P1-2: byte-wise truncation of a CJK error string could sever a
+	// multi-byte rune; under MySQL strict mode the resulting invalid UTF-8
+	// rejects the UPDATE and the row stays at 'pending' forever.
+	// truncateForLastError must produce a valid UTF-8 string and the row must
+	// reach 'failed'.
+	db := setupNotifyTestDB(t)
+	// Long CJK error message: 300 三-byte runes = 900 bytes, well past the
+	// 480-byte cap so the byte cut would almost certainly land mid-rune.
+	longCJK := strings.Repeat("中", 300)
+	d := &fakeDeliverer{failSend: errors.New("octo-server boom: " + longCJK)}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	n.OnTaskTerminal(baseTask(101, model.TriggerManual), model.StatusFailed, "x")
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 101).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("expected status=failed (markFailed must not wedge at pending), got %s", row.Status)
+	}
+	if row.LastError == nil {
+		t.Fatalf("expected last_error to be set")
+	}
+	le := *row.LastError
+	if !utf8.ValidString(le) {
+		t.Fatalf("last_error must be valid UTF-8 after truncation, got bytes=%q", []byte(le))
+	}
+	if len(le) > 480 {
+		t.Fatalf("last_error must be ≤480 bytes for VARCHAR(500) utf8mb4 headroom, got %d", len(le))
+	}
+	// Must still carry the original prefix so operators can diagnose.
+	// The deliver layer wraps with "sendMessage: "; the prefix must still
+	// contain the original error head so operators can diagnose.
+	if !strings.Contains(le, "octo-server boom:") {
+		t.Fatalf("expected truncated message to keep diagnostic prefix, got %q", le)
+	}
+}
+
+func TestTruncateForLastError_ShortInputUnchanged(t *testing.T) {
+	in := "short ascii error"
+	if got := truncateForLastError(in); got != in {
+		t.Fatalf("short input must pass through, got %q", got)
+	}
+	cjk := "失败：LLM 超时"
+	if got := truncateForLastError(cjk); got != cjk {
+		t.Fatalf("short CJK input must pass through, got %q", got)
+	}
+}
+
+func TestTruncateForLastError_NeverSplitsRune(t *testing.T) {
+	// Build a string whose byte length crosses the 480 cap exactly inside a
+	// multi-byte rune so a naive [:480] slice would produce invalid UTF-8.
+	// 中 is 3 bytes; placing 160 of them gives 480 bytes (boundary-aligned),
+	// then a 4-byte rune (𠮷, U+20BB7) starting at byte 480 ensures the cut
+	// would land mid-rune for any cap inside that rune. We assert validity for
+	// a sweep of caps around the boundary by repeatedly building inputs that
+	// straddle.
+	inputs := []string{
+		strings.Repeat("中", 160) + "𠮷" + strings.Repeat("a", 100),
+		strings.Repeat("a", 479) + "𠮷xx",
+		strings.Repeat("a", 478) + "中" + strings.Repeat("b", 100),
+		strings.Repeat("a", 477) + "中" + strings.Repeat("b", 100),
+	}
+	for i, in := range inputs {
+		out := truncateForLastError(in)
+		if !utf8.ValidString(out) {
+			t.Errorf("case %d: output not valid UTF-8: %q", i, out)
+		}
+		if len(out) > 480 {
+			t.Errorf("case %d: output too long: %d bytes", i, len(out))
+		}
+	}
+}
+
+// --- B1 (PR#113 review P1-1) — background sweep ---
+
+func TestSweep_RetriesFailedRowWithBudget(t *testing.T) {
+	// Simulates the common case: first OnTaskTerminal sees a transient HTTP
+	// failure and leaves the row at status='failed', attempt_count=1. No
+	// further OnTaskTerminal will fire (terminal callbacks are one-shot per
+	// task transition). Sweep must redeliver and reach status='sent'.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(201, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 201).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("precondition: expected failed after first attempt, got %s", row.Status)
+	}
+
+	// Persist the original task so redeliver can reload it.
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	db.Where("task_id = ?", 201).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("sweep must redeliver and mark sent, got status=%s attempts=%d", row.Status, row.AttemptCount)
+	}
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 send calls (1 initial fail + 1 sweep retry), got %d", len(d.sendCalls))
+	}
+}
+
+func TestSweep_DoesNotRetryWhenBudgetExhausted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("always down")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 2})
+
+	task := baseTask(202, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 1
+	n.Sweep(context.Background())                   // attempt 2 -> exhausted
+	sendsBefore := len(d.sendCalls)
+	n.Sweep(context.Background()) // must not retry
+
+	if len(d.sendCalls) != sendsBefore {
+		t.Fatalf("expected no further sends; before=%d after=%d", sendsBefore, len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 202).First(&row)
+	if row.AttemptCount != 2 {
+		t.Fatalf("attempt_count must cap at MaxAttempts=2, got %d", row.AttemptCount)
+	}
+}
+
+func TestSweep_ReclaimsStalePendingRow(t *testing.T) {
+	// Simulates a worker crash between claim() and markSent/markFailed: the
+	// row is left at status='pending' and would normally be skipped by every
+	// future OnTaskTerminal (dedup) forever. Sweep must reclaim it past the
+	// lease and redeliver.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(203, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// Inject a stale pending row directly: updated_at well past the lease.
+	stale := n.now().Add(-2 * PendingLease)
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:     203,
+		NotifyKind: model.NotifyKindCompleted,
+		Status:     model.NotifyStatusPending,
+		CreatedAt:  stale,
+		UpdatedAt:  stale,
+	}).Error; err != nil {
+		t.Fatalf("seed stale pending: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 203).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("sweep must redeliver stale pending row, got status=%s", row.Status)
+	}
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected exactly 1 send on reclaim, got %d", len(d.sendCalls))
+	}
+}
+
+func TestSweep_DoesNotReclaimFreshPendingRow(t *testing.T) {
+	// A fresh pending row (worker still trying) must not be stolen by Sweep.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(204, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	fresh := n.now() // just claimed
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:     204,
+		NotifyKind: model.NotifyKindCompleted,
+		Status:     model.NotifyStatusPending,
+		CreatedAt:  fresh,
+		UpdatedAt:  fresh,
+	}).Error; err != nil {
+		t.Fatalf("seed fresh pending: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("fresh pending row must not be reclaimed, got %d sends", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 204).First(&row)
+	if row.Status != model.NotifyStatusPending {
+		t.Fatalf("expected status=pending preserved, got %s", row.Status)
+	}
+}
+
+func TestSweep_DisabledIsNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, d, Config{Enabled: false})
+	n.Sweep(context.Background()) // must not panic / not query
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("disabled notifier sweep must be no-op")
 	}
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,8 +1,11 @@
+//go:build cgo
+
 package notify
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1350,5 +1353,166 @@ func TestBuildText_NilSanitizerFallsBackToSafeString(t *testing.T) {
 	}
 	if !strings.Contains(text, "AI 处理失败，请稍后重试") {
 		t.Fatalf("nil sanitizer fallback must render the safe default; text=%q", text)
+	}
+}
+
+// --- Blocker 3 regression: token-not-yet-provisioned MUST NOT consume retry budget ---
+//
+// See upstream PR#126 review (yujiawei / OctoBoooot / Jerry-Xin一致意见):
+// resolveToken 在 octo-server 尚未把 bot token 写库前返回错误，若被 markFailed
+// 当普通失败记账，MaxAttempts 内预算耗尽 → 通知永久丢失。修复：错误改为
+// ErrTokenNotYetProvisioned sentinel，deliver/redeliver 用 errors.Is 分流到
+// markDeferred（保 pending、不递增 attempt_count、回拨 updated_at 让下轮 Sweep
+// 立即接过），下面这组测试锁死该行为。
+
+// deferredDeliverer: EnsureFriend 前 failCount 次返回 sentinel-wrapped 错误，
+// 之后返回 nil；SendMessage 记录调用次数并成功。用于模拟 token 未 provisioned
+// 的启动窗口以及之后 octo-server 回填后的恢复过程。
+type deferredDeliverer struct {
+	mu           sync.Mutex
+	failCount    int // 还需失败几次
+	ensureCalls  int
+	sendCalls    int
+}
+
+func (d *deferredDeliverer) EnsureFriend(ctx context.Context, spaceID, uid string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.ensureCalls++
+	if d.failCount > 0 {
+		d.failCount--
+		// 模仿真实 client.go post() 的双层 wrap：外层 "path: resolve bot token: <sentinel>"
+		return fmt.Errorf("/v1/bot/ensureFriend: resolve bot token: %w", ErrTokenNotYetProvisioned)
+	}
+	return nil
+}
+
+func (d *deferredDeliverer) SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.sendCalls++
+	return nil
+}
+
+// TestOnTaskTerminal_TokenNotYetProvisioned_DoesNotConsumeBudget 覆盖主回归链路：
+// 前 5 次 EnsureFriend 返回 sentinel，第 6 次成功。断言全程 attempt_count 未增、
+// status 恒为 pending，直到 token 就绪才真正 SendMessage 一次并 status=sent。
+func TestOnTaskTerminal_TokenNotYetProvisioned_DoesNotConsumeBudget(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	// 5 次同步/sweep 都要落到 sentinel 上，第 6 次 Sweep 才真正投递成功。
+	d := &deferredDeliverer{failCount: 5}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(701, model.TriggerManual)
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// 同步路径：一次 OnTaskTerminal 应命中 sentinel → markDeferred（pending, attempt=0）
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 701).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusPending {
+		t.Fatalf("after sentinel-fail OnTaskTerminal, expected status=pending got %s", row.Status)
+	}
+	if row.AttemptCount != 0 {
+		t.Fatalf("sentinel must not increment attempt_count, got %d", row.AttemptCount)
+	}
+	// updated_at 应已被回拨到 PendingLease 之外，下一轮 Sweep 能立即接管
+	if !row.UpdatedAt.Before(n.now().Add(-PendingLease)) {
+		t.Fatalf("markDeferred must backdate updated_at past PendingLease; got %v (now=%v, lease=%v)",
+			row.UpdatedAt, n.now(), PendingLease)
+	}
+	if row.LastError == nil || *row.LastError == "" {
+		t.Fatalf("markDeferred should set last_error for operator visibility")
+	}
+
+	// 连续 4 次 Sweep（仍在 5 次失败窗口内），应始终 pending、attempt=0、
+	// SendMessage 一次都没被调（EnsureFriend 阶段就短路了）。
+	for i := 0; i < 4; i++ {
+		n.Sweep(context.Background())
+		db.Where("task_id = ?", 701).First(&row)
+		if row.Status != model.NotifyStatusPending {
+			t.Fatalf("sweep #%d: expected pending, got %s", i+1, row.Status)
+		}
+		if row.AttemptCount != 0 {
+			t.Fatalf("sweep #%d must not burn budget, got attempt=%d", i+1, row.AttemptCount)
+		}
+	}
+	if d.sendCalls != 0 {
+		t.Fatalf("SendMessage must not have been reached while token was unavailable, got %d calls", d.sendCalls)
+	}
+
+	// 第 5 次 Sweep：deferredDeliverer 的失败次数刚好用完（同步路径消耗 1 + 4 次 sweep = 5 次），
+	// EnsureFriend 首次成功 → SendMessage 一次 → markSent。
+	n.Sweep(context.Background())
+	db.Where("task_id = ?", 701).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("after token becomes available, expected status=sent, got %s (attempt=%d)",
+			row.Status, row.AttemptCount)
+	}
+	if d.sendCalls != 1 {
+		t.Fatalf("SendMessage must have been called exactly once (only when token was ready), got %d", d.sendCalls)
+	}
+}
+
+// TestOnTaskTerminal_TokenNotYetProvisioned_KeepsPendingIndefinitely 是长时间无
+// token 场景：无论多少次 Sweep，只要 sentinel 一直出现，就永远不消耗预算、
+// 永远不落 failed。防止将来有人给 markDeferred 加莫名其妙的上限。
+func TestOnTaskTerminal_TokenNotYetProvisioned_KeepsPendingIndefinitely(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	d := &deferredDeliverer{failCount: 1000} // 事实上无限
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(702, model.TriggerManual)
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	for i := 0; i < 20; i++ {
+		n.Sweep(context.Background())
+	}
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 702).First(&row)
+	if row.Status != model.NotifyStatusPending {
+		t.Fatalf("expected pending throughout, got %s", row.Status)
+	}
+	if row.AttemptCount != 0 {
+		t.Fatalf("attempt_count must remain 0 no matter how many sweeps, got %d", row.AttemptCount)
+	}
+	if d.sendCalls != 0 {
+		t.Fatalf("SendMessage must never fire while token remains unavailable, got %d", d.sendCalls)
+	}
+}
+
+// TestOnTaskTerminal_NonSentinelErrorStillConsumesBudget 是反向回归：
+// 普通 delivery 失败（HTTP 5xx / ensureFriend 语义失败 / 其他 tokenFn 错误）
+// 必须继续走 markFailed 计数，绝对不能被 sentinel 分流误伤。
+func TestOnTaskTerminal_NonSentinelErrorStillConsumesBudget(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("HTTP 500 boom")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	n.OnTaskTerminal(baseTask(703, model.TriggerManual), model.StatusCompleted, "")
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 703).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("non-sentinel error must land at status=failed, got %s", row.Status)
+	}
+	if row.AttemptCount != 1 {
+		t.Fatalf("non-sentinel error must increment attempt_count, got %d", row.AttemptCount)
 	}
 }

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -20,8 +20,9 @@ type deliveryTarget struct {
 // It returns a list so a by-person task can fan out one DM per recipient; an
 // empty list means "no deliverable target" (caller skips).
 //
-// by-person (SummaryMode==ModeByPerson): union of every summary_participant's
-// UserID with the task creator, deduped. Each uid becomes an independent creator
+// by-person (SummaryMode==ModeByPerson): union of active participants'
+// (excluding pending/declined, aligned with生成阶段) UserID with the task
+// creator, deduped. Each uid becomes an independent creator
 // DM target so the notify state machine dedups/retries each recipient on its own
 // (task, kind, uid) row.
 //
@@ -59,8 +60,12 @@ func (n *Notifier) resolveTargets(task model.SummaryTask) ([]deliveryTarget, err
 			targets = append(targets, mk(uid))
 		}
 		if n != nil && n.db != nil {
+			// Only fan out to真正参与的人：排除 pending/declined，与生成阶段
+			// (personal_processor.go) 对齐，避免未接受/已拒绝成员误收完成通知。
 			var parts []model.SummaryParticipant
-			if err := n.db.Where("task_id = ?", task.ID).Find(&parts).Error; err != nil {
+			if err := n.db.Where("task_id = ? AND status NOT IN ?",
+				task.ID, []int{model.ParticipantPending, model.ParticipantDeclined}).
+				Find(&parts).Error; err != nil {
 				return nil, err
 			}
 			for _, p := range parts {

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -1,0 +1,55 @@
+package notify
+
+import (
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// deliveryTarget is the resolved destination of a notification.
+type deliveryTarget struct {
+	ChannelID   string
+	ChannelType int // WireChannelDM / WireChannelGroup / WireChannelThread
+	// TargetUID is the user the bot must EnsureFriend with before a DM is
+	// deliverable. Set only for DM delivery; empty for group/thread回发.
+	TargetUID string
+	// SpaceID (SummaryTask.SpaceID) is passed to ensureFriend so octo-server can
+	// build the space-prefixed whitelist channel (s{spaceID}_{uid}).
+	SpaceID string
+}
+
+// resolveTarget decides where a terminal-state notification for `task` is sent.
+//
+// 本期口径 (OCT-4, this phase): we ALWAYS fall back to a DM to the task creator.
+// The task carries OriginChannelID/OriginChannelType (model.OriginChannel*:
+// 0=Global, 1=Group, 2=Thread, 3=DM), but 原群/thread 回发 is an explicit
+// follow-up enhancement and is intentionally NOT depended on here. Whether the
+// origin is DM, empty, or Global, we route to ChannelTypePerson with
+// channel_id = CreatorID. Group/Thread origins also fall back to a creator DM
+// this phase (we do not yet post back into the originating group/thread).
+//
+// The switch is written out so the future enhancement (route Group/Thread back
+// to the origin channel) is a localized change, but every branch currently
+// resolves to the DM fallback.
+func resolveTarget(task model.SummaryTask) (deliveryTarget, bool) {
+	creatorDM := func() (deliveryTarget, bool) {
+		if task.CreatorID == "" {
+			return deliveryTarget{}, false
+		}
+		return deliveryTarget{
+			ChannelID:   task.CreatorID,
+			ChannelType: WireChannelDM,
+			TargetUID:   task.CreatorID,
+			SpaceID:     task.SpaceID,
+		}, true
+	}
+
+	switch task.OriginChannelType {
+	case model.OriginChannelDM, model.OriginChannelGlobal:
+		// DM origin or no/global origin → creator DM (本期默认兜底).
+		return creatorDM()
+	case model.OriginChannelGroup, model.OriginChannelThread:
+		// 原群/thread 回发：后续增强，本期不做依赖 → 退回 creator DM 兜底.
+		return creatorDM()
+	default:
+		return creatorDM()
+	}
+}

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -16,40 +16,94 @@ type deliveryTarget struct {
 	SpaceID string
 }
 
-// resolveTarget decides where a terminal-state notification for `task` is sent.
+// resolveTargets decides where a terminal-state notification for `task` is sent.
+// It returns a list so a by-person task can fan out one DM per recipient; an
+// empty list means "no deliverable target" (caller skips).
 //
-// 本期口径 (OCT-4, this phase): we ALWAYS fall back to a DM to the task creator.
-// The task carries OriginChannelID/OriginChannelType (model.OriginChannel*:
-// 0=Global, 1=Group, 2=Thread, 3=DM), but 原群/thread 回发 is an explicit
-// follow-up enhancement and is intentionally NOT depended on here. Whether the
-// origin is DM, empty, or Global, we route to ChannelTypePerson with
-// channel_id = CreatorID. Group/Thread origins also fall back to a creator DM
-// this phase (we do not yet post back into the originating group/thread).
+// by-person (SummaryMode==ModeByPerson): union of every summary_participant's
+// UserID with the task creator, deduped. Each uid becomes an independent creator
+// DM target so the notify state machine dedups/retries each recipient on its own
+// (task, kind, uid) row.
 //
-// The switch is written out so the future enhancement (route Group/Thread back
-// to the origin channel) is a localized change, but every branch currently
-// resolves to the DM fallback.
-func resolveTarget(task model.SummaryTask) (deliveryTarget, bool) {
-	creatorDM := func() (deliveryTarget, bool) {
-		if task.CreatorID == "" {
-			return deliveryTarget{}, false
-		}
+// A participant-lookup error is returned (not swallowed): silently degrading to
+// just the creator would mark completed as delivered, never build participant
+// rows, and leave the miss invisible to the sweep — participants would be lost
+// forever. The caller skips this run so a later trigger/sweep can retry.
+//
+// non-by-person: a single creator DM (本期口径). The task carries
+// OriginChannelID/OriginChannelType but 原群/thread 回发 is an explicit follow-up
+// enhancement and is intentionally NOT depended on here — every origin routes to
+// the creator DM fallback this phase.
+func (n *Notifier) resolveTargets(task model.SummaryTask) ([]deliveryTarget, error) {
+	mk := func(uid string) deliveryTarget {
 		return deliveryTarget{
-			ChannelID:   task.CreatorID,
+			ChannelID:   uid,
 			ChannelType: WireChannelDM,
-			TargetUID:   task.CreatorID,
+			TargetUID:   uid,
 			SpaceID:     task.SpaceID,
-		}, true
+		}
 	}
 
-	switch task.OriginChannelType {
-	case model.OriginChannelDM, model.OriginChannelGlobal:
-		// DM origin or no/global origin → creator DM (本期默认兜底).
-		return creatorDM()
-	case model.OriginChannelGroup, model.OriginChannelThread:
-		// 原群/thread 回发：后续增强，本期不做依赖 → 退回 creator DM 兜底.
-		return creatorDM()
-	default:
-		return creatorDM()
+	if task.SummaryMode == model.ModeByPerson {
+		// Union participant UIDs with the creator, dedup, skip empties.
+		seen := make(map[string]struct{})
+		var targets []deliveryTarget
+		add := func(uid string) {
+			if uid == "" {
+				return
+			}
+			if _, ok := seen[uid]; ok {
+				return
+			}
+			seen[uid] = struct{}{}
+			targets = append(targets, mk(uid))
+		}
+		if n != nil && n.db != nil {
+			var parts []model.SummaryParticipant
+			if err := n.db.Where("task_id = ?", task.ID).Find(&parts).Error; err != nil {
+				return nil, err
+			}
+			for _, p := range parts {
+				add(p.UserID)
+			}
+		}
+		add(task.CreatorID) // creator always in the completed fan-out
+		return targets, nil
 	}
+
+	// Non-by-person: single creator DM (empty creator → no target).
+	if task.CreatorID == "" {
+		return nil, nil
+	}
+	return []deliveryTarget{mk(task.CreatorID)}, nil
+}
+
+// creatorTarget resolves the single creator DM target used for the failed path
+// (failed notifications go only to the creator, never fanned out) and for the
+// sweep redeliver path which reconstructs a target for a specific recipient_uid.
+func (n *Notifier) creatorTarget(task model.SummaryTask) (deliveryTarget, bool) {
+	if task.CreatorID == "" {
+		return deliveryTarget{}, false
+	}
+	return deliveryTarget{
+		ChannelID:   task.CreatorID,
+		ChannelType: WireChannelDM,
+		TargetUID:   task.CreatorID,
+		SpaceID:     task.SpaceID,
+	}, true
+}
+
+// targetForUID rebuilds a DM target for an explicit recipient uid using the
+// task's SpaceID. Used by the sweep redeliver path where the recipient is read
+// back from the stored notification row rather than re-derived from the task.
+func targetForUID(task model.SummaryTask, uid string) (deliveryTarget, bool) {
+	if uid == "" {
+		return deliveryTarget{}, false
+	}
+	return deliveryTarget{
+		ChannelID:   uid,
+		ChannelType: WireChannelDM,
+		TargetUID:   uid,
+		SpaceID:     task.SpaceID,
+	}, true
 }

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -294,6 +294,11 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			EventType: "META_SUMMARY_UPDATED",
 		})
 
+		// Task durably reached Completed (saveLatestResultAndCompleteTask succeeded).
+		// The notifier dedups on UNIQUE(task_id, completed), so a meta re-run that
+		// produces a new version still only sends ONE completed notification.
+		m.proc.notifyTaskTerminal(taskID, model.StatusCompleted)
+
 		log.Printf("[meta-worker] task %d meta-summary version %d created (%d participants)",
 			taskID, result.Version, len(submitted))
 

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -904,6 +904,39 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 	return finalContent, citations, targetMsgCount, totalTokens, p.llm.ModelVersion(), nil
 }
 
+func estimateTokens(content string, charsPerTokenCJK, charsPerTokenASCII int) int {
+	const overheadPerMsg = 50
+	// Defensive: avoid divide-by-zero or pathological values
+	if charsPerTokenCJK <= 0 {
+		charsPerTokenCJK = 1
+	}
+	if charsPerTokenASCII <= 0 {
+		charsPerTokenASCII = 4
+	}
+	cjkCount := 0
+	asciiCount := 0
+	for _, r := range content {
+		if r > 0x7F {
+			cjkCount++
+		} else {
+			asciiCount++
+		}
+	}
+	return cjkCount/charsPerTokenCJK + asciiCount/charsPerTokenASCII + overheadPerMsg
+}
+
+// SanitizeErrorForUser is the canonical whitelist that maps a raw internal
+// error string to a user-safe Chinese string suitable for an IM DM.
+//
+// Exported so the notify package can wire it as the single render-point
+// sanitizer in Notifier.buildText (covers both the synchronous worker path
+// AND the sweep/redeliver path that reads task.ErrorMessage raw from the DB).
+// See PR#113 Jerry-Xin/OctoBoooot R3: sanitizing only at the worker call
+// sites left the sweep path leaking DSN/IP/stack to the user DM on retry.
+func SanitizeErrorForUser(errMsg string) string {
+	return sanitizeErrorForUser(errMsg)
+}
+
 func sanitizeErrorForUser(errMsg string) string {
 	switch {
 	case strings.Contains(errMsg, "LLM API error"):

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -213,6 +213,9 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 			Progress: 100,
 			Message:  "总结完成",
 		})
+		// Task durably reached Completed above (saveLatestResultAndCompleteTask /
+		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
+		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
@@ -439,6 +442,9 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 			Progress: 0,
 			Message:  sanitized,
 		})
+		// shouldNotify is set only when the task-level CAS to StatusFailed actually
+		// flipped the row (single-person terminal failure). Fire the notification.
+		p.notifyTaskTerminal(pr.TaskID, model.StatusFailed)
 	}
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -44,6 +45,10 @@ type Processor struct {
 	// get dispatched) is observable without running the LLM personal pipeline.
 	// Production leaves it nil and the real pool/processPersonalSummary is used.
 	dispatchPersonalFn func(taskID, participantRefID int64)
+	// notifier delivers the terminal-state (Completed/Failed) IM-bot notification
+	// after a task's status is durably committed. nil = disabled (OnTaskTerminal
+	// is a no-op), so it is safe to call unconditionally.
+	notifier *notify.Notifier
 }
 
 // NewProcessor creates a new task processor.
@@ -104,6 +109,32 @@ func validateOctoSearchURL(raw string) error {
 		}
 	}
 	return nil
+}
+
+// SetNotifier wires the terminal-state IM-bot notifier. Optional: when unset,
+// notifyTaskTerminal is a no-op.
+func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
+
+// notifyTaskTerminal fires the terminal-state notification for a task that just
+// reached a terminal status. It reloads the committed task row so the
+// notification reflects the durable state (title, creator, origin channel,
+// trigger type, error_message). Best-effort: any failure is swallowed inside the
+// notifier and never affects the worker's completion path. Call this ONLY after
+// the terminal-status DB write has succeeded.
+func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
+	if p.notifier == nil {
+		return
+	}
+	var task model.SummaryTask
+	if err := p.db.First(&task, taskID).Error; err != nil {
+		log.Printf("[processor] notifyTaskTerminal: reload task %d failed: %v", taskID, err)
+		return
+	}
+	errMsg := ""
+	if task.ErrorMessage != nil {
+		errMsg = *task.ErrorMessage
+	}
+	p.notifier.OnTaskTerminal(task, status, errMsg)
 }
 
 // TriggerCh returns the channel for worker trigger requests.
@@ -250,6 +281,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			Status:  newStatus,
 			Message: errMsg,
 		})
+		if newStatus == model.StatusFailed {
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+		}
 		return
 	}
 
@@ -284,6 +318,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			Status:  newStatus,
 			Message: errMsg,
 		})
+		if newStatus == model.StatusFailed {
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+		}
 		return
 	}
 
@@ -323,6 +360,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 				Status:  newStatus,
 				Message: errMsg,
 			})
+			if newStatus == model.StatusFailed {
+				p.notifyTaskTerminal(task.ID, model.StatusFailed)
+			}
 			return
 		}
 		participantCount = 1

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -125,12 +125,16 @@ func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
 // The reloaded task.error_message is the RAW internal error string (may carry
 // DSN credentials, IPs, goroutine stack heads). It is intentionally persisted
 // raw in the DB so ops can root-cause from logs, but it MUST NOT reach a user
-// DM. We run it through sanitizeErrorForUser here — the same sanitizer the
-// personal failure path (markPersonalFailed) already uses — so the failure
-// reason rendered into the IM payload is the user-safe whitelist mapping.
-// Single-point intercept: every task-level failure that flows through
-// notifyTaskTerminal is sanitized exactly once, and new fail-write sites do
-// not have to re-add sanitize.
+// DM.
+//
+// Sanitization happens at a SINGLE render point inside notify.buildText (wired
+// via notify.WithErrorSanitizer(SanitizeErrorForUser) at construction in
+// cmd/summary-worker/main.go). That single intercept covers BOTH the
+// synchronous path here AND the asynchronous sweep/redeliver path
+// (notify.go: redeliver reloads task.ErrorMessage raw from DB). Pre-PR#113 R3,
+// sanitize was applied here only and the sweep path leaked raw errors to the
+// user DM — see Jerry-Xin/OctoBoooot R3 review. We deliberately pass the raw
+// errMsg through and let buildText scrub it once at the render boundary.
 func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if p.notifier == nil {
 		return
@@ -144,7 +148,7 @@ func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if task.ErrorMessage != nil {
 		errMsg = *task.ErrorMessage
 	}
-	p.notifier.OnTaskTerminal(task, status, sanitizeErrorForUser(errMsg))
+	p.notifier.OnTaskTerminal(task, status, errMsg)
 }
 
 // TriggerCh returns the channel for worker trigger requests.

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -121,6 +121,16 @@ func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
 // trigger type, error_message). Best-effort: any failure is swallowed inside the
 // notifier and never affects the worker's completion path. Call this ONLY after
 // the terminal-status DB write has succeeded.
+//
+// The reloaded task.error_message is the RAW internal error string (may carry
+// DSN credentials, IPs, goroutine stack heads). It is intentionally persisted
+// raw in the DB so ops can root-cause from logs, but it MUST NOT reach a user
+// DM. We run it through sanitizeErrorForUser here — the same sanitizer the
+// personal failure path (markPersonalFailed) already uses — so the failure
+// reason rendered into the IM payload is the user-safe whitelist mapping.
+// Single-point intercept: every task-level failure that flows through
+// notifyTaskTerminal is sanitized exactly once, and new fail-write sites do
+// not have to re-add sanitize.
 func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if p.notifier == nil {
 		return
@@ -134,7 +144,7 @@ func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 	if task.ErrorMessage != nil {
 		errMsg = *task.ErrorMessage
 	}
-	p.notifier.OnTaskTerminal(task, status, errMsg)
+	p.notifier.OnTaskTerminal(task, status, sanitizeErrorForUser(errMsg))
 }
 
 // TriggerCh returns the channel for worker trigger requests.

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -1,0 +1,154 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
+)
+
+// fakeNotifyDeliverer captures the SendMessage payloads so we can assert the
+// failure-reason text actually reaching the IM bot has been sanitized.
+type fakeNotifyDeliverer struct {
+	mu        sync.Mutex
+	sendCalls []notify.SendMessageRequest
+}
+
+func (f *fakeNotifyDeliverer) EnsureFriend(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (f *fakeNotifyDeliverer) SendMessage(_ context.Context, msg notify.SendMessageRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, msg)
+	return nil
+}
+
+// notifyTaskTerminal must run task.error_message through sanitizeErrorForUser
+// before it reaches the IM payload. This guards against raw internal errors
+// (DSN credentials, IPs, goroutine stack heads) being delivered to the user's
+// DM via the failure-reason line of buildText.
+//
+// Regression test for PR#113 review by Jerry-Xin (2026-06-29): the task-level
+// failure path previously fed *task.ErrorMessage straight to OnTaskTerminal,
+// so the user DM rendered raw internal errors. The personal failure path
+// already sanitized via markPersonalFailed; this brings the task path to
+// parity at the single-point intercept (notifyTaskTerminal).
+func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
+	cases := []struct {
+		name    string
+		rawErr  string
+		wantOut string // exact expected sanitized output
+		mustNot []string
+	}{
+		{
+			name:    "dsn-credentials",
+			rawErr:  "save task: dial mysql user:s3cret@tcp(10.0.0.1:3306)/summary failed",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"user:s3cret", "10.0.0.1:3306", "user:s3cret@tcp"},
+		},
+		{
+			name:    "ip-leak",
+			rawErr:  "dial tcp 192.168.1.5:8443: connect: connection refused",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"192.168.1.5", "8443"},
+		},
+		{
+			name:    "stack-trace-head",
+			rawErr:  "goroutine 17 [running]:\nmain.failPipeline(0xc0001a23c0)",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"goroutine 17 [running]", "main.failPipeline", "0xc0001a23c0"},
+		},
+		{
+			name:    "llm-api-error-mapped",
+			rawErr:  "LLM API error: status=401 body=invalid key bearer-abc123",
+			wantOut: "AI 服务暂时不可用，请稍后重试",
+			mustNot: []string{"bearer-abc123", "status=401", "invalid key"},
+		},
+		{
+			name:    "context-deadline-mapped",
+			rawErr:  "context deadline exceeded after 30s on llm.example.com:9443",
+			wantOut: "AI 处理超时，请稍后重试",
+			mustNot: []string{"llm.example.com", "9443"},
+		},
+		{
+			name:    "empty-error-message",
+			rawErr:  "",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupProcessorTestDB(t)
+			// summary_notification lives in the same summary DB; AutoMigrate so
+			// the real Notifier's claim INSERT succeeds.
+			if err := db.AutoMigrate(&model.SummaryNotification{}); err != nil {
+				t.Fatalf("automigrate notification: %v", err)
+			}
+
+			errMsg := tc.rawErr
+			task := model.SummaryTask{
+				TaskNo:            "TST-SAN-" + tc.name,
+				Title:             "今日群聊",
+				SpaceID:           "space-1",
+				CreatorID:         "user-1",
+				Status:            model.StatusFailed,
+				TriggerType:       model.TriggerManual,
+				OriginChannelType: model.OriginChannelGlobal,
+				ErrorMessage:      &errMsg,
+			}
+			if err := db.Create(&task).Error; err != nil {
+				t.Fatalf("save task: %v", err)
+			}
+
+			fake := &fakeNotifyDeliverer{}
+			n := notify.New(db, fake, notify.Config{Enabled: true, MaxAttempts: 3})
+
+			p := &Processor{db: db}
+			p.SetNotifier(n)
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+
+			if len(fake.sendCalls) != 1 {
+				t.Fatalf("expected exactly 1 SendMessage call, got %d", len(fake.sendCalls))
+			}
+			text, _ := fake.sendCalls[0].Payload["text"].(string)
+			// The failure-reason line is "失败原因：<sanitized>" — assert the
+			// sanitized whitelist mapping is what landed in the IM payload.
+			if !strings.Contains(text, tc.wantOut) {
+				t.Fatalf("expected DM text to contain sanitized %q, got %q", tc.wantOut, text)
+			}
+			for _, bad := range tc.mustNot {
+				if strings.Contains(text, bad) {
+					t.Fatalf("DM text leaked raw substring %q (full text: %q)", bad, text)
+				}
+			}
+		})
+	}
+}
+
+// notifyTaskTerminal must remain a no-op when notifier is unset (production
+// wires nil when SUMMARY_NOTIFY_ENABLED=false). Guards against the sanitize
+// change accidentally introducing a nil-deref on the disabled path.
+func TestNotifyTaskTerminal_NilNotifierIsNoop(t *testing.T) {
+	db := setupProcessorTestDB(t)
+	errMsg := "irrelevant"
+	task := model.SummaryTask{
+		TaskNo:       "TST-SAN-NIL",
+		SpaceID:      "space-1",
+		CreatorID:    "user-1",
+		Status:       model.StatusFailed,
+		ErrorMessage: &errMsg,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+	p := &Processor{db: db}
+	// p.notifier intentionally nil
+	p.notifyTaskTerminal(task.ID, model.StatusFailed) // must not panic
+}

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package worker
 
 import (

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -21,7 +21,7 @@ func (f *fakeNotifyDeliverer) EnsureFriend(_ context.Context, _, _ string) error
 	return nil
 }
 
-func (f *fakeNotifyDeliverer) SendMessage(_ context.Context, msg notify.SendMessageRequest) error {
+func (f *fakeNotifyDeliverer) SendMessage(_ context.Context, _ string, msg notify.SendMessageRequest) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sendCalls = append(f.sendCalls, msg)
@@ -108,7 +108,7 @@ func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
 			}
 
 			fake := &fakeNotifyDeliverer{}
-			n := notify.New(db, fake, notify.Config{Enabled: true, MaxAttempts: 3})
+			n := notify.New(db, nil, fake, notify.Config{Enabled: true, MaxAttempts: 3})
 
 			p := &Processor{db: db}
 			p.SetNotifier(n)
@@ -117,7 +117,9 @@ func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
 			if len(fake.sendCalls) != 1 {
 				t.Fatalf("expected exactly 1 SendMessage call, got %d", len(fake.sendCalls))
 			}
-			text, _ := fake.sendCalls[0].Payload["text"].(string)
+			// octo-server recognizes a plain-text bot message by "content" (type=1),
+			// not "text"; assert against the server-recognized payload key.
+			text, _ := fake.sendCalls[0].Payload["content"].(string)
 			// The failure-reason line is "失败原因：<sanitized>" — assert the
 			// sanitized whitelist mapping is what landed in the IM payload.
 			if !strings.Contains(text, tc.wantOut) {

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -78,8 +78,8 @@ func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
 		{
 			name:    "empty-error-message",
 			rawErr:  "",
-			wantOut: "AI 处理失败，请稍后重试",
-			mustNot: []string{},
+			wantOut: "", // empty errMsg → no "失败原因" line rendered (PR#113 R3 single-point sanitize)
+			mustNot: []string{"失败原因"},
 		},
 	}
 
@@ -108,7 +108,13 @@ func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
 			}
 
 			fake := &fakeNotifyDeliverer{}
-			n := notify.New(db, nil, fake, notify.Config{Enabled: true, MaxAttempts: 3})
+			// Production wiring: cmd/summary-worker/main.go injects
+			// worker.SanitizeErrorForUser via WithErrorSanitizer so the single
+			// render-point sanitizer in notify.buildText covers both the
+			// synchronous and the sweep/redeliver paths. Mirror that wiring
+			// here so the test exercises the same behavior as production.
+			n := notify.New(db, nil, fake, notify.Config{Enabled: true, MaxAttempts: 3}).
+				WithErrorSanitizer(SanitizeErrorForUser)
 
 			p := &Processor{db: db}
 			p.SetNotifier(n)

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/robfig/cron/v3"
@@ -21,12 +22,12 @@ var schedulerHTTPClient = &http.Client{Timeout: 5 * time.Second}
 // StartScheduler starts the 4 cron scan jobs (every 60s).
 // featureTeamSchedule, when true, lets multi-person schedules through the claim path
 // instead of disabling them (FEATURE_TEAM_SCHEDULE).
-func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int, featureTeamSchedule bool) *cron.Cron {
+func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int, featureTeamSchedule bool, notifier *notify.Notifier) *cron.Cron {
 	c := cron.New()
 
 	c.AddFunc("@every 60s", func() { scanPendingSchedules(db, imDB, maxWindowDays, featureTeamSchedule) })
 	c.AddFunc("@every 60s", func() { scanConfirmTimeouts(db) })
-	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry) })
+	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry, notifier) })
 	c.AddFunc("@every 60s", func() { scanStuckPersonalTasks(db, workerTriggerURL) })
 
 	c.Start()
@@ -339,7 +340,9 @@ func scanConfirmTimeouts(db *gorm.DB) {
 
 // scanStuckTasks resets tasks stuck in processing past their deadline.
 // Increments retry_count; if max retries exceeded, marks as Failed.
-func scanStuckTasks(db *gorm.DB, maxRetry int) {
+// notifier (optional) is fired once per task that this sweep transitions to
+// Failed, AFTER the terminal-status write has committed.
+func scanStuckTasks(db *gorm.DB, maxRetry int, notifier *notify.Notifier) {
 	now := timezone.Now()
 
 	// Reset tasks that can still retry (also handle NULL deadline for legacy data)
@@ -355,6 +358,16 @@ func scanStuckTasks(db *gorm.DB, maxRetry int) {
 		log.Printf("[scheduler] reset %d stuck tasks (retry incremented)", result.RowsAffected)
 	}
 
+	// Snapshot the IDs about to be failed so we can notify them precisely after
+	// the terminal write commits (the bulk UPDATE below cannot return the rows).
+	var toFail []int64
+	if notifier != nil {
+		db.Model(&model.SummaryTask{}).
+			Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
+				model.StatusProcessing, now, maxRetry-1).
+			Pluck("id", &toFail)
+	}
+
 	// Fail tasks that exceeded max retries (also handle NULL deadline)
 	failResult := db.Model(&model.SummaryTask{}).
 		Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
@@ -367,6 +380,26 @@ func scanStuckTasks(db *gorm.DB, maxRetry int) {
 		})
 	if failResult.RowsAffected > 0 {
 		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", failResult.RowsAffected)
+	}
+
+	// Notify the now-Failed tasks. Reload each so the notification reflects the
+	// committed terminal row; only fire for rows that are actually Failed (guards
+	// against a concurrent cancel/complete between snapshot and write).
+	if notifier != nil {
+		for _, id := range toFail {
+			var task model.SummaryTask
+			if err := db.First(&task, id).Error; err != nil {
+				continue
+			}
+			if task.Status != model.StatusFailed {
+				continue
+			}
+			errMsg := ""
+			if task.ErrorMessage != nil {
+				errMsg = *task.ErrorMessage
+			}
+			notifier.OnTaskTerminal(task, model.StatusFailed, errMsg)
+		}
 	}
 }
 

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -29,6 +30,22 @@ func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL s
 	c.AddFunc("@every 60s", func() { scanConfirmTimeouts(db) })
 	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry, notifier) })
 	c.AddFunc("@every 60s", func() { scanStuckPersonalTasks(db, workerTriggerURL) })
+	if notifier != nil {
+		// Background sweep for the notify state machine. Re-attempts rows stuck
+		// at status='failed' with retry budget remaining (the synchronous worker
+		// path is one-shot, so without this sweep MaxNotifyAttempts collapses
+		// to 1 for the common case) and reclaims rows stuck at status='pending'
+		// past their lease (worker crash mid-delivery). Both branches use atomic
+		// CAS, so they cannot double-send with a concurrent OnTaskTerminal call.
+		c.AddFunc("@every 60s", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 55*time.Second)
+			defer cancel()
+			notifier.Sweep(ctx)
+		})
+		c.Start()
+		log.Println("[scheduler] started with 5 scan jobs (every 60s)")
+		return c
+	}
 
 	c.Start()
 	log.Println("[scheduler] started with 4 scan jobs (every 60s)")
@@ -358,35 +375,44 @@ func scanStuckTasks(db *gorm.DB, maxRetry int, notifier *notify.Notifier) {
 		log.Printf("[scheduler] reset %d stuck tasks (retry incremented)", result.RowsAffected)
 	}
 
-	// Snapshot the IDs about to be failed so we can notify them precisely after
-	// the terminal write commits (the bulk UPDATE below cannot return the rows).
+	// Fail tasks that exceeded max retries. Two-step (snapshot IDs, then per-row
+	// CAS UPDATE) so we can attribute exactly which IDs *this* sweep flipped to
+	// Failed — a bulk UPDATE cannot return the rows, and a snapshot-then-bulk
+	// shape would miss any task that crossed the deadline between the snapshot
+	// and the UPDATE (review feedback P2-2: snapshot-then-update race could
+	// drop the notification for a late-crosser since on the next sweep its
+	// status is already Failed). The per-row CAS guards on the same predicates
+	// the snapshot used, so concurrent transitions are absorbed (RowsAffected==0
+	// means another worker / cancel got there first; we skip).
 	var toFail []int64
-	if notifier != nil {
-		db.Model(&model.SummaryTask{}).
-			Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
-				model.StatusProcessing, now, maxRetry-1).
-			Pluck("id", &toFail)
-	}
-
-	// Fail tasks that exceeded max retries (also handle NULL deadline)
-	failResult := db.Model(&model.SummaryTask{}).
+	db.Model(&model.SummaryTask{}).
 		Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
 			model.StatusProcessing, now, maxRetry-1).
-		Updates(map[string]interface{}{
-			"status":              model.StatusFailed,
-			"processing_deadline": nil,
-			"retry_count":         gorm.Expr("retry_count + 1"),
-			"error_message":       "exceeded max retries",
-		})
-	if failResult.RowsAffected > 0 {
-		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", failResult.RowsAffected)
+		Pluck("id", &toFail)
+
+	var failedIDs []int64
+	for _, id := range toFail {
+		res := db.Model(&model.SummaryTask{}).
+			Where("id = ? AND status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
+				id, model.StatusProcessing, now, maxRetry-1).
+			Updates(map[string]interface{}{
+				"status":              model.StatusFailed,
+				"processing_deadline": nil,
+				"retry_count":         gorm.Expr("retry_count + 1"),
+				"error_message":       "exceeded max retries",
+			})
+		if res.Error == nil && res.RowsAffected == 1 {
+			failedIDs = append(failedIDs, id)
+		}
+	}
+	if len(failedIDs) > 0 {
+		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", len(failedIDs))
 	}
 
-	// Notify the now-Failed tasks. Reload each so the notification reflects the
-	// committed terminal row; only fire for rows that are actually Failed (guards
-	// against a concurrent cancel/complete between snapshot and write).
+	// Notify exactly the tasks this sweep transitioned. Reload each so the
+	// notification reflects the committed terminal row.
 	if notifier != nil {
-		for _, id := range toFail {
+		for _, id := range failedIDs {
 			var task model.SummaryTask
 			if err := db.First(&task, id).Error; err != nil {
 				continue

--- a/migrations/sql/20260626-01-add-summary-notification.sql
+++ b/migrations/sql/20260626-01-add-summary-notification.sql
@@ -11,7 +11,8 @@ CREATE TABLE IF NOT EXISTS `summary_notification` (
     `updated_at`    DATETIME     NOT NULL,
     `sent_at`       DATETIME         NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_task_kind_uid` (`task_id`, `notify_kind`, `recipient_uid`)
+    UNIQUE KEY `uk_task_kind_uid` (`task_id`, `notify_kind`, `recipient_uid`),
+    KEY `idx_sweep` (`status`, `updated_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- +migrate Down

--- a/migrations/sql/20260626-01-add-summary-notification.sql
+++ b/migrations/sql/20260626-01-add-summary-notification.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS `summary_notification` (
+    `id`            BIGINT       NOT NULL AUTO_INCREMENT,
+    `task_id`       BIGINT       NOT NULL,
+    `notify_kind`   VARCHAR(16)  NOT NULL COMMENT 'completed | failed',
+    `status`        VARCHAR(16)  NOT NULL DEFAULT 'pending' COMMENT 'pending | sent | failed',
+    `attempt_count` INT          NOT NULL DEFAULT 0,
+    `last_error`    VARCHAR(500)     NULL,
+    `created_at`    DATETIME     NOT NULL,
+    `updated_at`    DATETIME     NOT NULL,
+    `sent_at`       DATETIME         NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_task_kind` (`task_id`, `notify_kind`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_notification`;

--- a/migrations/sql/20260626-01-add-summary-notification.sql
+++ b/migrations/sql/20260626-01-add-summary-notification.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `summary_notification` (
     `id`            BIGINT       NOT NULL AUTO_INCREMENT,
     `task_id`       BIGINT       NOT NULL,
     `notify_kind`   VARCHAR(16)  NOT NULL COMMENT 'completed | failed',
+    `recipient_uid` VARCHAR(64)  NOT NULL DEFAULT '' COMMENT 'per-recipient dedup: one row per (task, kind, uid)',
     `status`        VARCHAR(16)  NOT NULL DEFAULT 'pending' COMMENT 'pending | sent | failed',
     `attempt_count` INT          NOT NULL DEFAULT 0,
     `last_error`    VARCHAR(500)     NULL,
@@ -10,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `summary_notification` (
     `updated_at`    DATETIME     NOT NULL,
     `sent_at`       DATETIME         NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_task_kind` (`task_id`, `notify_kind`)
+    UNIQUE KEY `uk_task_kind_uid` (`task_id`, `notify_kind`, `recipient_uid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- +migrate Down


### PR DESCRIPTION
## 智能总结通知机制（定时任务 + 任务完成）

Closes #96

### 背景
smart-summary 此前无通知机制，用户对异步总结任务无主动反馈。本 PR 加入：定时任务跑完通知 + 按需任务完成/失败通知，经专属「总结助手」账号走 octo-server bot_api HTTP 投递。

### 改动
- **新增 `internal/notify` 包**：
  - HTTP 投递：先 `POST {OCTO_API_URL}/v1/bot/ensureFriend` 再 `POST .../v1/bot/sendMessage`，惰性解析 bot token，`space_id` 经 X-Space-ID header 透传。
  - 投递目标解析：本期兜底 DM 发起者（CreatorID），原群/thread 回发预留后续增强。
  - `OnTaskTerminal(task,status,errMsg)`：去重状态机 + 消息拼装 + quiet window + 有限重试 + 错误脱敏。
  - MySQL/SQLite 通用唯一键冲突识别（抢占式插入去重）。
- **新增 migration**：`summary_notification` 表，`UNIQUE(task_id, notify_kind)`，状态机字段（pending/sent/failed, attempt_count, last_error, sent_at）。
- **终态触发点接入**：personal/meta/scheduled 处理器在 `UPDATE status=终态` 成功之后调 `notify.OnTaskTerminal`；Cancelled 不发。
- **成功通知内容**：去掉不可达的结果链接（WKApp 内部 SPA 路由、用错 id、生产未配 base URL），改为 DM 自带的时间范围 / 参与成员数 / 消息数量 / 生成时间（均 best-effort，缺失省略不阻断投递）。
- **错误脱敏**：在 buildText render 点 sanitize 原始错误，覆盖 sweep redeliver 路径，避免泄漏 DSN/IP/stack。

### 验证
- `go build ./...` 通过；`go test ./internal/notify/... ./internal/worker/...` 全绿。
