### PR TITLE
fix: use Asia/Shanghai wall clock for LLM prompt dates

### DIFF
--- a/internal/pipeline/narrow.go
+++ b/internal/pipeline/narrow.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 )
 
 // TimeNarrowResult represents the structured output from time-range extraction.
@@ -77,7 +78,7 @@ func PreRetrievalNarrow(ctx context.Context, topic string, originalStart, origin
 	}
 	topic = sanitizeTopic(topic)
 
-	now := time.Now()
+	now := timezone.Now()
 	currentDate := now.Format("2006-01-02")
 	weekdays := [...]string{"日", "一", "二", "三", "四", "五", "六"}
 	weekday := weekdays[now.Weekday()]

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 )
 
 const MapFailedMarker = "总结失败"
@@ -398,7 +399,7 @@ func buildMapSystemPrompt(userName, topic string) string {
 	sb.WriteString(fmt.Sprintf("- 当前用户：%s\n", userName))
 	sb.WriteString(fmt.Sprintf("- 总结主题：%s\n", topic))
 
-	now := time.Now()
+	now := timezone.Now()
 	weekdays := [...]string{"日", "一", "二", "三", "四", "五", "六"}
 	sb.WriteString(fmt.Sprintf("- 当前日期：%s（星期%s）\n",
 		now.Format("2006-01-02"), weekdays[now.Weekday()]))
@@ -443,7 +444,7 @@ func buildReduceSystemPrompt(topic string) string {
 	sb.WriteString(`你是一个专业的工作内容整理助手。请将以下多个分片总结合并为一份完整的总结报告。
 
 `)
-	now := time.Now()
+	now := timezone.Now()
 	weekdays := [...]string{"日", "一", "二", "三", "四", "五", "六"}
 	sb.WriteString(fmt.Sprintf("当前日期：%s（星期%s）\n\n",
 		now.Format("2006-01-02"), weekdays[now.Weekday()]))


### PR DESCRIPTION
## Summary

The "current date/time" injected into the LLM prompts was derived from the bare `time.Now()`, which uses the server's local timezone. This switches the three business/wall-clock sites to the project's existing `timezone.Now()` (Asia/Shanghai).

## Impact

When the server timezone is not `+08:00` (for example, containers running in UTC), the "current date" fed to the LLM is wrong. Since the summarization feature interprets relative time expressions (今天 / 昨天 / 本周 …) against this injected current date, a wrong reference day breaks today/yesterday/this-week parsing and the resulting summaries — silently returning the wrong messages and reasoning about the wrong day.

## Changes

Swapped `time.Now()` → `timezone.Now()` at the three current-date/time prompt sites (formatting unchanged):

- `internal/pipeline/narrow.go` — current date/weekday/time for the time-parsing prompt (added the `internal/timezone` import).
- `internal/service/llm.go` — current date in the map (summary) prompt.
- `internal/service/llm.go` — current date in the reduce prompt.

## Convention

Per project convention, business/wall-clock time uses `timezone.Now()`, while pure elapsed-timing starts use bare `time.Now()`. The elapsed-timing starts (`narrowStart` in narrow.go, `start` in llm.go) are timezone-irrelevant and are intentionally left unchanged.

## Scope

This is the timezone-only slice of PR #92. The CRC32 DM-channel change from #92 has already been merged via #124 and is intentionally excluded here.

## Verification

- `go build ./internal/...` — passes.
- `go vet ./...` — passes.

Closes #131
