### PR TITLE
chore(observability): make octo-search batch poll interval configurable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,6 +11,7 @@ All configuration is done via environment variables.
 | `MESSAGE_FETCH_BACKEND` | Message content backend: `batch` or `mysql` | No | `batch` |
 | `OCTO_SEARCH_URL` | octo-search-batch base URL for message export (without `/v1`) | Yes when `MESSAGE_FETCH_BACKEND=batch` | — |
 | `OCTO_SEARCH_TOKEN` | S2S bearer token for octo-search-batch | Yes when `MESSAGE_FETCH_BACKEND=batch` | — |
+| `OCTO_SEARCH_POLL_INTERVAL_SECONDS` | Poll interval for octo-search-batch task status | No | `1` |
 | `OCTO_API_URL` | Authentication API base URL | Yes (API) | — |
 | `LLM_API_URL` | LLM gateway base URL (OpenAI-compatible) | Yes (Worker) | — |
 | `LLM_API_KEY` | API key for the LLM gateway | Yes (Worker) | — |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ export LLM_API_KEY=sk-your-key-here
 export MESSAGE_FETCH_BACKEND=batch
 export OCTO_SEARCH_URL=http://octo-search-batch:8080
 export OCTO_SEARCH_TOKEN=your-s2s-token
+export OCTO_SEARCH_POLL_INTERVAL_SECONDS=1
 export SUMMARY_LISTEN_ADDR=:8090
 
 ./cmd serve

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	MessageFetchBackend string
 	OctoSearchURL       string
 	OctoSearchToken     string
+	OctoSearchPollSec   int
 
 	// Channel scope narrowing
 	ChannelScopeEnabled bool
@@ -157,6 +158,7 @@ func Load() *Config {
 		MessageFetchBackend: strings.ToLower(strings.TrimSpace(envStr("MESSAGE_FETCH_BACKEND", "batch"))),
 		OctoSearchURL:       envStr("OCTO_SEARCH_URL", ""),
 		OctoSearchToken:     envStr("OCTO_SEARCH_TOKEN", ""),
+		OctoSearchPollSec:   envInt("OCTO_SEARCH_POLL_INTERVAL_SECONDS", 1),
 
 		ChannelScopeEnabled: envBool("CHANNEL_SCOPE_ENABLED", true),
 

--- a/internal/config/config_workflow_test.go
+++ b/internal/config/config_workflow_test.go
@@ -14,11 +14,15 @@ func TestLoad_WorkflowConfigs(t *testing.T) {
 		t.Setenv("SKIP_MAP_REDUCE_THRESHOLD", "")
 		t.Setenv("TOKENIZER_HTTP_TIMEOUT", "")
 		t.Setenv("MESSAGE_FETCH_BACKEND", "")
+		t.Setenv("OCTO_SEARCH_POLL_INTERVAL_SECONDS", "")
 
 		cfg := Load()
 
 		if cfg.MessageFetchBackend != "batch" {
 			t.Errorf("MessageFetchBackend = %q, want batch", cfg.MessageFetchBackend)
+		}
+		if cfg.OctoSearchPollSec != 1 {
+			t.Errorf("OctoSearchPollSec = %d, want 1", cfg.OctoSearchPollSec)
 		}
 		if cfg.EnableIntentShortcut != true {
 			t.Errorf("EnableIntentShortcut = %v, want true", cfg.EnableIntentShortcut)
@@ -45,11 +49,15 @@ func TestLoad_WorkflowConfigs(t *testing.T) {
 		t.Setenv("SKIP_MAP_REDUCE_THRESHOLD", "150000")
 		t.Setenv("TOKENIZER_HTTP_TIMEOUT", "20")
 		t.Setenv("MESSAGE_FETCH_BACKEND", "mysql")
+		t.Setenv("OCTO_SEARCH_POLL_INTERVAL_SECONDS", "2")
 
 		cfg := Load()
 
 		if cfg.MessageFetchBackend != "mysql" {
 			t.Errorf("MessageFetchBackend = %q, want mysql", cfg.MessageFetchBackend)
+		}
+		if cfg.OctoSearchPollSec != 2 {
+			t.Errorf("OctoSearchPollSec = %d, want 2", cfg.OctoSearchPollSec)
 		}
 		if cfg.EnableIntentShortcut != false {
 			t.Errorf("EnableIntentShortcut = %v, want false", cfg.EnableIntentShortcut)

--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -416,7 +416,7 @@ func FetchMessagesFromChannel(ctx context.Context, channelID string, channelType
 	return messages, nil
 }
 
-func fetchMessagesByBackend(ctx context.Context, backend string, octoClient octoSearchClient, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, imDB *gorm.DB, tableCount int, maxPerChannel int, fetchConcurrency int) ([]Message, error) {
+func fetchMessagesByBackend(ctx context.Context, backend string, octoClient octoSearchClient, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, imDB *gorm.DB, tableCount int, maxPerChannel int, fetchConcurrency int, octoSearchPollSec int) ([]Message, error) {
 	selected := strings.ToLower(strings.TrimSpace(backend))
 	if selected == "" {
 		selected = "batch"
@@ -426,7 +426,7 @@ func fetchMessagesByBackend(ctx context.Context, backend string, octoClient octo
 		if octoClient == nil {
 			return nil, fmt.Errorf("octo-search client is not configured")
 		}
-		return fetchViaBatch(ctx, octoClient, candidates, creatorUID, startTS, endTS, fetchConcurrency)
+		return fetchViaBatch(ctx, octoClient, candidates, creatorUID, startTS, endTS, fetchConcurrency, time.Duration(octoSearchPollSec)*time.Second)
 	case "mysql":
 		return fetchViaMySQL(ctx, candidates, creatorUID, startTS, endTS, imDB, tableCount, maxPerChannel, fetchConcurrency)
 	default:
@@ -701,7 +701,7 @@ func FilterMessagesByRelevance(messages []Message, topic string, participantUIDs
 // - Target persons (for post-fetch filtering)
 //
 // Returns messages, intent result (for target person filtering), and error.
-func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, participantUIDs []string, participantNames []string, specifiedSources []map[string]interface{}, topic string, timeStart, timeEnd time.Time, imDB *gorm.DB, octoClient octoSearchClient, messageFetchBackend string, toolCallFn LLMToolCallFn, llmFn LLMCallFn, tableCount int, maxPerChannel int, fetchConcurrency int, channelScopeOpts *ChannelScopeOptions) ([]Message, *IntentResult, error) {
+func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, participantUIDs []string, participantNames []string, specifiedSources []map[string]interface{}, topic string, timeStart, timeEnd time.Time, imDB *gorm.DB, octoClient octoSearchClient, messageFetchBackend string, toolCallFn LLMToolCallFn, llmFn LLMCallFn, tableCount int, maxPerChannel int, fetchConcurrency int, octoSearchPollSec int, channelScopeOpts *ChannelScopeOptions) ([]Message, *IntentResult, error) {
 	maxDays := DefaultTimeRangeDays
 	if timeEnd.Sub(timeStart) > time.Duration(maxDays)*24*time.Hour {
 		return nil, nil, fmt.Errorf("时间范围不能超过 %d 天", maxDays)
@@ -798,7 +798,7 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 
 	// Layer 4: fetch message content from the configured backend.
 	fetchStart := time.Now()
-	allMessages, err := fetchMessagesByBackend(ctx, messageFetchBackend, octoClient, candidates, creatorUID, startTS, endTS, imDB, tableCount, maxPerChannel, fetchConcurrency)
+	allMessages, err := fetchMessagesByBackend(ctx, messageFetchBackend, octoClient, candidates, creatorUID, startTS, endTS, imDB, tableCount, maxPerChannel, fetchConcurrency, octoSearchPollSec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetch messages via %s: %w", messageFetchBackend, err)
 	}

--- a/internal/pipeline/fetch_archive_test.go
+++ b/internal/pipeline/fetch_archive_test.go
@@ -216,7 +216,7 @@ func TestResolveAndFetch_SelectedArchivedThread_ProducesMessages(t *testing.T) {
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, specifiedSources, "",
-		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, nil,
+		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, 1, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -246,7 +246,7 @@ func TestResolveAndFetch_MySQLBackend_UsesLegacyMessageFilter(t *testing.T) {
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, specifiedSources, "",
-		start, end, db, nil, "mysql", nil, nil, 1, 0, 2, nil,
+		start, end, db, nil, "mysql", nil, nil, 1, 0, 2, 1, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -270,7 +270,7 @@ func TestResolveAndFetch_NoSources_ArchivedExcluded(t *testing.T) {
 	// No explicit sources -> auto discovery -> only the active thread's message.
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, nil, "",
-		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, nil,
+		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, 1, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -377,7 +377,7 @@ func TestResolveAndFetch_MultiPerson_SelectedArchivedThread_Retained(t *testing.
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", []string{"user2"}, nil, specifiedSources, "",
-		start, end, db, echoOctoClient("user1", "user2"), "batch", nil, nil, 1, 0, 2, nil,
+		start, end, db, echoOctoClient("user1", "user2"), "batch", nil, nil, 1, 0, 2, 1, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)

--- a/internal/pipeline/octo_search_fetch.go
+++ b/internal/pipeline/octo_search_fetch.go
@@ -24,7 +24,6 @@ import (
 const octoSearchBatchSize = 30
 
 const (
-	octoSearchPollInterval = 5 * time.Second  // API-recommended polling interval.
 	octoSearchTotalBudget  = 20 * time.Minute // Total client-side budget; upstream ctx has no deadline.
 	octoSearchDefaultConc  = 10               // Default concurrency, matching existing fetchConcurrency.
 	octoSearchMinWindowSec = int64(6 * 3600)  // Minimum single-channel split window before skipping.
@@ -112,7 +111,7 @@ type octoSearchClient interface {
 // fetchConcurrency preserves the existing configurable concurrency behavior.
 // This function creates the total timeout because the upstream context has no
 // deadline.
-func fetchViaBatch(ctx context.Context, client octoSearchClient, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, fetchConcurrency int) ([]Message, error) {
+func fetchViaBatch(ctx context.Context, client octoSearchClient, candidates []ChannelInfo, creatorUID string, startTS, endTS int64, fetchConcurrency int, pollInterval time.Duration) ([]Message, error) {
 	if len(candidates) == 0 {
 		return nil, nil // Do not submit an empty channel list.
 	}
@@ -124,6 +123,9 @@ func fetchViaBatch(ctx context.Context, client octoSearchClient, candidates []Ch
 
 	if fetchConcurrency <= 0 {
 		fetchConcurrency = octoSearchDefaultConc
+	}
+	if pollInterval <= 0 {
+		pollInterval = time.Second
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, octoSearchTotalBudget)
@@ -154,7 +156,7 @@ func fetchViaBatch(ctx context.Context, client octoSearchClient, candidates []Ch
 			}
 			defer func() { <-sem }()
 
-			msgs, err := runBatchWithSplit(ctx, client, chs, startTS, endTS, infoByID)
+			msgs, err := runBatchWithSplit(ctx, client, chs, startTS, endTS, infoByID, pollInterval)
 			if err != nil {
 				if isFatalBatchErr(err) {
 					// Aborting errors stop the whole fetch.
@@ -213,8 +215,8 @@ func isFatalBatchErr(err error) bool {
 // runBatchWithSplit submits one batch. On 413 it first bisects by channel; when
 // a single channel is still too large, it switches to time-window splitting.
 // Other errors are returned for the caller to classify.
-func runBatchWithSplit(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
-	msgs, err := runOneBatch(ctx, client, chs, startTS, endTS, infoByID)
+func runBatchWithSplit(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo, pollInterval time.Duration) ([]Message, error) {
+	msgs, err := runOneBatch(ctx, client, chs, startTS, endTS, infoByID, pollInterval)
 	if err == nil {
 		return msgs, nil
 	}
@@ -227,7 +229,7 @@ func runBatchWithSplit(ctx context.Context, client octoSearchClient, chs []strin
 	if splittable {
 		var out []Message
 		for _, p := range parts {
-			sub, subErr := runBatchWithSplit(ctx, client, p, startTS, endTS, infoByID)
+			sub, subErr := runBatchWithSplit(ctx, client, p, startTS, endTS, infoByID, pollInterval)
 			if subErr != nil {
 				if isFatalBatchErr(subErr) {
 					return nil, subErr
@@ -242,13 +244,13 @@ func runBatchWithSplit(ctx context.Context, client octoSearchClient, chs []strin
 	}
 
 	// A single channel is still too large; shrink the time window.
-	return runWithTimeWindowSplit(ctx, client, chs, startTS, endTS, infoByID)
+	return runWithTimeWindowSplit(ctx, client, chs, startTS, endTS, infoByID, pollInterval)
 }
 
 // runWithTimeWindowSplit bisects the time window for a single channel after
 // 413. If the minimum window is still too large, the channel is skipped instead
 // of retrying forever.
-func runWithTimeWindowSplit(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
+func runWithTimeWindowSplit(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo, pollInterval time.Duration) ([]Message, error) {
 	if endTS-startTS <= octoSearchMinWindowSec {
 		log.Printf("[pipeline-personal] octo-search: channel %v still 413 at min window (%ds), skipping", chs, endTS-startTS)
 		return nil, nil
@@ -258,7 +260,7 @@ func runWithTimeWindowSplit(ctx context.Context, client octoSearchClient, chs []
 	// Recurse on both halves; aborting errors stop the fetch, isolatable errors skip only
 	// that half.
 	for _, w := range [2][2]int64{{startTS, mid}, {mid + 1, endTS}} {
-		sub, err := runBatchWithSplit(ctx, client, chs, w[0], w[1], infoByID)
+		sub, err := runBatchWithSplit(ctx, client, chs, w[0], w[1], infoByID, pollInterval)
 		if err != nil {
 			if isFatalBatchErr(err) {
 				return nil, err
@@ -273,7 +275,7 @@ func runWithTimeWindowSplit(ctx context.Context, client octoSearchClient, chs []
 
 // runOneBatch submits one batch, polls to a terminal status, downloads rows,
 // then maps rows back to pipeline messages.
-func runOneBatch(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo) ([]Message, error) {
+func runOneBatch(ctx context.Context, client octoSearchClient, chs []string, startTS, endTS int64, infoByID map[string]ChannelInfo, pollInterval time.Duration) ([]Message, error) {
 	batchStart := time.Now()
 	taskID, err := client.Submit(ctx, chs, startTS, endTS)
 	if err != nil {
@@ -281,7 +283,7 @@ func runOneBatch(ctx context.Context, client octoSearchClient, chs []string, sta
 	}
 	submitElapsed := time.Since(batchStart)
 
-	status, err := pollUntilTerminal(ctx, client, taskID)
+	status, err := pollUntilTerminal(ctx, client, taskID, pollInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -340,10 +342,13 @@ func validateBatchStatusParts(status *service.BatchStatus, chs []string) error {
 	return nil
 }
 
-// pollUntilTerminal polls at a fixed interval until a terminal status. On
+// pollUntilTerminal polls at the configured interval until a terminal status. On
 // cancellation or poll error it attempts best-effort Delete.
-func pollUntilTerminal(ctx context.Context, client octoSearchClient, taskID string) (*service.BatchStatus, error) {
-	ticker := time.NewTicker(octoSearchPollInterval)
+func pollUntilTerminal(ctx context.Context, client octoSearchClient, taskID string, pollInterval time.Duration) (*service.BatchStatus, error) {
+	if pollInterval <= 0 {
+		pollInterval = time.Second
+	}
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 	for {
 		status, err := client.Poll(ctx, taskID)

--- a/internal/pipeline/octo_search_fetch_test.go
+++ b/internal/pipeline/octo_search_fetch_test.go
@@ -173,7 +173,7 @@ func TestFetchViaBatch_HappyPathMappingAndBackfill(t *testing.T) {
 		},
 	}
 	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2, ChannelName: "群一"}}
-	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestRunOneBatch_RejectsUnexpectedRowChannel(t *testing.T) {
 	}
 	_, err := runOneBatch(context.Background(), fc, []string{"g1"}, 0, 100, map[string]ChannelInfo{
 		"g1": {ChannelID: "g1", ChannelType: 2},
-	})
+	}, time.Second)
 	if err == nil {
 		t.Fatal("unexpected row channel must fail the batch")
 	}
@@ -231,7 +231,7 @@ func TestRunOneBatch_RejectsUnexpectedPartChannel(t *testing.T) {
 	}
 	_, err := runOneBatch(context.Background(), fc, []string{"g1"}, 0, 100, map[string]ChannelInfo{
 		"g1": {ChannelID: "g1", ChannelType: 2},
-	})
+	}, time.Second)
 	if err == nil {
 		t.Fatal("unexpected part channel must fail the batch")
 	}
@@ -250,7 +250,7 @@ func TestRunOneBatch_RejectsPositiveCountWithoutParts(t *testing.T) {
 	}
 	_, err := runOneBatch(context.Background(), fc, []string{"g1"}, 0, 100, map[string]ChannelInfo{
 		"g1": {ChannelID: "g1", ChannelType: 2},
-	})
+	}, time.Second)
 	if err == nil {
 		t.Fatal("positive actual_count without parts must fail the batch")
 	}
@@ -263,7 +263,7 @@ func TestFetchViaBatch_FatalErrorAborts(t *testing.T) {
 		parseFn:  func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
 	}
 	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
-	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if !errors.Is(err, service.ErrUnauthorized) {
 		t.Fatalf("401 must abort whole fetch, got err=%v", err)
 	}
@@ -288,7 +288,7 @@ func TestFetchViaBatch_IsolatableSkipsBadBatchKeepsRest(t *testing.T) {
 	for i := range candidates {
 		candidates[i] = ChannelInfo{ChannelID: fmt.Sprintf("g%02d", i), ChannelType: 2}
 	}
-	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if err != nil {
 		t.Fatalf("isolatable failure must NOT abort, got err=%v", err)
 	}
@@ -316,7 +316,7 @@ func TestFetchViaBatch_413SplitsByChannel(t *testing.T) {
 		{ChannelID: "c1", ChannelType: 2},
 		{ChannelID: "c2", ChannelType: 2},
 	}
-	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if err != nil {
 		t.Fatalf("413 should split, not fail: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestFetchViaBatch_EmptyCandidates(t *testing.T) {
 		pollFn:  func(string) (*service.BatchStatus, error) { return nil, nil },
 		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
 	}
-	msgs, err := fetchViaBatch(context.Background(), fc, nil, "self", 0, 100000, 4)
+	msgs, err := fetchViaBatch(context.Background(), fc, nil, "self", 0, 100000, 4, time.Second)
 	if err != nil || msgs != nil {
 		t.Fatalf("empty candidates → (nil,nil), got msgs=%v err=%v", msgs, err)
 	}
@@ -349,7 +349,7 @@ func TestFetchViaBatch_PollErrorTriggersDelete(t *testing.T) {
 	}
 	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
 	// Plain errors are isolatable, but the submitted task must still be deleted.
-	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if err != nil {
 		t.Fatalf("plain poll error should be isolatable (nil err), got %v", err)
 	}
@@ -380,7 +380,7 @@ func TestFetchViaBatch_413SplitKeepsSuccessfulSiblingOnIsolatableFailure(t *test
 		{ChannelID: "c1", ChannelType: 2},
 		{ChannelID: "c2", ChannelType: 2},
 	}
-	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	msgs, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if err != nil {
 		t.Fatalf("isolatable sibling failure must NOT fail the whole batch: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestFetchViaBatch_UnknownClientErrorAborts(t *testing.T) {
 		parseFn: func([]service.Part) ([]service.BatchMessageRow, error) { return nil, nil },
 	}
 	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
-	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4)
+	_, err := fetchViaBatch(context.Background(), fc, candidates, "self", 0, 100000, 4, time.Second)
 	if !errors.Is(err, service.ErrFatalClient) {
 		t.Fatalf("unknown 4xx must abort whole fetch, got err=%v", err)
 	}
@@ -420,7 +420,7 @@ func TestFetchViaBatch_ContextDeadlinePropagates(t *testing.T) {
 	candidates := []ChannelInfo{{ChannelID: "g1", ChannelType: 2}}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
-	_, err := fetchViaBatch(ctx, fc, candidates, "self", 0, 100000, 4)
+	_, err := fetchViaBatch(ctx, fc, candidates, "self", 0, 100000, 4, time.Second)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("ctx deadline must propagate (not be swallowed as isolatable), got err=%v", err)
 	}

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -503,7 +503,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		ctx, userID, nil, nil, specifiedSources, task.Title,
 		task.TimeRangeStart, task.TimeRangeEnd,
 		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn,
-		p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency,
+		p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency, p.cfg.OctoSearchPollSec,
 		channelScopeOpts,
 	)
 	timing.Observe(taskNo, "fetch_messages", fetchStart)

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -699,7 +699,7 @@ func (p *Processor) executePipeline(task model.SummaryTask) error {
 	messages, _, err = pipeline.ResolveAndFetchMessagesForPersonal(
 		ctx, task.CreatorID, participantUIDs, participantNames, specifiedSources, task.Title,
 		task.TimeRangeStart, task.TimeRangeEnd,
-		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn, p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency,
+		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn, p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency, p.cfg.OctoSearchPollSec,
 		channelScopeOpts,
 	)
 	timing.Observe(task.TaskNo, "fetch_messages", fetchStart)


### PR DESCRIPTION
## What
Extract the hard-coded octo-search batch poll interval into env `OCTO_SEARCH_POLL_INTERVAL_SECONDS` (default 1s), threaded through fetchViaBatch -> runOneBatch -> pollUntilTerminal. A non-positive value falls back to 1s to guard against a zero-interval ticker.

## Why
Lets each environment tune poll frequency without a rebuild, and pairs with the per-stage latency logging from #130 to choose a final value from real status-ready timings (the api-spec suggests 5s; this makes it adjustable per environment).

## Test
- gofmt clean on changed files; `go vet` clean
- `go test ./internal/config/ ./internal/pipeline/` green
- worker package (CGO) green

Closes #133