### PR TITLE
chore(observability): log octo-search batch per-stage latency

### DIFF
--- a/internal/pipeline/octo_search_fetch.go
+++ b/internal/pipeline/octo_search_fetch.go
@@ -274,18 +274,22 @@ func runWithTimeWindowSplit(ctx context.Context, client octoSearchClient, chs []
 // runOneBatch submits one batch, polls to a terminal status, downloads rows,
 // then maps rows back to pipeline messages.
 func runOneBatch(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
+	batchStart := time.Now()
 	taskID, err := client.Submit(ctx, chs, startTS, endTS)
 	if err != nil {
 		return nil, err
 	}
+	submitElapsed := time.Since(batchStart)
 
 	status, err := pollUntilTerminal(ctx, client, taskID)
 	if err != nil {
 		return nil, err
 	}
+	statusReadyElapsed := time.Since(batchStart)
 
 	switch status.Status {
 	case "completed", "partial":
+		downloadMapStart := time.Now()
 		if status.Status == "partial" {
 			for _, w := range status.Warnings {
 				log.Printf("[pipeline-personal] octo-search partial truncation: channel=%s code=%s limit=%d seen=%d",
@@ -299,7 +303,16 @@ func runOneBatch(ctx context.Context, client octoSearchClient, chs []string, sta
 		if err != nil {
 			return nil, err
 		}
-		return rowsToMessages(rows, infoByID)
+		msgs, err := rowsToMessages(rows, infoByID)
+		if err != nil {
+			return nil, err
+		}
+		downloadMapElapsed := time.Since(downloadMapStart)
+		totalElapsed := time.Since(batchStart)
+		log.Printf("[pipeline-personal] octo-search task completed: task_id=%s status=%s channels=%d parts=%d rows=%d messages=%d submit_ms=%d status_ready_ms=%d download_map_ms=%d total_ms=%d",
+			taskID, status.Status, len(chs), len(status.Parts), len(rows), len(msgs),
+			submitElapsed.Milliseconds(), statusReadyElapsed.Milliseconds(), downloadMapElapsed.Milliseconds(), totalElapsed.Milliseconds())
+		return msgs, nil
 	case "failed":
 		return nil, fmt.Errorf("octo-search task %s failed: %s %s", taskID, status.ErrorCode, status.ErrorMsg)
 	case "cancelled":


### PR DESCRIPTION
## Summary
Add per-stage latency logging when personal summary messages are fetched via octo-search-batch.

After the #124 migration from synchronous MySQL fetch to the async octo-search-batch path, we had no visibility into where time is spent across the batch lifecycle. This adds a single summary log line in `runOneBatch` covering:

- `submit_ms` — time to submit the batch task
- `status_ready_ms` — start until the task reaches a terminal status (submit + poll)
- `download_map_ms` — download NDJSON parts, parse and map rows to messages
- `total_ms` — end-to-end

The line also carries task_id, status, channels, parts, rows and messages.

## Scope
Logging only. No business logic change; `rowsToMessages` error handling is preserved.

## Testing
- gofmt clean, go vet clean
- `go build ./internal/pipeline/...` OK
- `go test ./internal/pipeline/` passing

Closes #129