### PR TITLE
feat(notify): 智能总结主动通知（调用 octo-server internal-notify 接口）

### DIFF
--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
@@ -90,12 +91,40 @@ func main() {
 	// Start worker pool
 	pool := worker.NewWorkerPool(cfg.WorkerMaxConcurrent)
 
+	// Build the terminal-state notifier (方向 B: reliable delivery + full fan-out).
+	// Disabled unless SUMMARY_NOTIFY_ENABLED=true; a nil deliverer / disabled
+	// config makes OnTaskTerminal a no-op, so it is always safe to wire.
+	var notifier *notify.Notifier
+	if cfg.NotifyEnabled {
+		if cfg.OctoAPIURL == "" {
+			log.Printf("[worker] SUMMARY_NOTIFY_ENABLED=true but OCTO_API_URL missing; notifications disabled")
+		} else {
+			// SUMMARY_NOTIFY_TOKEN authenticates /v1/internal/notify. Prod misconfig
+			// must fail fast; dev only warns.
+			if cfg.NotifyInternalToken == "" {
+				if cfg.AppEnv == "prod" {
+					log.Fatalf("[worker] SUMMARY_NOTIFY_ENABLED=true but SUMMARY_NOTIFY_TOKEN missing (APP_ENV=prod)")
+				}
+				log.Printf("[worker] WARNING: SUMMARY_NOTIFY_ENABLED=true but SUMMARY_NOTIFY_TOKEN missing (APP_ENV=%s); /v1/internal/notify will 401", cfg.AppEnv)
+			}
+			deliverer := notify.NewInternalNotifyDeliverer(cfg.OctoAPIURL, cfg.NotifyInternalToken, cfg.SummaryWebBaseURL)
+			// imDB (shared IM DB, read-only) resolves space names in the text and the
+			// active-membership pre-check; nil-safe degradation inside notify.
+			notifier = notify.New(summaryDB, imDB, deliverer, notify.Config{
+				Enabled:     true,
+				MaxAttempts: cfg.MaxNotifyAttempts,
+			}).WithErrorSanitizer(worker.SanitizeErrorForUser)
+			log.Printf("[worker] terminal-state notifications ENABLED (internal-notify transport)")
+		}
+	}
+
 	// Start processor (polling loop)
 	proc := worker.NewProcessor(summaryDB, imDB, pool, llm, cfg)
+	proc.SetNotifier(notifier)
 	go proc.Run()
 
 	// Start scheduler (cron jobs)
-	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays, cfg.FeatureTeamSchedule)
+	cronSched := worker.StartScheduler(summaryDB, imDB, cfg.WorkerMaxRetry, cfg.WorkerTriggerURL, cfg.ScheduleMaxWindowDays, cfg.FeatureTeamSchedule, notifier)
 
 	// Start internal HTTP server for worker-trigger
 	hub := ws.NewHub(summaryDB)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Mininglamp-OSS/octo-smart-summary
 go 1.25
 
 require (
+	github.com/daulet/tokenizers v1.27.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/gorilla/websocket v1.5.1
@@ -21,7 +22,6 @@ require (
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
-	github.com/daulet/tokenizers v1.27.0 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/internal/api/handler/regenerate_test.go
+++ b/internal/api/handler/regenerate_test.go
@@ -32,6 +32,7 @@ func setupRegenerateDB(t *testing.T) *gorm.DB {
 		&model.PersonalResult{},
 		&model.SummaryResult{},
 		&model.SummaryChunk{},
+		&model.SummaryNotification{},
 	)
 	return db
 }
@@ -101,6 +102,16 @@ func seedCompletedTask(t *testing.T, db *gorm.DB) (taskID int64, participantID i
 		ChunkIndex:   0,
 		ChunkSummary: "old chunk",
 		TokenUsed:    50,
+	})
+
+	// Prior terminal-state notification rows: a 'sent' completed row that would
+	// otherwise survive Regenerate and silently suppress the re-run's delivery.
+	db.Create(&model.SummaryNotification{
+		TaskID:       task.ID,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "creator1",
+		Status:       model.NotifyStatusSent,
+		SentAt:       &now,
 	})
 
 	return task.ID, participant.ID, pr.ID
@@ -193,6 +204,13 @@ func TestRegenerate_ResetsAllAssociatedData(t *testing.T) {
 	db.Model(&model.SummaryChunk{}).Where("task_id = ?", taskID).Count(&chunkCount)
 	if chunkCount != 0 {
 		t.Errorf("summary_chunk count: want 0, got %d", chunkCount)
+	}
+
+	// Verify SummaryNotification cleared (re-arms delivery for the re-run).
+	var notifCount int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", taskID).Count(&notifCount)
+	if notifCount != 0 {
+		t.Errorf("summary_notification count: want 0, got %d", notifCount)
 	}
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -971,6 +971,11 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		}).Error; err != nil {
 			return err
 		}
+		// Regenerate must re-arm notification delivery: clear all prior rows so
+		// OnTaskTerminal re-claims fresh instead of hitting sent/failed dedup rows.
+		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryNotification{}).Error; err != nil {
+			return err
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	CharsPerTokenCJK          int
 	CharsPerTokenASCII        int
 
-	// Worker trigger URL (API → Worker)
+	// Worker trigger URL (API -> Worker)
 	WorkerTriggerURL string
 
 	// Candidate search query limit (-1 = no limit, >0 = use as SQL LIMIT)
@@ -108,6 +108,28 @@ type Config struct {
 	SkipMapReduceThreshold int    // Skip Map-Reduce threshold (tokens), env SKIP_MAP_REDUCE_THRESHOLD
 	KimiAPIKey             string // Kimi API key for exact token counting, env KIMI_API_KEY
 	TokenizerHTTPTimeout   int    // HTTP timeout for tokenizer API calls, env TOKENIZER_HTTP_TIMEOUT
+
+	// --- task-terminal notification (delivery via octo-server internal-notify) ---
+
+	// NotifyEnabled is the master switch for delivering a terminal-state
+	// notification (Completed / Failed) to the task's recipients. Default OFF so
+	// the feature can be dark-launched.
+	NotifyEnabled bool
+	// NotifyInternalToken authenticates POST /v1/internal/notify via the
+	// X-Internal-Token header (constant-time compared server-side). SECRET: read
+	// from env only, never printed/logged, never written to
+	// summary_notification.last_error. Prod + NotifyEnabled but empty => startup
+	// fatal (fail-fast on misconfig); dev only warns.
+	NotifyInternalToken string
+	// SummaryWebBaseURL is the base for a result link in the notification text.
+	// Empty => no link appended.
+	SummaryWebBaseURL string
+	// AppEnv is the deployment environment ("prod" | "dev"). Drives the
+	// prod-fatal / dev-warn handling of a missing NotifyInternalToken.
+	AppEnv string
+	// MaxNotifyAttempts caps same-row retries for a single (task_id, notify_kind)
+	// notification before it is left in status='failed'. Default 3.
+	MaxNotifyAttempts int
 }
 
 func Load() *Config {
@@ -162,6 +184,7 @@ func Load() *Config {
 
 		ToolCallTimeout: envInt("TOOL_CALL_TIMEOUT", 30),
 
+		// keep upstream main default (true, #112)
 		FeatureTeamSchedule: envBool("FEATURE_TEAM_SCHEDULE", true),
 
 		EnableIntentShortcut: envBool("ENABLE_INTENT_SHORTCUT", true),
@@ -172,6 +195,14 @@ func Load() *Config {
 		SkipMapReduceThreshold: envInt("SKIP_MAP_REDUCE_THRESHOLD", 0),
 		KimiAPIKey:             envStr("KIMI_API_KEY", ""),
 		TokenizerHTTPTimeout:   envInt("TOKENIZER_HTTP_TIMEOUT", 10),
+
+		NotifyEnabled:       envBool("SUMMARY_NOTIFY_ENABLED", false),
+		// Custom env name (老板拍板): distinct from matter's NOTIFY_INTERNAL_TOKEN.
+		// Header contract X-Internal-Token is unchanged; only the source env differs.
+		NotifyInternalToken: envStr("SUMMARY_NOTIFY_TOKEN", ""),
+		SummaryWebBaseURL:   envStr("SUMMARY_WEB_BASE_URL", ""),
+		AppEnv:              envStr("APP_ENV", "dev"),
+		MaxNotifyAttempts:   envInt("MAX_NOTIFY_ATTEMPTS", 3),
 	}
 }
 

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -1,0 +1,42 @@
+package model
+
+import "time"
+
+// Notification kind constants (summary_notification.notify_kind).
+// failed/completed are independent kinds, deduped per recipient via
+// UNIQUE(task_id, notify_kind, recipient_uid).
+const (
+	NotifyKindCompleted = "completed"
+	NotifyKindFailed    = "failed"
+)
+
+// Notification status constants (summary_notification.status).
+const (
+	NotifyStatusPending = "pending" // 抢占式插入后的初始态
+	NotifyStatusSent    = "sent"    // 投递成功（HTTP 2xx）
+	NotifyStatusFailed  = "failed"  // 重试耗尽，终态失败
+)
+
+// SummaryNotification is the dedup / idempotency state machine row for a single
+// terminal-state notification. It lives in the summary DB (never the IM DB).
+//
+// The UNIQUE(task_id, notify_kind, recipient_uid) key is the per-recipient
+// preemptive-insert lock: the first writer INSERTs status='pending' for a given
+// (task, kind, uid) and wins; a duplicate-key error means that recipient is
+// already owned so the current run skips it. by-person tasks fan out to one row
+// per recipient, so each person is deduped/retried independently. A row is NEVER
+// DELETEd — failed deliveries stay as status='failed' with last_error for audit.
+type SummaryNotification struct {
+	ID           int64      `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID       int64      `gorm:"column:task_id;not null;uniqueIndex:uk_task_kind_uid,priority:1" json:"task_id"`
+	NotifyKind   string     `gorm:"column:notify_kind;type:varchar(16);not null;uniqueIndex:uk_task_kind_uid,priority:2" json:"notify_kind"`
+	RecipientUID string     `gorm:"column:recipient_uid;type:varchar(64);not null;default:'';uniqueIndex:uk_task_kind_uid,priority:3" json:"recipient_uid"`
+	Status       string     `gorm:"column:status;type:varchar(16);not null;default:'pending'" json:"status"`
+	AttemptCount int        `gorm:"column:attempt_count;not null;default:0" json:"attempt_count"`
+	LastError    *string    `gorm:"column:last_error;type:varchar(500)" json:"last_error"`
+	CreatedAt    time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt    time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+	SentAt       *time.Time `gorm:"column:sent_at" json:"sent_at"`
+}
+
+func (SummaryNotification) TableName() string { return "summary_notification" }

--- a/internal/notify/client.go
+++ b/internal/notify/client.go
@@ -1,0 +1,204 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Channel type values on the IM wire protocol (SendMessageRequest.ChannelType).
+// 1=DM, 2=Group, 5=Thread. The state machine only ever builds DM targets, but
+// the enum is kept for target resolution parity with the origin channel.
+const (
+	WireChannelDM     = 1
+	WireChannelGroup  = 2
+	WireChannelThread = 5
+)
+
+// Deliverer is the transport the state machine drives per recipient. It is an
+// interface so the claim/deliver/mark logic is unit-testable without a live
+// octo-server.
+type Deliverer interface {
+	// EnsureFriend is a delivery precondition hook. internal-notify needs none,
+	// so its implementation is a no-op returning nil.
+	EnsureFriend(ctx context.Context, spaceID, targetUID string) error
+	// SendMessage posts one message for one recipient. The state machine calls
+	// it once per recipient (targets is a single uid on the wire), so
+	// per-recipient dedup/retry semantics are preserved. A delivery that did not
+	// actually reach the user (network error, non-2xx, or 2xx with the recipient
+	// filtered out server-side) MUST return an error so the state machine records
+	// attempt+last_error and the sweep retries.
+	SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error
+}
+
+// SendMessageRequest is the state-machine-internal message shape. deliver()
+// fills ChannelID with the recipient uid, ChannelType=WireChannelDM, and Payload
+// with the IM-recognized shape {type:1, content:text, space_id?}. The
+// InternalNotifyDeliverer forwards Payload verbatim into the NotifyReq.
+type SendMessageRequest struct {
+	ChannelID   string         `json:"channel_id"`
+	ChannelType int            `json:"channel_type"`
+	Payload     map[string]any `json:"payload"`
+}
+
+// oboReservedKeys are OBO markers that must never appear in a payload.
+var oboReservedKeys = map[string]struct{}{
+	"actual_sender_uid": {},
+}
+
+func payloadHasOBOReserved(payload map[string]any) bool {
+	for k := range payload {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "__obo_") || strings.HasPrefix(lk, "obo_") {
+			return true
+		}
+		if _, ok := oboReservedKeys[lk]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// notifyReq mirrors octo-server modules/notify.NotifyReq (POST /v1/internal/notify).
+// One request carries exactly one recipient in Targets so the state machine's
+// per-recipient dedup/retry granularity is preserved.
+type notifyReq struct {
+	SpaceID  string         `json:"space_id"`
+	Service  string         `json:"service"`
+	Event    string         `json:"event"`
+	Targets  []string       `json:"targets"`
+	ActorUID string         `json:"actor_uid"`
+	Payload  map[string]any `json:"payload"`
+}
+
+const (
+	// notifyService is the service label carried in every NotifyReq.
+	notifyService = "summary-service"
+	// notifyEndpoint is the octo-server internal notify path.
+	notifyEndpoint = "/v1/internal/notify"
+	// internalTokenHeader authenticates the request (constant-time compared server-side).
+	internalTokenHeader = "X-Internal-Token"
+)
+
+// InternalNotifyDeliverer posts to octo-server's internal-notify API. Auth is the
+// constant X-Internal-Token; no per-user relationship is needed, so EnsureFriend
+// is a no-op.
+type InternalNotifyDeliverer struct {
+	baseURL string
+	token   string
+	// webBaseURL builds the result link folded into payload.result_url. Empty => omitted.
+	webBaseURL string
+	client     *http.Client
+}
+
+// NewInternalNotifyDeliverer builds the internal-notify transport. token is the
+// SUMMARY_NOTIFY_TOKEN secret (memory-only, only ever set on the request header).
+func NewInternalNotifyDeliverer(baseURL, token, webBaseURL string) *InternalNotifyDeliverer {
+	return &InternalNotifyDeliverer{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		token:      token,
+		webBaseURL: strings.TrimRight(webBaseURL, "/"),
+		client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// EnsureFriend is a no-op: internal-notify needs no per-user relationship.
+func (d *InternalNotifyDeliverer) EnsureFriend(ctx context.Context, spaceID, targetUID string) error {
+	return nil
+}
+
+// notifyResp mirrors octo-server modules/notify.NotifyResp. The server returns
+// 200 even when every target is filtered out (non-member), so Delivered is the
+// only trustworthy signal that the message actually reached someone.
+type notifyResp struct {
+	Delivered []string          `json:"delivered"`
+	Filtered  map[string]string `json:"filtered"`
+}
+
+// SendMessage posts one recipient's message to /v1/internal/notify. Payload is
+// forwarded verbatim: octo-server passes it straight to the IM message builder,
+// which requires the {type:1, content} shape — reshaping it here would render an
+// empty message under a 2xx and silently lose the notification.
+func (d *InternalNotifyDeliverer) SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error {
+	if payloadHasOBOReserved(msg.Payload) {
+		return fmt.Errorf("notify payload contains forbidden OBO reserved field")
+	}
+	// Copy so appending result_url never mutates the caller's payload.
+	payload := make(map[string]any, len(msg.Payload)+1)
+	for k, v := range msg.Payload {
+		payload[k] = v
+	}
+	if d.webBaseURL != "" {
+		payload["result_url"] = d.webBaseURL
+	}
+
+	// NotifyReq.space_id is required (binding); fall back to payload.space_id.
+	spaceID = strings.TrimSpace(spaceID)
+	if spaceID == "" {
+		if ps, _ := payload["space_id"].(string); ps != "" {
+			spaceID = strings.TrimSpace(ps)
+		}
+	}
+
+	req := notifyReq{
+		SpaceID:  spaceID,
+		Service:  notifyService,
+		Event:    "",
+		Targets:  []string{msg.ChannelID}, // single recipient — keep per-uid granularity
+		ActorUID: "",
+		Payload:  payload,
+	}
+	return d.post(ctx, notifyEndpoint, req, msg.ChannelID)
+}
+
+// post sends the request and treats "not actually delivered" as an error.
+// recipientUID is the single target; a 2xx whose Delivered list omits it means
+// the server filtered the recipient (e.g. non-member) — surface that as an
+// explicit failure so the state machine retries instead of marking sent.
+func (d *InternalNotifyDeliverer) post(ctx context.Context, path string, body any, recipientUID string) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal %s body: %w", path, err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", path, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(internalTokenHeader, d.token)
+
+	resp, err := d.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	// Bounded read: the token lives only in the request header and is never
+	// echoed back, so the body is safe to inspect/surface.
+	rawResp, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s returned HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(rawResp)))
+	}
+
+	// 2xx does not guarantee delivery: the server filters non-member targets and
+	// still returns 200 {delivered:[], filtered:{...}}. Require our recipient in
+	// Delivered, else fail so this is retried and left as last_error.
+	var body200 notifyResp
+	if err := json.Unmarshal(rawResp, &body200); err != nil {
+		return fmt.Errorf("%s: parse response: %w", path, err)
+	}
+	for _, uid := range body200.Delivered {
+		if uid == recipientUID {
+			return nil
+		}
+	}
+	if reason := body200.Filtered[recipientUID]; reason != "" {
+		return fmt.Errorf("%s: recipient filtered by server: %s", path, reason)
+	}
+	return fmt.Errorf("%s: recipient not in delivered set (filtered/dropped server-side)", path)
+}

--- a/internal/notify/dupkey.go
+++ b/internal/notify/dupkey.go
@@ -1,0 +1,38 @@
+package notify
+
+import (
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// isDuplicateKey reports whether err is a unique-constraint violation on the
+// summary_notification UNIQUE(task_id, notify_kind, recipient_uid) key. It is
+// driver-agnostic:
+//   - gorm v2 surfaces gorm.ErrDuplicatedKey for known drivers;
+//   - MySQL (go-sql-driver) reports "Error 1062" / "Duplicate entry";
+//   - SQLite (used by the unit tests) reports "UNIQUE constraint failed".
+//
+// We match all three so the preemptive-insert dedup works in prod and in tests.
+func isDuplicateKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "duplicate entry"):
+		return true
+	case strings.Contains(msg, "error 1062"):
+		return true
+	case strings.Contains(msg, "unique constraint failed"):
+		return true
+	case strings.Contains(msg, "constraint failed: unique"):
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,729 @@
+// Package notify delivers a terminal-state notification (Completed / Failed)
+// for a summary task to its recipients (by-person: participants ∪ creator;
+// otherwise the creator) via octo-server internal-notify. It is invoked by the
+// worker AFTER a task's terminal status is durably committed to the summary DB.
+//
+// Design:
+//   - Dedup / idempotency via a summary_notification row keyed
+//     UNIQUE(task_id, notify_kind, recipient_uid). The first writer INSERTs
+//     status='pending' and wins the right to deliver; a duplicate-key error
+//     means that recipient is already owned, so we skip. Rows are NEVER deleted.
+//     completed and failed are independent kinds, deduped per recipient.
+//   - On delivery success: UPDATE status='sent', sent_at=now.
+//   - On delivery failure: UPDATE status='failed', last_error, attempt_count+1,
+//     with bounded same-row retries (MaxNotifyAttempts). The SECRET token is
+//     never written to last_error.
+//   - Cancelled tasks are not notified (the caller never calls OnTaskTerminal
+//     for Cancelled).
+package notify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/gorm"
+)
+
+// Config is the subset of application config the notifier needs. It is passed
+// explicitly (rather than importing internal/config) so the package stays
+// decoupled and trivially testable.
+type Config struct {
+	Enabled     bool
+	MaxAttempts int
+}
+
+// Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
+type Notifier struct {
+	db             *gorm.DB
+	imDB           *gorm.DB // shared IM DB, read-only; used to resolve space names. May be nil.
+	deliverer      Deliverer
+	cfg            Config
+	now            func() time.Time    // injectable clock for tests
+	errorSanitizer func(string) string // single render-point sanitizer for failure reasons (see WithErrorSanitizer)
+}
+
+// New builds a Notifier. A nil deliverer or Enabled=false makes OnTaskTerminal a
+// no-op, so callers can wire it unconditionally. imDB is the shared IM DB used
+// (read-only) to resolve the space name for notification text; it may be nil, in
+// which case the text gracefully degrades to the space-less wording.
+func New(db *gorm.DB, imDB *gorm.DB, deliverer Deliverer, cfg Config) *Notifier {
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 3
+	}
+	return &Notifier{
+		db:        db,
+		imDB:      imDB,
+		deliverer: deliverer,
+		cfg:       cfg,
+		now:       timezone.Now,
+	}
+}
+
+// WithErrorSanitizer wires a single-render-point sanitizer for failure-reason
+// strings. It MUST be set in production: buildText runs every failure reason
+// (whether arriving via the synchronous OnTaskTerminal path OR the
+// sweep/redeliver path that reloads task.ErrorMessage raw from DB) through this
+// sanitizer before composing the user DM. The canonical implementation lives in
+// internal/worker.SanitizeErrorForUser (whitelist-maps LLM/timeout/chunk errors
+// to safe Chinese strings, everything else → "AI 处理失败，请稍后重试").
+//
+// If left nil, buildText falls back to a hardcoded safe string for any
+// non-empty failure reason — never leaks raw err.Error() to the user DM.
+// See PR#113 Jerry-Xin/OctoBoooot R3 blocker: sanitizing only at the worker
+// call sites left the sweep redeliver path renderring raw DSN/IP/stack.
+func (n *Notifier) WithErrorSanitizer(fn func(string) string) *Notifier {
+	if n != nil {
+		n.errorSanitizer = fn
+	}
+	return n
+}
+
+// OnTaskTerminal is the single entry point the worker calls right AFTER a task
+// reaches a terminal status (Completed / Failed) durably in the DB. errMsg is
+// the task's ErrorMessage for a Failed task (ignored for Completed). It is
+// best-effort: a delivery failure is logged and persisted, never propagated to
+// the worker's completion path.
+func (n *Notifier) OnTaskTerminal(task model.SummaryTask, status int, errMsg string) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+
+	kind, ok := kindForStatus(status)
+	if !ok {
+		// Cancelled / non-terminal: never notify.
+		return
+	}
+
+	// Quiet window removed (一期不做): manual and scheduled notifications are
+	// delivered immediately with no time-of-day suppression.
+
+	// completed fans out to every recipient (participants ∪ creator for a
+	// by-person task, else just the creator). failed goes ONLY to the creator to
+	// avoid broadcasting a failure to participants who never asked. Each recipient
+	// runs the claim/deliver/mark state machine on its own (task, kind, uid) row,
+	// so one recipient's failure never blocks another's.
+	var targets []deliveryTarget
+	if kind == model.NotifyKindFailed {
+		if t, ok := n.creatorTarget(task); ok {
+			targets = []deliveryTarget{t}
+		}
+	} else {
+		// A participant-lookup error must NOT degrade to a creator-only "success":
+		// that would fake-deliver to the creator, never build participant rows,
+		// and hide the miss from the sweep. Skip this run and let the next
+		// OnTaskTerminal trigger / sweep retry a full resolve.
+		resolved, err := n.resolveTargets(task)
+		if err != nil {
+			log.Printf("[notify] task=%d kind=%s: resolveTargets failed, skipping (will retry on next trigger/sweep): %v", task.ID, kind, err)
+			return
+		}
+		targets = resolved
+	}
+	if len(targets) == 0 {
+		log.Printf("[notify] task=%d kind=%s: no deliverable target (empty creator), skipping", task.ID, kind)
+		return
+	}
+
+	for _, target := range targets {
+		n.deliverToRecipient(task, kind, errMsg, target)
+	}
+}
+
+// deliverToRecipient runs the per-recipient claim/deliver/mark state machine for
+// a single (task, kind, recipient_uid). Extracted from OnTaskTerminal so the
+// by-person fan-out drives it once per recipient; each call is fully independent
+// (its own dedup row, retry budget, and failure handling).
+func (n *Notifier) deliverToRecipient(task model.SummaryTask, kind, errMsg string, target deliveryTarget) {
+	uid := target.TargetUID
+
+	// 1) Preemptive unique insert — claim the right to deliver this (task, kind, uid).
+	claimed, row, err := n.claim(task.ID, kind, uid)
+	if err != nil {
+		log.Printf("[notify] task=%d kind=%s uid=%s: claim failed: %v", task.ID, kind, uid, err)
+		return
+	}
+	if !claimed {
+		// First-delivery is serialized by the unique INSERT, but the retry
+		// decision must ALSO be atomic: two runners firing in the same tick
+		// (markPersonalFailed notify + scanStuckTasks reload-and-notify on the
+		// same task) would otherwise both read the same failed row, both see
+		// budget remaining, and both deliver, sending duplicate failure DMs.
+		// claimRetry does an atomic CAS UPDATE; only the runner that flips the
+		// row to pending (RowsAffected==1) proceeds, the loser skips.
+		if row != nil && row.Status == model.NotifyStatusFailed && row.AttemptCount < n.cfg.MaxAttempts {
+			won, e := n.claimRetry(task.ID, kind, uid)
+			if e != nil {
+				log.Printf("[notify] task=%d kind=%s uid=%s: claimRetry failed: %v", task.ID, kind, uid, e)
+				return
+			}
+			if !won {
+				return
+			}
+			log.Printf("[notify] task=%d kind=%s uid=%s: retrying failed row (won retry slot)", task.ID, kind, uid)
+		} else {
+			return
+		}
+	}
+
+	// 2) Build + deliver.
+	text := n.buildText(task, kind, errMsg)
+	deliverErr := n.deliver(task.ID, target, text)
+
+	// 3) Persist outcome.
+	if deliverErr == nil {
+		n.markSent(task.ID, kind, uid)
+		log.Printf("[notify] task=%d kind=%s uid=%s delivered to channel_type=%d", task.ID, kind, uid, target.ChannelType)
+		return
+	}
+	n.markFailed(task.ID, kind, uid, deliverErr)
+	log.Printf("[notify] task=%d kind=%s uid=%s delivery failed: %v", task.ID, kind, uid, sanitize(deliverErr.Error()))
+}
+
+func kindForStatus(status int) (string, bool) {
+	switch status {
+	case model.StatusCompleted:
+		return model.NotifyKindCompleted, true
+	case model.StatusFailed:
+		return model.NotifyKindFailed, true
+	default:
+		return "", false
+	}
+}
+
+// claim attempts the preemptive INSERT. Returns claimed=true when this run won
+// the (task, kind) slot. When the row already exists, claimed=false and the
+// existing row is returned so the caller can decide whether retry budget remains.
+func (n *Notifier) claim(taskID int64, kind, uid string) (bool, *model.SummaryNotification, error) {
+	now := n.now()
+	row := &model.SummaryNotification{
+		TaskID:       taskID,
+		NotifyKind:   kind,
+		RecipientUID: uid,
+		Status:       model.NotifyStatusPending,
+		AttemptCount: 0,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	// Plain Create: the UNIQUE(task_id, notify_kind, recipient_uid) constraint
+	// rejects a duplicate with an error we treat as "this recipient is owned".
+	err := n.db.Create(row).Error
+	if err == nil {
+		return true, row, nil
+	}
+	if isDuplicateKey(err) {
+		var existing model.SummaryNotification
+		if e := n.db.Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).First(&existing).Error; e != nil {
+			return false, nil, e
+		}
+		return false, &existing, nil
+	}
+	return false, nil, err
+}
+
+// claimRetry atomically reclaims a failed (task, kind) row for one more
+// delivery attempt. It flips status failed->pending in a single conditional
+// UPDATE guarded on status=failed AND attempt_count<MaxAttempts, so concurrent
+// runners race on the row and exactly one gets RowsAffected==1. Returns
+// won=true only for that single winner; losers skip to avoid duplicate sends.
+func (n *Notifier) claimRetry(taskID int64, kind, uid string) (bool, error) {
+	now := n.now()
+	res := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ? AND status = ? AND attempt_count < ?",
+			taskID, kind, uid, model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Updates(map[string]any{
+			"status":     model.NotifyStatusPending,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
+func (n *Notifier) deliver(taskID int64, target deliveryTarget, text string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Light guard against the silent-success trap: for a system-bot DM, if the
+	// recipient is NOT an active member of this Space, octo-server strips space_id
+	// but still returns 200 — the message is then dropped and the user silently
+	// gets nothing while we would mark it "sent". Detect provable non-membership
+	// here and fail the delivery explicitly instead. (nil imDB / query error =>
+	// allowed; server still enforces.)
+	if target.TargetUID != "" && target.SpaceID != "" &&
+		!n.recipientIsActiveMember(uint(taskID), target.SpaceID, target.TargetUID) {
+		return fmt.Errorf("recipient %s is not an active member of space %s; "+
+			"server would strip space_id and drop the notification", target.TargetUID, target.SpaceID)
+	}
+
+	// DM 可达前置：先 ensureFriend（幂等，带 space_id 供 server 拼 s{spaceID}_{uid}
+	// 白名单 channel），再 sendMessage.
+	if target.TargetUID != "" {
+		if err := n.deliverer.EnsureFriend(ctx, target.SpaceID, target.TargetUID); err != nil {
+			return fmt.Errorf("ensureFriend: %w", err)
+		}
+	}
+	// octo-server identifies a plain-text bot message by its ContentType enum
+	// (type=1=Text) carrying the body in "content"; a bare {"text":...} payload is
+	// not recognized and renders as an empty/unopenable message. Send the
+	// server-recognized shape instead.
+	//
+	// summary is registered as a system bot, so its messages must carry space_id:
+	// octo-server's filterPersonMessagesBySpace drops a system-bot message whose
+	// payload has an empty space_id (it would otherwise be unopenable in the UI).
+	// Include space_id only when known, to hit the "exact match keep" branch and
+	// avoid regressing the empty-SpaceID case.
+	payload := map[string]any{"type": 1, "content": text}
+	if target.SpaceID != "" {
+		payload["space_id"] = target.SpaceID
+	}
+	msg := SendMessageRequest{
+		ChannelID:   target.ChannelID,
+		ChannelType: target.ChannelType,
+		Payload:     payload,
+	}
+	if err := n.deliverer.SendMessage(ctx, target.SpaceID, msg); err != nil {
+		return fmt.Errorf("sendMessage: %w", err)
+	}
+	return nil
+}
+
+// recipientIsActiveMember reports whether uid is an active member (status=1) of
+// an active Space (status=1), mirroring octo-server's space.CheckMembership.
+//
+// Why this matters: for a system-bot DM, octo-server only adopts the X-Space-ID
+// header (and thus injects the authoritative payload.space_id) when the
+// RECIPIENT is an active member of that Space. If they are not, the server
+// STRIPS space_id yet still returns 200 — the message is then dropped by
+// filterPersonMessagesBySpace and the user silently never sees it, while the
+// worker would otherwise record it as "sent". Pre-checking here turns that
+// silent loss into an explicit delivery failure (retried/visible), instead of a
+// false success.
+//
+// Conservative failure mode: on a nil imDB or a query error we return true
+// (do NOT block delivery) — the server-side CheckMembership still guards
+// correctness; this pre-check only exists to avoid the silent-success trap when
+// we can cheaply prove non-membership.
+func (n *Notifier) recipientIsActiveMember(taskID uint, spaceID, uid string) bool {
+	if n == nil || n.imDB == nil {
+		return true // cannot check → don't block; server still enforces.
+	}
+	spaceID = strings.TrimSpace(spaceID)
+	uid = strings.TrimSpace(uid)
+	if spaceID == "" || uid == "" {
+		return true // nothing to check against; leave existing behavior.
+	}
+	var count int
+	err := n.imDB.Raw(
+		"SELECT COUNT(*) FROM space_member sm "+
+			"INNER JOIN space s ON s.space_id = sm.space_id AND s.status = 1 "+
+			"WHERE sm.uid = ? AND sm.space_id = ? AND sm.status = 1",
+		uid, spaceID,
+	).Scan(&count).Error
+	if err != nil {
+		log.Printf("[notify] task=%d: recipientIsActiveMember(space=%s,uid=%s) query failed: %v; allowing delivery", taskID, spaceID, uid, err)
+		return true // fail-open: don't turn a transient DB error into a drop.
+	}
+	return count > 0
+}
+
+func (n *Notifier) markSent(taskID int64, kind, uid string) {
+	now := n.now()
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).
+		Updates(map[string]any{
+			"status":        model.NotifyStatusSent,
+			"sent_at":       now,
+			"updated_at":    now,
+			"attempt_count": gorm.Expr("attempt_count + 1"),
+			"last_error":    nil,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s uid=%s: markSent failed: %v", taskID, kind, uid, err)
+	}
+}
+
+func (n *Notifier) markFailed(taskID int64, kind, uid string, cause error) {
+	now := n.now()
+	le := truncateForLastError(sanitize(cause.Error()))
+	if err := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ?", taskID, kind, uid).
+		Updates(map[string]any{
+			"status":        model.NotifyStatusFailed,
+			"updated_at":    now,
+			"attempt_count": gorm.Expr("attempt_count + 1"),
+			"last_error":    le,
+		}).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s uid=%s: markFailed failed: %v", taskID, kind, uid, err)
+	}
+}
+
+// markDeferred removed with the bot-token startup-race path: internal-notify
+// authenticates with a static X-Internal-Token, so there is no
+// "token not yet provisioned" state. All delivery errors are real failures and
+// go through markFailed (attempt+last_error, bounded by MaxAttempts + sweep).
+
+// buildText composes the user-facing notification body. Success carries the
+// result link (when a base URL is configured); failure carries the sanitized
+// error message.
+func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string {
+	title := strings.TrimSpace(task.Title)
+	space := n.resolveSpaceName(task)
+	switch kind {
+	case model.NotifyKindCompleted:
+		var b strings.Builder
+		switch {
+		case space != "" && title != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结「%s」已生成完成。", space, title)
+		case space != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结已生成完成。", space)
+		case title != "":
+			fmt.Fprintf(&b, "你的总结「%s」已生成完成。", title)
+		default:
+			b.WriteString("你的总结已生成完成。")
+		}
+		// 追加有用的元信息（全部 best-effort，查不到/为零的行直接跳过，绝不阻断通知）：
+		// - 时间范围：本次总结覆盖的聊天区间；
+		// - 参与成员：多人任务的成员数（单人任务无意义，省略）；
+		// - 消息数量：本次总结处理的消息条数；
+		// - 生成时间：结果产出的本地时间。
+		// 之前这里追加的是「查看结果：<link>」外链，但该链接与前端真实入口
+		// （WKApp 内部路由 /summary/detail?taskId=）三重错位、根本打不开，已移除。
+		if tr := formatTimeRange(task); tr != "" {
+			fmt.Fprintf(&b, "\n时间范围：%s", tr)
+		}
+		meta := n.resultMeta(task)
+		if cnt := n.participantCount(task); cnt > 0 {
+			fmt.Fprintf(&b, "\n参与成员：%d 人", cnt)
+		}
+		if meta.msgCount > 0 {
+			fmt.Fprintf(&b, "\n消息数量：%d 条", meta.msgCount)
+		}
+		if !meta.generatedAt.IsZero() {
+			fmt.Fprintf(&b, "\n生成时间：%s", timezone.In(meta.generatedAt).Format("2006-01-02 15:04"))
+		}
+		return b.String()
+	case model.NotifyKindFailed:
+		var b strings.Builder
+		switch {
+		case space != "" && title != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结「%s」生成失败。", space, title)
+		case space != "":
+			fmt.Fprintf(&b, "你在空间「%s」的总结生成失败。", space)
+		case title != "":
+			fmt.Fprintf(&b, "你的总结「%s」生成失败。", title)
+		default:
+			b.WriteString("你的总结生成失败。")
+		}
+		// Single render-point sanitization: every failure reason — whether arriving
+		// via the synchronous worker path (OnTaskTerminal) or the sweep/redeliver
+		// path that reloads task.ErrorMessage raw from DB — is scrubbed here before
+		// it can reach the user DM. See WithErrorSanitizer / PR#113 R3.
+		if reason := strings.TrimSpace(errMsg); reason != "" {
+			safe := reason
+			if n.errorSanitizer != nil {
+				safe = n.errorSanitizer(reason)
+			} else {
+				// Defensive: never leak raw internals if no sanitizer wired.
+				safe = "AI 处理失败，请稍后重试"
+			}
+			fmt.Fprintf(&b, "\n失败原因：%s", safe)
+		}
+		return b.String()
+	default:
+		return ""
+	}
+}
+
+// resolveSpaceName looks up the human-readable space name for the task's
+// SpaceID from the shared IM DB (read-only). It is best-effort and degrades
+// gracefully: a nil imDB, empty SpaceID, query error, or no row all yield ""
+// so buildText falls back to the space-less wording. It never panics and never
+// blocks delivery — any error is swallowed (logged only).
+func (n *Notifier) resolveSpaceName(task model.SummaryTask) string {
+	if n == nil || n.imDB == nil {
+		return ""
+	}
+	spaceID := strings.TrimSpace(task.SpaceID)
+	if spaceID == "" {
+		return ""
+	}
+	var name string
+	if err := n.imDB.Raw("SELECT name FROM space WHERE space_id = ? LIMIT 1", spaceID).Scan(&name).Error; err != nil {
+		log.Printf("[notify] task=%d: resolveSpaceName(space_id=%s) failed: %v", task.ID, spaceID, err)
+		return ""
+	}
+	return strings.TrimSpace(name)
+}
+
+// resultLink builds the result URL from the configured base. Empty base → no link.
+// notifyResultMeta carries the best-effort metadata pulled from summary_result
+// for a completed task's notification text. Zero values mean "unknown / omit".
+type notifyResultMeta struct {
+	generatedAt time.Time
+	msgCount    int
+}
+
+// resultMeta best-effort loads the completed task's summary_result row for the
+// generation time + processed message count shown in the success notification.
+// It degrades gracefully: nil db, query error, or no row all yield the zero
+// value so buildText simply omits those lines. Never panics, never blocks.
+func (n *Notifier) resultMeta(task model.SummaryTask) notifyResultMeta {
+	if n == nil || n.db == nil {
+		return notifyResultMeta{}
+	}
+	var row struct {
+		GeneratedAt   time.Time
+		TotalMsgCount int
+	}
+	// Latest version wins if a result was regenerated. Read-only single row.
+	if err := n.db.Raw(
+		"SELECT generated_at, total_msg_count FROM summary_result WHERE task_id = ? ORDER BY version DESC, id DESC LIMIT 1",
+		task.ID,
+	).Scan(&row).Error; err != nil {
+		log.Printf("[notify] task=%d: resultMeta query failed: %v", task.ID, err)
+		return notifyResultMeta{}
+	}
+	return notifyResultMeta{generatedAt: row.GeneratedAt, msgCount: row.TotalMsgCount}
+}
+
+// participantCount best-effort counts the participants of a by-person task for
+// the "参与成员：N 人" line. Returns 0 (line omitted) for single-person tasks,
+// nil db, or a query error. Read-only; never panics, never blocks.
+func (n *Notifier) participantCount(task model.SummaryTask) int {
+	if n == nil || n.db == nil {
+		return 0
+	}
+	var cnt int64
+	if err := n.db.Raw(
+		"SELECT COUNT(*) FROM summary_participant WHERE task_id = ?",
+		task.ID,
+	).Scan(&cnt).Error; err != nil {
+		log.Printf("[notify] task=%d: participantCount query failed: %v", task.ID, err)
+		return 0
+	}
+	return int(cnt)
+}
+
+// formatTimeRange renders the chat window a summary covers as
+// "YYYY-MM-DD HH:MM ~ YYYY-MM-DD HH:MM" in the local timezone. Returns "" when
+// either bound is zero so buildText omits the line.
+func formatTimeRange(task model.SummaryTask) string {
+	if task.TimeRangeStart.IsZero() || task.TimeRangeEnd.IsZero() {
+		return ""
+	}
+	start := timezone.In(task.TimeRangeStart).Format("2006-01-02 15:04")
+	end := timezone.In(task.TimeRangeEnd).Format("2006-01-02 15:04")
+	return start + " ~ " + end
+}
+
+// SweepInterval is the recommended cron cadence for Notifier.Sweep. Exposed
+// so callers (cmd/summary-worker) don't have to pick a magic interval.
+const SweepInterval = 60 * time.Second
+
+// PendingLease is how long a 'pending' row may sit without progress before
+// Sweep reclaims it. The worker's synchronous delivery path uses a 15s HTTP
+// timeout (see deliver), so anything over ~1 min must mean the worker crashed
+// between claim and markSent/markFailed, OR markFailed itself failed (e.g.
+// the byte-truncation utf8 wedge that truncateForLastError now prevents — kept
+// as belt-and-suspenders for any other write error).
+const PendingLease = 5 * time.Minute
+
+// sweepBatchSize caps how many candidate rows Sweep handles per tick so a
+// degraded octo-server cannot pile up a single sweep beyond the cron cadence.
+const sweepBatchSize = 50
+
+// Sweep is the background recovery pass invoked by the scheduler cron. It
+// looks for two classes of rows that the synchronous worker path cannot
+// recover on its own:
+//
+//   - status='failed' AND attempt_count<MaxAttempts: a transient delivery
+//     blip dropped the message; retry budget remains but no fresh
+//     OnTaskTerminal hook will fire on its own (terminal callbacks are
+//     one-shot per task transition). Without this sweep, MaxAttempts is
+//     effectively 1 for the common path.
+//   - status='pending' AND updated_at<now-PendingLease: a worker crashed (or
+//     a write failed) between claim and the markSent/markFailed write.
+//     Without this sweep the row would sit at 'pending' forever and the
+//     dedup claim would keep skipping the (task, kind) pair.
+//
+// Both branches use the existing atomic CAS (claimRetry / claimPending) so a
+// concurrent OnTaskTerminal cannot double-send: only the runner whose UPDATE
+// flips the row to pending (RowsAffected==1) proceeds.
+//
+// Sweep is best-effort: any per-row error is logged and the loop continues.
+// It is safe to call when the notifier is disabled (returns immediately).
+func (n *Notifier) Sweep(ctx context.Context) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+	n.sweepRetryFailed(ctx)
+	n.sweepStalePending(ctx)
+}
+
+// sweepRetryFailed re-attempts delivery for rows stuck at status='failed'
+// with retry budget remaining.
+func (n *Notifier) sweepRetryFailed(ctx context.Context) {
+	var rows []model.SummaryNotification
+	if err := n.db.
+		Where("status = ? AND attempt_count < ?", model.NotifyStatusFailed, n.cfg.MaxAttempts).
+		Order("updated_at ASC").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		log.Printf("[notify] sweep: query failed rows: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		won, err := n.claimRetry(row.TaskID, row.NotifyKind, row.RecipientUID)
+		if err != nil {
+			log.Printf("[notify] sweep: task=%d kind=%s uid=%s claimRetry: %v", row.TaskID, row.NotifyKind, row.RecipientUID, err)
+			continue
+		}
+		if !won {
+			continue // another runner won, or budget exhausted concurrently
+		}
+		n.redeliver(row.TaskID, row.NotifyKind, row.RecipientUID)
+	}
+}
+
+// sweepStalePending reclaims rows stuck at status='pending' past the lease
+// (worker died or a write step failed between claim and markSent/markFailed).
+func (n *Notifier) sweepStalePending(ctx context.Context) {
+	cutoff := n.now().Add(-PendingLease)
+	var rows []model.SummaryNotification
+	if err := n.db.
+		Where("status = ? AND updated_at < ? AND attempt_count < ?",
+			model.NotifyStatusPending, cutoff, n.cfg.MaxAttempts).
+		Order("updated_at ASC").
+		Limit(sweepBatchSize).
+		Find(&rows).Error; err != nil {
+		log.Printf("[notify] sweep: query pending rows: %v", err)
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		won, err := n.claimStalePending(row.TaskID, row.NotifyKind, row.RecipientUID, cutoff)
+		if err != nil {
+			log.Printf("[notify] sweep: task=%d kind=%s uid=%s claimStalePending: %v", row.TaskID, row.NotifyKind, row.RecipientUID, err)
+			continue
+		}
+		if !won {
+			continue
+		}
+		log.Printf("[notify] sweep: reclaimed stale pending row task=%d kind=%s uid=%s", row.TaskID, row.NotifyKind, row.RecipientUID)
+		n.redeliver(row.TaskID, row.NotifyKind, row.RecipientUID)
+	}
+}
+
+// claimStalePending atomically refreshes a stale 'pending' row's updated_at
+// so exactly one sweeper wins the right to redeliver it. Guarded on
+// status='pending' AND updated_at<cutoff so concurrent sweepers race and only
+// the row flipped by RowsAffected==1 proceeds.
+func (n *Notifier) claimStalePending(taskID int64, kind, uid string, cutoff time.Time) (bool, error) {
+	now := n.now()
+	res := n.db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND recipient_uid = ? AND status = ? AND updated_at < ?",
+			taskID, kind, uid, model.NotifyStatusPending, cutoff).
+		Update("updated_at", now)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// redeliver performs one delivery attempt for a row whose retry slot we just
+// won (claimRetry or claimStalePending). It reloads the SummaryTask so the
+// message reflects the durable terminal-state row, then rebuilds the target for
+// THIS recipient_uid (not blindly the creator) and mirrors the
+// build+deliver+persist sequence from OnTaskTerminal. Any failure persists
+// via markFailed and is left for the next sweep tick or until budget runs out.
+func (n *Notifier) redeliver(taskID int64, kind, uid string) {
+	var task model.SummaryTask
+	if err := n.db.First(&task, taskID).Error; err != nil {
+		// Task row gone (extremely unusual: rows are never deleted in the
+		// happy path). Treat as a permanent delivery failure so attempt_count
+		// advances and the row eventually leaves the retry set.
+		n.markFailed(taskID, kind, uid, fmt.Errorf("reload task %d: %w", taskID, err))
+		return
+	}
+	target, ok := targetForUID(task, uid)
+	if !ok {
+		n.markFailed(taskID, kind, uid, errors.New("no deliverable target on reload"))
+		return
+	}
+	errMsg := ""
+	if task.ErrorMessage != nil {
+		errMsg = *task.ErrorMessage
+	}
+	text := n.buildText(task, kind, errMsg)
+	if deliverErr := n.deliver(taskID, target, text); deliverErr != nil {
+		n.markFailed(taskID, kind, uid, deliverErr)
+		log.Printf("[notify] sweep: task=%d kind=%s uid=%s delivery failed: %v", taskID, kind, uid, sanitize(deliverErr.Error()))
+		return
+	}
+	n.markSent(taskID, kind, uid)
+	log.Printf("[notify] sweep: task=%d kind=%s uid=%s delivered via retry", taskID, kind, uid)
+}
+
+// truncateForLastError caps an error string for the VARCHAR(500) last_error
+// column. It enforces both a byte cap (≤480 bytes, leaving utf8mb4 headroom)
+// AND a rune boundary so a multi-byte codepoint is never sliced through the
+// middle — MySQL strict mode rejects invalid UTF-8 with Error 1366, which
+// would leave the notification row stuck in 'pending' (no sweep / no retry).
+func truncateForLastError(s string) string {
+	const maxBytes = 480
+	if len(s) <= maxBytes {
+		return s
+	}
+	s = s[:maxBytes]
+	// Back off until the tail is a valid UTF-8 sequence. utf8.ValidString runs
+	// over the whole string, but the only way a prefix becomes invalid is a
+	// truncated trailing rune (at most 3 bytes for utf8mb4-safe runes), so this
+	// loop terminates in ≤3 iterations.
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// sanitize strips any accidental Bearer token / Authorization material from an
+// error string before it is persisted to last_error or logged. Defense in
+// depth: the deliverer already keeps the token out of errors. It scans forward
+// and advances past each rewritten marker so the inserted "Bearer [REDACTED]"
+// is never re-matched (which would loop forever).
+func sanitize(s string) string {
+	const marker = "bearer "
+	const redacted = "Bearer [REDACTED]"
+	var b strings.Builder
+	lower := strings.ToLower(s)
+	for {
+		idx := strings.Index(lower, marker)
+		if idx < 0 {
+			b.WriteString(s)
+			break
+		}
+		b.WriteString(s[:idx])
+		b.WriteString(redacted)
+		rest := s[idx+len(marker):]
+		end := strings.IndexAny(rest, " \n\t")
+		if end < 0 {
+			// Token runs to end of string; drop it entirely.
+			break
+		}
+		// Keep the delimiter and everything after; continue scanning the tail.
+		s = rest[end:]
+		lower = strings.ToLower(s)
+	}
+	return b.String()
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,1604 @@
+//go:build cgo
+
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupNotifyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.SummaryNotification{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+// ensureCall records one EnsureFriend invocation.
+type ensureCall struct {
+	SpaceID string
+	UID     string
+}
+
+// fakeDeliverer records calls and can be told to fail.
+type fakeDeliverer struct {
+	mu          sync.Mutex
+	ensureCalls []ensureCall
+	sendCalls   []SendMessageRequest
+	sendSpaceID []string // spaceID passed to each SendMessage (parallel to sendCalls)
+	failEnsure  error
+	failSend    error
+	sendErrOnce error // returned once then cleared (for retry tests)
+}
+
+func (f *fakeDeliverer) EnsureFriend(ctx context.Context, spaceID, uid string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureCalls = append(f.ensureCalls, ensureCall{SpaceID: spaceID, UID: uid})
+	return f.failEnsure
+}
+
+func (f *fakeDeliverer) SendMessage(ctx context.Context, spaceID string, msg SendMessageRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, msg)
+	f.sendSpaceID = append(f.sendSpaceID, spaceID)
+	if f.sendErrOnce != nil {
+		e := f.sendErrOnce
+		f.sendErrOnce = nil
+		return e
+	}
+	return f.failSend
+}
+
+func baseTask(id int64, trigger int) model.SummaryTask {
+	return model.SummaryTask{
+		ID:                id,
+		TaskNo:            "TST-1",
+		Title:             "今日群聊",
+		SpaceID:           "space-9",
+		CreatorID:         "user-1",
+		TriggerType:       trigger,
+		OriginChannelType: model.OriginChannelGlobal,
+	}
+}
+
+func newTestNotifier(db *gorm.DB, d Deliverer, cfg Config) *Notifier {
+	n := New(db, nil, d, cfg)
+	// Fixed clock at 10:00 Asia/Shanghai.
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+	// Default test sanitizer is identity so existing tests can assert on the
+	// exact errMsg they pass in (e.g. "LLM timeout"). Production wires
+	// worker.SanitizeErrorForUser via WithErrorSanitizer; the dedicated R3
+	// regression tests below opt into that mapping explicitly.
+	n.errorSanitizer = func(s string) string { return s }
+	return n
+}
+
+func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	if len(d.ensureCalls) != 1 || d.ensureCalls[0].UID != "user-1" || d.ensureCalls[0].SpaceID != "space-9" {
+		t.Fatalf("expected ensureFriend(space-9, user-1), got %v", d.ensureCalls)
+	}
+	msg := d.sendCalls[0]
+	if msg.ChannelType != WireChannelDM || msg.ChannelID != "user-1" {
+		t.Fatalf("expected DM to user-1, got type=%d id=%s", msg.ChannelType, msg.ChannelID)
+	}
+	text, _ := msg.Payload["content"].(string)
+	if !strings.Contains(text, "今日群聊") {
+		t.Fatalf("completed text missing title: %q", text)
+	}
+	// The unreachable WKApp-internal result link was removed (see notify.go
+	// buildText); success notifications must NOT carry a browser URL anymore.
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") {
+		t.Fatalf("completed text must not carry a result link anymore: %q", text)
+	}
+	// octo-server recognizes a plain-text bot message by ContentType type=1 (Text)
+	// carrying "content"; a bare {"text":...} renders empty. Assert the wire shape.
+	if tp, _ := msg.Payload["type"].(int); tp != 1 {
+		t.Fatalf("expected payload type=1 (Text), got %v", msg.Payload["type"])
+	}
+	if _, ok := msg.Payload["text"]; ok {
+		t.Fatalf("payload must not carry legacy 'text' key, got %v", msg.Payload)
+	}
+	// OBO reserved fields must not be present.
+	if payloadHasOBOReserved(msg.Payload) {
+		t.Fatalf("payload leaked OBO reserved field: %v", msg.Payload)
+	}
+
+	var row model.SummaryNotification
+	db.Where("task_id = ? AND notify_kind = ?", 1, model.NotifyKindCompleted).First(&row)
+	if row.Status != model.NotifyStatusSent || row.SentAt == nil {
+		t.Fatalf("expected status=sent with sent_at, got status=%s sent_at=%v", row.Status, row.SentAt)
+	}
+}
+
+func TestOnTaskTerminal_FailedCarriesReason(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(2, model.TriggerManual), model.StatusFailed, "LLM timeout")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if !strings.Contains(text, "失败") || !strings.Contains(text, "LLM timeout") {
+		t.Fatalf("failed text missing reason: %q", text)
+	}
+}
+
+func TestOnTaskTerminal_DedupSameKindSendsOnce(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(3, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // duplicate
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // duplicate
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected exactly 1 send after 3 calls (dedup), got %d", len(d.sendCalls))
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 3).Count(&cnt)
+	if cnt != 1 {
+		t.Fatalf("expected exactly 1 notification row, got %d", cnt)
+	}
+}
+
+func TestOnTaskTerminal_CompletedAndFailedAreIndependent(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(4, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (completed + failed), got %d", len(d.sendCalls))
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 4).Count(&cnt)
+	if cnt != 2 {
+		t.Fatalf("expected 2 notification rows, got %d", cnt)
+	}
+}
+
+func TestOnTaskTerminal_CancelledNeverNotifies(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(5, model.TriggerManual), model.StatusCancelled, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("cancelled must not notify, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestOnTaskTerminal_DisabledIsNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: false})
+
+	n.OnTaskTerminal(baseTask(6, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("disabled must be no-op, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestOnTaskTerminal_FailureMarksFailedWithRetryBudget(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("network down: Bearer secret-token-123 leaked")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(7, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 7).First(&row)
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("expected status=failed, got %s", row.Status)
+	}
+	if row.AttemptCount != 1 {
+		t.Fatalf("expected attempt_count=1, got %d", row.AttemptCount)
+	}
+	if row.LastError == nil {
+		t.Fatalf("expected last_error set")
+	}
+	// SECRET must never be persisted to last_error.
+	if strings.Contains(*row.LastError, "secret-token-123") {
+		t.Fatalf("last_error leaked the bearer token: %q", *row.LastError)
+	}
+	if !strings.Contains(*row.LastError, "[REDACTED]") {
+		t.Fatalf("expected token redaction marker, got %q", *row.LastError)
+	}
+
+	// Second call has retry budget (1 < 3) and now succeeds.
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+	db.Where("task_id = ?", 7).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("expected retry to send, status=%s", row.Status)
+	}
+}
+
+func TestOnTaskTerminal_RetryBudgetExhausted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("always down")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 2})
+
+	task := baseTask(8, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 1
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 2 -> budget exhausted
+	sendsBefore := len(d.sendCalls)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // no budget -> must NOT send again
+
+	if len(d.sendCalls) != sendsBefore {
+		t.Fatalf("expected no further sends after budget exhausted; before=%d after=%d", sendsBefore, len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 8).First(&row)
+	if row.AttemptCount != 2 {
+		t.Fatalf("expected attempt_count capped at 2, got %d", row.AttemptCount)
+	}
+}
+
+// TestScheduledAndManual_BothDeliverImmediately confirms the quiet window was
+// removed (一期不做): scheduled and manual terminal notifications are both
+// delivered immediately, regardless of time of day.
+func TestScheduledAndManual_BothDeliverImmediately(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	n.OnTaskTerminal(baseTask(9, model.TriggerScheduled), model.StatusCompleted, "")
+	n.OnTaskTerminal(baseTask(10, model.TriggerManual), model.StatusCompleted, "")
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("scheduled + manual must both deliver immediately, got %d sends", len(d.sendCalls))
+	}
+}
+
+func TestResolveTarget_DMFallbackForAllOrigins(t *testing.T) {
+	n := newTestNotifier(setupNotifyTestDB(t), &fakeDeliverer{}, Config{Enabled: true})
+	origins := []int{model.OriginChannelGlobal, model.OriginChannelDM, model.OriginChannelGroup, model.OriginChannelThread}
+	for _, o := range origins {
+		task := baseTask(1, model.TriggerManual)
+		task.OriginChannelType = o
+		task.OriginChannelID = "origin-chan"
+		tgt, ok := n.creatorTarget(task)
+		if !ok {
+			t.Fatalf("origin %d: expected resolvable target", o)
+		}
+		if tgt.ChannelType != WireChannelDM || tgt.ChannelID != "user-1" || tgt.TargetUID != "user-1" {
+			t.Fatalf("origin %d: expected creator DM fallback, got %+v", o, tgt)
+		}
+	}
+}
+
+func TestResolveTarget_EmptyCreatorUnresolvable(t *testing.T) {
+	n := newTestNotifier(setupNotifyTestDB(t), &fakeDeliverer{}, Config{Enabled: true})
+	task := baseTask(1, model.TriggerManual)
+	task.CreatorID = ""
+	if _, ok := n.creatorTarget(task); ok {
+		t.Fatalf("empty creator must be unresolvable")
+	}
+	// resolveTargets for a non-by-person task with empty creator yields no target.
+	if tgts, err := n.resolveTargets(task); err != nil || len(tgts) != 0 {
+		t.Fatalf("empty creator non-by-person must yield no targets/no err, got %d err=%v", len(tgts), err)
+	}
+}
+
+func TestPayloadHasOBOReserved(t *testing.T) {
+	if !payloadHasOBOReserved(map[string]any{"__obo_uid": "x"}) {
+		t.Errorf("expected __obo_ prefix detected")
+	}
+	if !payloadHasOBOReserved(map[string]any{"obo_sender": "x"}) {
+		t.Errorf("expected obo_ prefix detected")
+	}
+	if !payloadHasOBOReserved(map[string]any{"actual_sender_uid": "x"}) {
+		t.Errorf("expected actual_sender_uid detected")
+	}
+	if payloadHasOBOReserved(map[string]any{"text": "hello"}) {
+		t.Errorf("clean payload flagged as OBO")
+	}
+}
+
+// --- B2 (PR#113 review P1-2) ---
+
+func TestMarkFailed_TruncatesAtRuneBoundary_NoUTF8Wedge(t *testing.T) {
+	// Reviewer P1-2: byte-wise truncation of a CJK error string could sever a
+	// multi-byte rune; under MySQL strict mode the resulting invalid UTF-8
+	// rejects the UPDATE and the row stays at 'pending' forever.
+	// truncateForLastError must produce a valid UTF-8 string and the row must
+	// reach 'failed'.
+	db := setupNotifyTestDB(t)
+	// Long CJK error message: 300 三-byte runes = 900 bytes, well past the
+	// 480-byte cap so the byte cut would almost certainly land mid-rune.
+	longCJK := strings.Repeat("中", 300)
+	d := &fakeDeliverer{failSend: errors.New("octo-server boom: " + longCJK)}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	n.OnTaskTerminal(baseTask(101, model.TriggerManual), model.StatusFailed, "x")
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 101).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("expected status=failed (markFailed must not wedge at pending), got %s", row.Status)
+	}
+	if row.LastError == nil {
+		t.Fatalf("expected last_error to be set")
+	}
+	le := *row.LastError
+	if !utf8.ValidString(le) {
+		t.Fatalf("last_error must be valid UTF-8 after truncation, got bytes=%q", []byte(le))
+	}
+	if len(le) > 480 {
+		t.Fatalf("last_error must be ≤480 bytes for VARCHAR(500) utf8mb4 headroom, got %d", len(le))
+	}
+	// Must still carry the original prefix so operators can diagnose.
+	// The deliver layer wraps with "sendMessage: "; the prefix must still
+	// contain the original error head so operators can diagnose.
+	if !strings.Contains(le, "octo-server boom:") {
+		t.Fatalf("expected truncated message to keep diagnostic prefix, got %q", le)
+	}
+}
+
+func TestTruncateForLastError_ShortInputUnchanged(t *testing.T) {
+	in := "short ascii error"
+	if got := truncateForLastError(in); got != in {
+		t.Fatalf("short input must pass through, got %q", got)
+	}
+	cjk := "失败：LLM 超时"
+	if got := truncateForLastError(cjk); got != cjk {
+		t.Fatalf("short CJK input must pass through, got %q", got)
+	}
+}
+
+func TestTruncateForLastError_NeverSplitsRune(t *testing.T) {
+	// Build a string whose byte length crosses the 480 cap exactly inside a
+	// multi-byte rune so a naive [:480] slice would produce invalid UTF-8.
+	// 中 is 3 bytes; placing 160 of them gives 480 bytes (boundary-aligned),
+	// then a 4-byte rune (𠮷, U+20BB7) starting at byte 480 ensures the cut
+	// would land mid-rune for any cap inside that rune. We assert validity for
+	// a sweep of caps around the boundary by repeatedly building inputs that
+	// straddle.
+	inputs := []string{
+		strings.Repeat("中", 160) + "𠮷" + strings.Repeat("a", 100),
+		strings.Repeat("a", 479) + "𠮷xx",
+		strings.Repeat("a", 478) + "中" + strings.Repeat("b", 100),
+		strings.Repeat("a", 477) + "中" + strings.Repeat("b", 100),
+	}
+	for i, in := range inputs {
+		out := truncateForLastError(in)
+		if !utf8.ValidString(out) {
+			t.Errorf("case %d: output not valid UTF-8: %q", i, out)
+		}
+		if len(out) > 480 {
+			t.Errorf("case %d: output too long: %d bytes", i, len(out))
+		}
+	}
+}
+
+// --- B1 (PR#113 review P1-1) — background sweep ---
+
+func TestSweep_RetriesFailedRowWithBudget(t *testing.T) {
+	// Simulates the common case: first OnTaskTerminal sees a transient HTTP
+	// failure and leaves the row at status='failed', attempt_count=1. No
+	// further OnTaskTerminal will fire (terminal callbacks are one-shot per
+	// task transition). Sweep must redeliver and reach status='sent'.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(201, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x")
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 201).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("precondition: expected failed after first attempt, got %s", row.Status)
+	}
+
+	// Persist the original task so redeliver can reload it.
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	db.Where("task_id = ?", 201).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("sweep must redeliver and mark sent, got status=%s attempts=%d", row.Status, row.AttemptCount)
+	}
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 send calls (1 initial fail + 1 sweep retry), got %d", len(d.sendCalls))
+	}
+}
+
+func TestSweep_DoesNotRetryWhenBudgetExhausted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{failSend: errors.New("always down")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 2})
+
+	task := baseTask(202, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // attempt 1
+	n.Sweep(context.Background())                   // attempt 2 -> exhausted
+	sendsBefore := len(d.sendCalls)
+	n.Sweep(context.Background()) // must not retry
+
+	if len(d.sendCalls) != sendsBefore {
+		t.Fatalf("expected no further sends; before=%d after=%d", sendsBefore, len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 202).First(&row)
+	if row.AttemptCount != 2 {
+		t.Fatalf("attempt_count must cap at MaxAttempts=2, got %d", row.AttemptCount)
+	}
+}
+
+func TestSweep_ReclaimsStalePendingRow(t *testing.T) {
+	// Simulates a worker crash between claim() and markSent/markFailed: the
+	// row is left at status='pending' and would normally be skipped by every
+	// future OnTaskTerminal (dedup) forever. Sweep must reclaim it past the
+	// lease and redeliver.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(203, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// Inject a stale pending row directly: updated_at well past the lease.
+	stale := n.now().Add(-2 * PendingLease)
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:       203,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "user-1",
+		Status:       model.NotifyStatusPending,
+		CreatedAt:    stale,
+		UpdatedAt:    stale,
+	}).Error; err != nil {
+		t.Fatalf("seed stale pending: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 203).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("sweep must redeliver stale pending row, got status=%s", row.Status)
+	}
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected exactly 1 send on reclaim, got %d", len(d.sendCalls))
+	}
+}
+
+func TestSweep_DoesNotReclaimFreshPendingRow(t *testing.T) {
+	// A fresh pending row (worker still trying) must not be stolen by Sweep.
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(204, model.TriggerManual)
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	fresh := n.now() // just claimed
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:       204,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "user-1",
+		Status:       model.NotifyStatusPending,
+		CreatedAt:    fresh,
+		UpdatedAt:    fresh,
+	}).Error; err != nil {
+		t.Fatalf("seed fresh pending: %v", err)
+	}
+
+	n.Sweep(context.Background())
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("fresh pending row must not be reclaimed, got %d sends", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	db.Where("task_id = ?", 204).First(&row)
+	if row.Status != model.NotifyStatusPending {
+		t.Fatalf("expected status=pending preserved, got %s", row.Status)
+	}
+}
+
+func TestSweep_DisabledIsNoop(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: false})
+	n.Sweep(context.Background()) // must not panic / not query
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("disabled notifier sweep must be no-op")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// InternalNotifyDeliverer tests (发送层：octo-server /v1/internal/notify)
+//
+// 验证：POST 到 /v1/internal/notify、带 X-Internal-Token 头、body 字段
+// (space_id/service/targets 单 uid/actor_uid 空/payload.message)、非 2xx 返 error、
+// EnsureFriend no-op。
+// ---------------------------------------------------------------------------
+
+// TestInternalNotifyDeliverer_PostsToInternalNotify asserts the request path,
+// X-Internal-Token header, and NotifyReq body shape for a single recipient.
+// Payload must be forwarded verbatim (IM-recognized {type:1, content}), NOT
+// reshaped into {message_key,message,...} which would render an empty message.
+func TestInternalNotifyDeliverer_PostsToInternalNotify(t *testing.T) {
+	var gotPath, gotToken, gotCT string
+	var gotBody notifyReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotToken = r.Header.Get("X-Internal-Token")
+		gotCT = r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(notifyResp{Delivered: []string{"u1"}})
+	}))
+	defer srv.Close()
+
+	d := NewInternalNotifyDeliverer(srv.URL, "secret-int-token", "https://web.example.com")
+	msg := SendMessageRequest{
+		ChannelID:   "u1",
+		ChannelType: WireChannelDM,
+		Payload:     map[string]any{"type": 1, "content": "你的总结已生成完成。", "space_id": "space-9"},
+	}
+	if err := d.SendMessage(context.Background(), "space-9", msg); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	if gotPath != "/v1/internal/notify" {
+		t.Fatalf("expected path /v1/internal/notify, got %q", gotPath)
+	}
+	if gotToken != "secret-int-token" {
+		t.Fatalf("expected X-Internal-Token header, got %q", gotToken)
+	}
+	if gotCT != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", gotCT)
+	}
+	if gotBody.SpaceID != "space-9" {
+		t.Fatalf("expected body.space_id=space-9, got %q", gotBody.SpaceID)
+	}
+	if gotBody.Service != "summary-service" {
+		t.Fatalf("expected body.service=summary-service, got %q", gotBody.Service)
+	}
+	// State machine drives one recipient per call: targets must be a single uid.
+	if len(gotBody.Targets) != 1 || gotBody.Targets[0] != "u1" {
+		t.Fatalf("expected targets=[u1] (single-recipient granularity), got %v", gotBody.Targets)
+	}
+	if gotBody.ActorUID != "" {
+		t.Fatalf("expected empty actor_uid, got %q", gotBody.ActorUID)
+	}
+	// Payload forwarded verbatim: the IM-recognized {type:1, content} shape.
+	if tp, _ := gotBody.Payload["type"].(float64); tp != 1 { // JSON numbers decode as float64
+		t.Fatalf("expected payload.type=1 forwarded verbatim, got %v", gotBody.Payload["type"])
+	}
+	if c, _ := gotBody.Payload["content"].(string); c != "你的总结已生成完成。" {
+		t.Fatalf("expected payload.content forwarded verbatim, got %v", gotBody.Payload["content"])
+	}
+	if _, ok := gotBody.Payload["message"]; ok {
+		t.Fatalf("payload must NOT be reshaped into {message:...}, got %v", gotBody.Payload)
+	}
+	if ru, _ := gotBody.Payload["result_url"].(string); ru != "https://web.example.com" {
+		t.Fatalf("expected payload.result_url from web base, got %v", gotBody.Payload["result_url"])
+	}
+}
+
+// TestInternalNotifyDeliverer_FilteredRecipientReturnsError covers M1: the
+// server returns 200 even when the recipient is filtered out (non-member), with
+// an empty Delivered list. That is a silent drop — SendMessage must turn it into
+// an error so the state machine retries instead of marking sent.
+func TestInternalNotifyDeliverer_FilteredRecipientReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(notifyResp{
+			Delivered: []string{},
+			Filtered:  map[string]string{"u1": "not_a_member"},
+		})
+	}))
+	defer srv.Close()
+
+	d := NewInternalNotifyDeliverer(srv.URL, "tok", "")
+	err := d.SendMessage(context.Background(), "space-9",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM, Payload: map[string]any{"type": 1, "content": "x"}})
+	if err == nil {
+		t.Fatalf("filtered recipient (200 + empty delivered) must return error, not silent success")
+	}
+	if !strings.Contains(err.Error(), "not_a_member") {
+		t.Fatalf("expected filtered reason in error, got %v", err)
+	}
+}
+
+// TestInternalNotifyDeliverer_EmptyDeliveredReturnsError: 200 with empty
+// delivered and no filtered entry for the uid is still a drop → error.
+func TestInternalNotifyDeliverer_EmptyDeliveredReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(notifyResp{Delivered: []string{}})
+	}))
+	defer srv.Close()
+
+	d := NewInternalNotifyDeliverer(srv.URL, "tok", "")
+	err := d.SendMessage(context.Background(), "space-9",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM, Payload: map[string]any{"type": 1, "content": "x"}})
+	if err == nil {
+		t.Fatalf("empty delivered set must return error")
+	}
+}
+
+// TestInternalNotifyDeliverer_Non2xxReturnsError asserts a non-2xx response is
+// surfaced as an error so the state machine records attempt+last_error and the
+// sweep retries (NOT fire-and-forget).
+func TestInternalNotifyDeliverer_Non2xxReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	d := NewInternalNotifyDeliverer(srv.URL, "tok", "")
+	err := d.SendMessage(context.Background(), "space-9",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM, Payload: map[string]any{"content": "x"}})
+	if err == nil {
+		t.Fatalf("expected error on non-2xx response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected error to mention HTTP status, got %v", err)
+	}
+}
+
+// TestInternalNotifyDeliverer_NetworkErrorReturnsError asserts a transport error
+// (unreachable server) is returned, driving the retry state machine.
+func TestInternalNotifyDeliverer_NetworkErrorReturnsError(t *testing.T) {
+	d := NewInternalNotifyDeliverer("http://127.0.0.1:0", "tok", "")
+	err := d.SendMessage(context.Background(), "space-9",
+		SendMessageRequest{ChannelID: "u1", ChannelType: WireChannelDM, Payload: map[string]any{"content": "x"}})
+	if err == nil {
+		t.Fatalf("expected error when server is unreachable")
+	}
+}
+
+// TestInternalNotifyDeliverer_EnsureFriendIsNoop asserts EnsureFriend performs no
+// HTTP call and returns nil (internal-notify needs no friend relationship).
+func TestInternalNotifyDeliverer_EnsureFriendIsNoop(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewInternalNotifyDeliverer(srv.URL, "tok", "")
+	if err := d.EnsureFriend(context.Background(), "space-9", "u1"); err != nil {
+		t.Fatalf("EnsureFriend must be a no-op returning nil, got %v", err)
+	}
+	if called {
+		t.Fatalf("EnsureFriend must not make any HTTP call")
+	}
+}
+
+// TestInternalNotifyDeliverer_SpaceIDFallsBackToPayload asserts that when the
+// spaceID arg is empty the deliverer falls back to payload.space_id for the
+// required top-level body field.
+func TestInternalNotifyDeliverer_SpaceIDFallsBackToPayload(t *testing.T) {
+	var gotBody notifyReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(notifyResp{Delivered: []string{"u1"}})
+	}))
+	defer srv.Close()
+
+	d := NewInternalNotifyDeliverer(srv.URL, "tok", "")
+	msg := SendMessageRequest{
+		ChannelID:   "u1",
+		ChannelType: WireChannelDM,
+		Payload:     map[string]any{"content": "x", "space_id": "space-fallback"},
+	}
+	if err := d.SendMessage(context.Background(), "", msg); err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	if gotBody.SpaceID != "space-fallback" {
+		t.Fatalf("expected body.space_id to fall back to payload.space_id, got %q", gotBody.SpaceID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PR#113 notify — payload wire shape + 「空间名 + 总结名称」文本
+// ---------------------------------------------------------------------------
+
+// setupIMTestDB builds an in-memory IM DB with just the `space` table that
+// resolveSpaceName reads (read-only raw SELECT). Schema is NOT owned by this
+// service — created here only to back the unit test.
+func setupIMTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE space (space_id TEXT PRIMARY KEY, name TEXT)").Error; err != nil {
+		t.Fatalf("create space table: %v", err)
+	}
+	return db
+}
+
+// TestBuildText_CompletedIncludesSpaceAndTitle 注入可控 imDB 让 resolveSpaceName
+// 返回已知空间名，断言成功文本同时含「空间「<名>」」与「总结「<Title>」」。
+func TestBuildText_CompletedIncludesSpaceAndTitle(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDB(t)
+	if err := imDB.Exec("INSERT INTO space (space_id, name) VALUES (?, ?)", "space-9", "研发一组").Error; err != nil {
+		t.Fatalf("seed space: %v", err)
+	}
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(301, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if !strings.Contains(text, "空间「研发一组」") {
+		t.Fatalf("completed text missing space name: %q", text)
+	}
+	if !strings.Contains(text, "总结「今日群聊」") {
+		t.Fatalf("completed text missing title: %q", text)
+	}
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") {
+		t.Fatalf("completed text must not carry a result link anymore: %q", text)
+	}
+}
+
+// TestBuildText_CompletedIncludesRichMeta 验证成功通知追加的完整元信息：
+// 时间范围 + 参与成员数 + 消息数量 + 生成时间（替代已删除的不可达链接）。
+// 都是 best-effort，此处 seed 齐数据确认都渲染出来。
+func TestBuildText_CompletedIncludesRichMeta(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	// Seed the read-only source tables buildText best-effort queries.
+	if err := db.Exec("CREATE TABLE summary_result (id INTEGER PRIMARY KEY, task_id INTEGER, total_msg_count INTEGER, version INTEGER, generated_at DATETIME)").Error; err != nil {
+		t.Fatalf("create summary_result: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE summary_participant (id INTEGER PRIMARY KEY, task_id INTEGER)").Error; err != nil {
+		t.Fatalf("create summary_participant: %v", err)
+	}
+	gen := time.Date(2026, 6, 26, 9, 30, 0, 0, timezone.Location())
+	db.Exec("INSERT INTO summary_result (task_id, total_msg_count, version, generated_at) VALUES (?,?,?,?)", 601, 128, 1, gen)
+	db.Exec("INSERT INTO summary_participant (task_id) VALUES (?),(?),(?)", 601, 601, 601)
+
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	task := baseTask(601, model.TriggerManual)
+	task.TimeRangeStart = time.Date(2026, 6, 25, 0, 0, 0, 0, timezone.Location())
+	task.TimeRangeEnd = time.Date(2026, 6, 25, 23, 59, 0, 0, timezone.Location())
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	for _, want := range []string{
+		"已生成完成",
+		"时间范围：2026-06-25 00:00 ~ 2026-06-25 23:59",
+		"参与成员：3 人",
+		"消息数量：128 条",
+		"生成时间：2026-06-26 09:30",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("completed text missing %q; full text:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") {
+		t.Fatalf("completed text must not carry a link: %q", text)
+	}
+}
+
+// TestParticipantCount_SinglePersonOmitted 单人任务（无 participant 行）不渲染
+// 「参与成员」行；meta 表不存在时也优雅降级不崩。
+func TestParticipantCount_SinglePersonOmitted(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(602, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send (best-effort must not block), got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "参与成员") {
+		t.Fatalf("single-person task must omit member line; got %q", text)
+	}
+}
+func TestBuildText_FailedIncludesSpaceAndReason(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDB(t)
+	if err := imDB.Exec("INSERT INTO space (space_id, name) VALUES (?, ?)", "space-9", "研发一组").Error; err != nil {
+		t.Fatalf("seed space: %v", err)
+	}
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	// Identity sanitizer: this test asserts space name + verbatim reason are
+	// composed together; it is not exercising the R3 scrub (covered separately).
+	n.errorSanitizer = func(s string) string { return s }
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(302, model.TriggerManual), model.StatusFailed, "LLM timeout")
+
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if !strings.Contains(text, "空间「研发一组」") {
+		t.Fatalf("failed text missing space name: %q", text)
+	}
+	if !strings.Contains(text, "总结「今日群聊」") || !strings.Contains(text, "失败") {
+		t.Fatalf("failed text missing title/失败: %q", text)
+	}
+	if !strings.Contains(text, "LLM timeout") {
+		t.Fatalf("failed text missing reason: %q", text)
+	}
+}
+
+// TestBuildText_DegradesWhenIMDBNil 降级路径：imDB 为 nil 时退回不带空间名的旧文案。
+func TestBuildText_DegradesWhenIMDBNil(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(303, model.TriggerManual), model.StatusCompleted, "")
+
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "空间「") {
+		t.Fatalf("nil imDB must degrade to space-less wording, got %q", text)
+	}
+	if text != "你的总结「今日群聊」已生成完成。" {
+		t.Fatalf("degraded text mismatch: %q", text)
+	}
+}
+
+// TestBuildText_DegradesWhenSpaceNotFound 降级路径：imDB 在但查不到该 space_id，
+// 同样退回旧文案，且绝不阻断投递。
+func TestBuildText_DegradesWhenSpaceNotFound(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDB(t) // table exists but no matching row
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(304, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("delivery must not be blocked by missing space, got %d sends", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "空间「") {
+		t.Fatalf("missing space row must degrade to space-less wording, got %q", text)
+	}
+	if !strings.Contains(text, "你的总结「今日群聊」已生成完成。") {
+		t.Fatalf("degraded text mismatch: %q", text)
+	}
+}
+
+// TestResolveSpaceName_NilReceiverAndNilDB 直接覆盖 resolveSpaceName 的 nil 防护。
+func TestResolveSpaceName_NilReceiverAndNilDB(t *testing.T) {
+	var nilN *Notifier
+	if got := nilN.resolveSpaceName(baseTask(1, model.TriggerManual)); got != "" {
+		t.Fatalf("nil receiver must return empty, got %q", got)
+	}
+	n := New(setupNotifyTestDB(t), nil, &fakeDeliverer{}, Config{Enabled: true})
+	if got := n.resolveSpaceName(baseTask(1, model.TriggerManual)); got != "" {
+		t.Fatalf("nil imDB must return empty, got %q", got)
+	}
+	// Empty SpaceID short-circuits even with a live imDB.
+	n2 := New(setupNotifyTestDB(t), setupIMTestDB(t), &fakeDeliverer{}, Config{Enabled: true})
+	task := baseTask(1, model.TriggerManual)
+	task.SpaceID = ""
+	if got := n2.resolveSpaceName(task); got != "" {
+		t.Fatalf("empty space_id must return empty, got %q", got)
+	}
+}
+
+// --- space_id in payload (system-bot space filter fix) ---
+
+// TestDeliver_PayloadCarriesSpaceID_WhenKnown asserts the delivered payload
+// includes space_id when the target SpaceID is non-empty. Summary runs as a
+// system bot; octo-server's filterPersonMessagesBySpace drops a system-bot
+// message whose payload has an empty space_id, so it must be carried through.
+// fail-before: deliver previously built the payload without space_id, so this
+// key assertion would have failed.
+func TestDeliver_PayloadCarriesSpaceID_WhenKnown(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	// baseTask carries SpaceID="space-9".
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	got, ok := d.sendCalls[0].Payload["space_id"]
+	if !ok {
+		t.Fatalf("payload must carry space_id when target.SpaceID is set, got %v", d.sendCalls[0].Payload)
+	}
+	if got != "space-9" {
+		t.Fatalf("expected space_id=space-9, got %v", got)
+	}
+}
+
+// TestDeliver_PayloadOmitsSpaceID_WhenEmpty asserts the payload does NOT
+// include a space_id key when the target SpaceID is empty, avoiding a
+// regression on the empty-SpaceID path.
+func TestDeliver_PayloadOmitsSpaceID_WhenEmpty(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := baseTask(1, model.TriggerManual)
+	task.SpaceID = ""
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	if _, ok := d.sendCalls[0].Payload["space_id"]; ok {
+		t.Fatalf("payload must not carry space_id when target.SpaceID is empty, got %v", d.sendCalls[0].Payload)
+	}
+}
+
+// --- spaceID propagation to the send layer ---
+//
+// deliver() must pass target.SpaceID to Deliverer.SendMessage; the
+// InternalNotifyDeliverer then places it in the required top-level
+// NotifyReq.space_id. These tests lock the propagation through both the
+// synchronous and sweep-redeliver paths.
+
+// TestDeliver_PassesSpaceIDToSendMessage 断言 deliver()（OnTaskTerminal 路径）把
+// target.SpaceID 透传给 Deliverer.SendMessage 的 spaceID 参数。
+func TestDeliver_PassesSpaceIDToSendMessage(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	// baseTask carries SpaceID="space-9".
+	n.OnTaskTerminal(baseTask(1, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendSpaceID) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendSpaceID))
+	}
+	if d.sendSpaceID[0] != "space-9" {
+		t.Fatalf("expected spaceID=space-9 passed to SendMessage, got %q", d.sendSpaceID[0])
+	}
+}
+
+// TestRedeliver_PassesSpaceIDToSendMessage 确认 redeliver（sweep 重投递）路径同样
+// 经过 deliver→SendMessage，因此也带上权威 spaceID。
+func TestRedeliver_PassesSpaceIDToSendMessage(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(401, model.TriggerManual)
+	n.OnTaskTerminal(task, model.StatusFailed, "x") // first attempt fails, row -> failed
+
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	n.Sweep(context.Background()) // redeliver path
+
+	if len(d.sendSpaceID) != 2 {
+		t.Fatalf("expected 2 sends (initial + sweep redeliver), got %d", len(d.sendSpaceID))
+	}
+	for i, sid := range d.sendSpaceID {
+		if sid != "space-9" {
+			t.Fatalf("send #%d: expected spaceID=space-9 (redeliver must carry it too), got %q", i, sid)
+		}
+	}
+}
+
+// --- R3 (PR#113 Jerry-Xin/OctoBoooot) — sweep redeliver MUST sanitize ---
+//
+// Regression test for the blocker reported on head fede1ab5: the sweep path
+// reloaded task.ErrorMessage raw from DB and rendered it into the user DM,
+// bypassing the worker-side SanitizeErrorForUser scrub applied only at
+// OnTaskTerminal call sites. We now sanitize at a single render point in
+// buildText, and the production wiring (cmd/summary-worker/main.go) injects
+// worker.SanitizeErrorForUser via WithErrorSanitizer. This test asserts that
+// the sanitizer is actually invoked on the sweep redeliver path — i.e. raw
+// internal substrings never reach the deliverer.
+func TestSweep_RedeliverSanitizesRawError(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	// Wire a strict sanitizer mimicking worker.SanitizeErrorForUser: anything
+	// containing raw markers maps to a fixed safe string. We can't import the
+	// worker package here (import cycle), so we cover the contract: the render
+	// point invokes the injected sanitizer, raw markers never reach the DM.
+	rawMarkers := []string{"dial tcp", "10.2.3.4", "postgres://", "goroutine", "secretpw"}
+	sanitizerCalls := 0
+	n.errorSanitizer = func(s string) string {
+		sanitizerCalls++
+		for _, m := range rawMarkers {
+			if strings.Contains(s, m) {
+				return "AI 处理失败，请稍后重试"
+			}
+		}
+		return s
+	}
+
+	// Raw err in the shape the reviewer flagged: DSN + IP + credential + stack head.
+	rawErr := "dial tcp 10.2.3.4:5432: connect: connection refused (dsn=postgres://user:secretpw@10.2.3.4:5432/db) goroutine 1 [running]"
+	task := baseTask(901, model.TriggerManual)
+	task.ErrorMessage = &rawErr
+	if err := db.AutoMigrate(&model.SummaryTask{}); err != nil {
+		t.Fatalf("automigrate task: %v", err)
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+
+	// First call: synchronous path. Even on the immediate hop the new
+	// single-render-point sanitize runs, so the synchronous send (which fails
+	// once via sendErrOnce) must not leak the raw err either.
+	n.OnTaskTerminal(task, model.StatusFailed, rawErr)
+
+	var row model.SummaryNotification
+	if err := db.Where("task_id = ?", 901).First(&row).Error; err != nil {
+		t.Fatalf("row not found: %v", err)
+	}
+	if row.Status != model.NotifyStatusFailed {
+		t.Fatalf("precondition: expected failed after first send, got %s", row.Status)
+	}
+
+	// Sweep — this is the path that historically read task.ErrorMessage raw
+	// and rendered it unsanitized into the DM.
+	n.Sweep(context.Background())
+
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 send calls (1 initial fail + 1 sweep retry), got %d", len(d.sendCalls))
+	}
+	if sanitizerCalls < 2 {
+		t.Fatalf("sanitizer must be invoked on BOTH the synchronous AND the redeliver render; got calls=%d", sanitizerCalls)
+	}
+	for i, call := range d.sendCalls {
+		text, _ := call.Payload["content"].(string)
+		for _, m := range rawMarkers {
+			if strings.Contains(text, m) {
+				t.Fatalf("send #%d leaked raw marker %q into DM text:\n%s", i, m, text)
+			}
+		}
+		if !strings.Contains(text, "AI 处理失败，请稍后重试") {
+			t.Fatalf("send #%d missing safe failure reason; got:\n%s", i, text)
+		}
+	}
+
+	// Final state: sweep succeeded → sent.
+	db.Where("task_id = ?", 901).First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("after sweep retry expected sent, got %s (attempts=%d)", row.Status, row.AttemptCount)
+	}
+}
+
+
+// ---------------------------------------------------------------------------
+// 轻量防护：接收人非该 space 活跃成员时，deliver 应显式失败，而非静默「已发送」
+// （octo-server 对系统 bot DM 在接收人非成员时会 strip space_id 但仍返 200，
+// 导致消息被丢弃、用户看不到；worker 侧预检把静默丢失转成显式失败。）
+// ---------------------------------------------------------------------------
+
+// setupIMTestDBWithMembers 建带 space + space_member 两表的内存 IM 库，用于成员校验。
+func setupIMTestDBWithMembers(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE space (space_id TEXT PRIMARY KEY, name TEXT, status INTEGER)").Error; err != nil {
+		t.Fatalf("create space table: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE space_member (space_id TEXT, uid TEXT, status INTEGER)").Error; err != nil {
+		t.Fatalf("create space_member table: %v", err)
+	}
+	return db
+}
+
+// TestDeliver_ActiveMember_Delivers 接收人是活跃成员 → 正常投递。
+func TestDeliver_ActiveMember_Delivers(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDBWithMembers(t)
+	imDB.Exec("INSERT INTO space (space_id, name, status) VALUES (?,?,1)", "space-9", "研发一组")
+	imDB.Exec("INSERT INTO space_member (space_id, uid, status) VALUES (?,?,1)", "space-9", "user-1")
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(501, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("active member: expected 1 send, got %d", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	if err := db.Where("task_id=?", 501).First(&row).Error; err != nil {
+		t.Fatalf("load notification: %v", err)
+	}
+	if row.Status != "sent" {
+		t.Fatalf("active member: expected status=sent, got %q", row.Status)
+	}
+}
+
+// TestDeliver_NonMember_FailsNotSilentSent 接收人非活跃成员 → 不发送，记录 failed（非 sent）。
+func TestDeliver_NonMember_FailsNotSilentSent(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	imDB := setupIMTestDBWithMembers(t)
+	imDB.Exec("INSERT INTO space (space_id, name, status) VALUES (?,?,1)", "space-9", "研发一组")
+	// user-1 有一行但 status=2（被降权/退出）→ 非活跃成员。
+	imDB.Exec("INSERT INTO space_member (space_id, uid, status) VALUES (?,?,2)", "space-9", "user-1")
+	d := &fakeDeliverer{}
+	n := New(db, imDB, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(502, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("non-member: expected 0 send (blocked), got %d", len(d.sendCalls))
+	}
+	var row model.SummaryNotification
+	if err := db.Where("task_id=?", 502).First(&row).Error; err != nil {
+		t.Fatalf("load notification: %v", err)
+	}
+	if row.Status == "sent" {
+		t.Fatalf("non-member: notification wrongly marked sent (silent-success trap not closed)")
+	}
+}
+
+// TestDeliver_NilIMDB_AllowsDelivery imDB 为 nil → 无法校验 → 放行（不阻断，server 兜底）。
+func TestDeliver_NilIMDB_AllowsDelivery(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	n.OnTaskTerminal(baseTask(503, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("nil imDB: expected 1 send (fail-open), got %d", len(d.sendCalls))
+	}
+}
+
+// TestBuildText_NilSanitizerFallsBackToSafeString asserts the defensive
+// fallback: if Notifier is constructed without WithErrorSanitizer (production
+// misconfig), buildText still refuses to render raw err.Error() to the user
+// DM. This guards against future call sites accidentally forgetting the wiring.
+func TestBuildText_NilSanitizerFallsBackToSafeString(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	// Bypass newTestNotifier so we get a Notifier with nil errorSanitizer.
+	n := New(db, nil, d, Config{Enabled: true})
+	n.now = func() time.Time { return time.Date(2026, 6, 26, 10, 0, 0, 0, timezone.Location()) }
+
+	rawErr := "dial tcp 10.2.3.4: connect refused dsn=postgres://u:secretpw@h/db"
+	task := baseTask(902, model.TriggerManual)
+
+	n.OnTaskTerminal(task, model.StatusFailed, rawErr)
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	for _, m := range []string{"dial tcp", "10.2.3.4", "postgres://", "secretpw"} {
+		if strings.Contains(text, m) {
+			t.Fatalf("nil sanitizer must not leak raw marker %q to DM; text=%q", m, text)
+		}
+	}
+	if !strings.Contains(text, "AI 处理失败，请稍后重试") {
+		t.Fatalf("nil sanitizer fallback must render the safe default; text=%q", text)
+	}
+}
+
+
+// ---------------------------------------------------------------------------
+// by-person 多目标逐人 DM (feat/notify-delivery)
+//
+// completed：给「所有 participant ∪ 发起者 CreatorID」并集去重后逐人各发一条 DM。
+// failed：只发发起者一人（不群发，避免噪音）。
+// 非 by-person：成功/失败都只回退发起者单 DM（保持现状语义）。
+// 幂等：每个收件人独立去重（三元键 task_id+notify_kind+recipient_uid），重试只
+// 重发失败的那个人。
+// ---------------------------------------------------------------------------
+
+// setupByPersonDB 在通知库上追加 summary_participant 表，供 resolveTargets 查参与人。
+func setupByPersonDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := setupNotifyTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryParticipant{}); err != nil {
+		t.Fatalf("automigrate participant: %v", err)
+	}
+	return db
+}
+
+func seedParticipants(t *testing.T, db *gorm.DB, taskID int64, uids ...string) {
+	t.Helper()
+	for _, uid := range uids {
+		// Seed as an active (submitted) status so these fan-out/dedup/idempotency
+		// tests express "real participants who should receive the DM"; the default
+		// zero value is ParticipantPending, which resolveTargets now excludes.
+		if err := db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: uid, Status: model.ParticipantSubmitted}).Error; err != nil {
+			t.Fatalf("seed participant %s: %v", uid, err)
+		}
+	}
+}
+
+// seedParticipantStatus seeds one participant row with an explicit status,
+// so tests can exercise resolveTargets' pending/declined exclusion filter.
+func seedParticipantStatus(t *testing.T, db *gorm.DB, taskID int64, uid string, status int) {
+	t.Helper()
+	if err := db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: uid, Status: status}).Error; err != nil {
+		t.Fatalf("seed participant %s (status=%d): %v", uid, status, err)
+	}
+}
+
+func sentUIDs(d *fakeDeliverer) map[string]int {
+	got := make(map[string]int)
+	for _, c := range d.sendCalls {
+		got[c.ChannelID]++
+	}
+	return got
+}
+
+func byPersonTask(id int64) model.SummaryTask {
+	task := baseTask(id, model.TriggerManual)
+	task.SummaryMode = model.ModeByPerson
+	return task
+}
+
+// (a) by-person + 发起者不在 participant 里 → completed 每人各一条、发起者也收到、去重无重复。
+func TestOnTaskTerminal_ByPerson_CompletedFansOutToAllPlusCreator(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1001) // creator=user-1
+	seedParticipants(t, db, 1001, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	want := map[string]int{"p-a": 1, "p-b": 1, "user-1": 1}
+	if len(d.sendCalls) != 3 {
+		t.Fatalf("expected 3 sends (2 participants + creator), got %d (%v)", len(d.sendCalls), got)
+	}
+	for uid, c := range want {
+		if got[uid] != c {
+			t.Fatalf("expected uid %s to receive %d DM, got %d (all=%v)", uid, c, got[uid], got)
+		}
+	}
+	// One row per (task, completed, uid) — three distinct recipient_uids.
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND notify_kind = ?", 1001, model.NotifyKindCompleted).Count(&cnt)
+	if cnt != 3 {
+		t.Fatalf("expected 3 notification rows (one per recipient), got %d", cnt)
+	}
+}
+
+// (a-dedup) 发起者同时也是 participant → 并集去重，只发一条给发起者。
+func TestOnTaskTerminal_ByPerson_CreatorAlsoParticipant_Deduped(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1002) // creator=user-1
+	seedParticipants(t, db, 1002, "user-1", "p-x")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (deduped creator+participant), got %d (%v)", len(d.sendCalls), got)
+	}
+	if got["user-1"] != 1 || got["p-x"] != 1 {
+		t.Fatalf("expected exactly one DM each to user-1 and p-x, got %v", got)
+	}
+}
+
+// (b) failed 时只有发起者收到（participant 不收）。
+func TestOnTaskTerminal_ByPerson_FailedOnlyCreator(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1003) // creator=user-1
+	seedParticipants(t, db, 1003, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 1 || got["user-1"] != 1 {
+		t.Fatalf("failed must go ONLY to creator, got %d sends (%v)", len(d.sendCalls), got)
+	}
+	// No participant row should exist for the failed kind.
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND notify_kind = ? AND recipient_uid <> ?", 1003, model.NotifyKindFailed, "user-1").Count(&cnt)
+	if cnt != 0 {
+		t.Fatalf("failed must not create participant rows, got %d", cnt)
+	}
+}
+
+// (c) 非 by-person → completed 和 failed 都只发发起者。
+func TestOnTaskTerminal_NonByPerson_OnlyCreatorBothKinds(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	// Even if participant rows exist, a non-by-person task must ignore them.
+	seedParticipants(t, db, 1004, "p-a", "p-b")
+	task := baseTask(1004, model.TriggerManual) // SummaryMode != ModeByPerson
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusFailed, "boom")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 2 || got["user-1"] != 2 {
+		t.Fatalf("non-by-person must send only to creator (completed+failed), got %d sends (%v)", len(d.sendCalls), got)
+	}
+}
+
+// (d) 三元去重键幂等：同 (task,kind,uid) 重复触发只发一次；不同 uid 各自独立。
+func TestOnTaskTerminal_ByPerson_PerRecipientIdempotent(t *testing.T) {
+	db := setupByPersonDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true})
+
+	task := byPersonTask(1005) // creator=user-1
+	seedParticipants(t, db, 1005, "p-a", "p-b")
+
+	// Fire three times: dedup must collapse to exactly one DM per recipient.
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 3 {
+		t.Fatalf("dedup: expected 3 sends total across 3 recipients, got %d (%v)", len(d.sendCalls), got)
+	}
+	for _, uid := range []string{"p-a", "p-b", "user-1"} {
+		if got[uid] != 1 {
+			t.Fatalf("dedup: uid %s must receive exactly 1 DM, got %d (%v)", uid, got[uid], got)
+		}
+	}
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 1005).Count(&cnt)
+	if cnt != 3 {
+		t.Fatalf("dedup: expected 3 rows (one per uid), got %d", cnt)
+	}
+}
+
+// (d-independent) 一个收件人 fail、其余成功：重试只重发失败的那个人，不重发已成功的人。
+func TestOnTaskTerminal_ByPerson_OneFailsOthersUnaffected(t *testing.T) {
+	db := setupByPersonDB(t)
+	// First send fails (sendErrOnce), subsequent succeed. The failed recipient
+	// gets status=failed with budget; a second OnTaskTerminal must retry ONLY
+	// that recipient and leave the already-sent ones alone.
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip on first recipient")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := byPersonTask(1006) // creator=user-1
+	seedParticipants(t, db, 1006, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // one of the three fails once
+
+	var failedRows int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND status = ?", 1006, model.NotifyStatusFailed).Count(&failedRows)
+	if failedRows != 1 {
+		t.Fatalf("expected exactly 1 recipient failed on first pass, got %d", failedRows)
+	}
+	var sentRows int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND status = ?", 1006, model.NotifyStatusSent).Count(&sentRows)
+	if sentRows != 2 {
+		t.Fatalf("expected 2 recipients sent on first pass, got %d", sentRows)
+	}
+
+	sendsAfterFirst := len(d.sendCalls) // 3 (2 ok + 1 failed attempt)
+
+	// Second pass: only the failed recipient should be retried (one more send);
+	// the two already-sent recipients must be skipped (dedup).
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	if len(d.sendCalls) != sendsAfterFirst+1 {
+		t.Fatalf("retry must resend ONLY the failed recipient (+1 send); before=%d after=%d", sendsAfterFirst, len(d.sendCalls))
+	}
+	var allSent int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ? AND status = ?", 1006, model.NotifyStatusSent).Count(&allSent)
+	if allSent != 3 {
+		t.Fatalf("after retry all 3 recipients must be sent, got %d", allSent)
+	}
+}
+
+// (e) 单人（非 by-person）fail-before/pass-after 不回归：首投失败→标 failed，
+// 预算内二次触发重试成功。等价于历史单目标语义在新签名下不变。
+func TestOnTaskTerminal_SinglePerson_FailBeforePassAfter(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{sendErrOnce: errors.New("transient blip")}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := baseTask(1007, model.TriggerManual) // single-person
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	var row model.SummaryNotification
+	db.Where("task_id = ? AND recipient_uid = ?", 1007, "user-1").First(&row)
+	if row.Status != model.NotifyStatusFailed || row.AttemptCount != 1 {
+		t.Fatalf("fail-before: expected failed attempt=1, got status=%s attempt=%d", row.Status, row.AttemptCount)
+	}
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "") // retry succeeds
+	db.Where("task_id = ? AND recipient_uid = ?", 1007, "user-1").First(&row)
+	if row.Status != model.NotifyStatusSent {
+		t.Fatalf("pass-after: expected sent, got %s", row.Status)
+	}
+	if len(d.sendCalls) != 2 {
+		t.Fatalf("expected 2 sends (fail + retry), got %d", len(d.sendCalls))
+	}
+}
+
+// (f) by-person 参与人查询出错时：绝不降级成「只发发起者的假成功」。
+// 之前 err 被静默吞掉 → 只 add(CreatorID) → 发起者被标 sent、participant 一行不建、
+// sweep 也发现不了，participant 永久漏发。修复后 resolveTargets 返回 err，
+// OnTaskTerminal 跳过整轮：不投递、不建任何行（尤其没有 creator 的 sent 行）。
+// 用一个缺 summary_participant 表的通知库触发真实查询错误（no such table）。
+func TestOnTaskTerminal_ByPerson_ParticipantQueryError_NoPartialSuccess(t *testing.T) {
+	// setupNotifyTestDB 只建 summary_notification，故意不建 summary_participant，
+	// 让 resolveTargets 的 Find(&parts) 真正报错（而非空结果）。
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := byPersonTask(1008) // creator=user-1, ModeByPerson
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	// fail-then-no-partial-success: 一条都不能发，尤其不能发给发起者。
+	if len(d.sendCalls) != 0 {
+		t.Fatalf("participant query error must skip delivery entirely, got %d sends (%v)", len(d.sendCalls), sentUIDs(d))
+	}
+	// 一行都不能建：既不能有 creator 的 sent 行，也不能有任何 pending/failed 行。
+	var cnt int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", 1008).Count(&cnt)
+	if cnt != 0 {
+		t.Fatalf("participant query error must create NO notification rows (no fake creator success), got %d", cnt)
+	}
+	var creatorSent int64
+	db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND recipient_uid = ? AND status = ?", 1008, "user-1", model.NotifyStatusSent).
+		Count(&creatorSent)
+	if creatorSent != 0 {
+		t.Fatalf("must not produce a creator sent row on participant query error, got %d", creatorSent)
+	}
+}
+
+// (f-control) 参与人表存在且正常：新 (,, error) 签名不得回归多目标扇出。
+// 与 fail 用例对照，确认改动只在"查询出错"分支生效，正常路径依旧全绿。
+func TestOnTaskTerminal_ByPerson_ParticipantQueryOK_StillFansOut(t *testing.T) {
+	db := setupByPersonDB(t) // 建了 summary_participant 表
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, MaxAttempts: 3})
+
+	task := byPersonTask(1009) // creator=user-1
+	seedParticipants(t, db, 1009, "p-a", "p-b")
+
+	n.OnTaskTerminal(task, model.StatusCompleted, "")
+
+	got := sentUIDs(d)
+	if len(d.sendCalls) != 3 {
+		t.Fatalf("normal path must still fan out to 3 recipients, got %d (%v)", len(d.sendCalls), got)
+	}
+	for _, uid := range []string{"p-a", "p-b", "user-1"} {
+		if got[uid] != 1 {
+			t.Fatalf("uid %s must receive exactly 1 DM, got %d (%v)", uid, got[uid], got)
+		}
+	}
+}
+
+// (g) by-person 状态过滤：resolveTargets 只 fan-out 真正参与的人。
+// pending(0)/declined(2) 成员绝不进扇出（不该收「总结完成」通知），
+// accepted(1)/submitted(5) 成员 + 发起者 CreatorID 必须在 targets 里。
+// 与生成阶段 (personal_processor.go) 排除 pending/declined 的口径对齐。
+// fail-before: 未加 status 过滤时全部 participant 都会被塞进 targets，
+// pending/declined 的断言会红；加过滤后变绿。
+func TestResolveTargets_ByPerson_ExcludesPendingAndDeclined(t *testing.T) {
+	db := setupByPersonDB(t)
+	n := newTestNotifier(db, &fakeDeliverer{}, Config{Enabled: true})
+
+	task := byPersonTask(1010) // creator=user-1, ModeByPerson
+	seedParticipantStatus(t, db, 1010, "p-pending", model.ParticipantPending)     // 0 -> excluded
+	seedParticipantStatus(t, db, 1010, "p-declined", model.ParticipantDeclined)   // 2 -> excluded
+	seedParticipantStatus(t, db, 1010, "p-accepted", model.ParticipantAccepted)   // 1 -> included
+	seedParticipantStatus(t, db, 1010, "p-submitted", model.ParticipantSubmitted) // 5 -> included
+
+	targets, err := n.resolveTargets(task)
+	if err != nil {
+		t.Fatalf("resolveTargets returned err: %v", err)
+	}
+
+	got := make(map[string]int)
+	for _, tgt := range targets {
+		got[tgt.TargetUID]++
+	}
+
+	// declined/pending must NOT be fanned out.
+	for _, uid := range []string{"p-pending", "p-declined"} {
+		if got[uid] != 0 {
+			t.Fatalf("uid %s (pending/declined) must be excluded from targets, got %d (all=%v)", uid, got[uid], got)
+		}
+	}
+	// accepted/submitted + creator must be present exactly once.
+	for _, uid := range []string{"p-accepted", "p-submitted", "user-1"} {
+		if got[uid] != 1 {
+			t.Fatalf("uid %s must appear exactly once in targets, got %d (all=%v)", uid, got[uid], got)
+		}
+	}
+	if len(targets) != 3 {
+		t.Fatalf("expected 3 targets (accepted + submitted + creator), got %d (%v)", len(targets), got)
+	}
+}

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -1,0 +1,114 @@
+package notify
+
+import (
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// deliveryTarget is the resolved destination of a notification.
+type deliveryTarget struct {
+	ChannelID   string
+	ChannelType int // WireChannelDM / WireChannelGroup / WireChannelThread
+	// TargetUID is the user the bot must EnsureFriend with before a DM is
+	// deliverable. Set only for DM delivery; empty for group/thread回发.
+	TargetUID string
+	// SpaceID (SummaryTask.SpaceID) is passed to ensureFriend so octo-server can
+	// build the space-prefixed whitelist channel (s{spaceID}_{uid}).
+	SpaceID string
+}
+
+// resolveTargets decides where a terminal-state notification for `task` is sent.
+// It returns a list so a by-person task can fan out one DM per recipient; an
+// empty list means "no deliverable target" (caller skips).
+//
+// by-person (SummaryMode==ModeByPerson): union of active participants'
+// (excluding pending/declined, aligned with生成阶段) UserID with the task
+// creator, deduped. Each uid becomes an independent creator
+// DM target so the notify state machine dedups/retries each recipient on its own
+// (task, kind, uid) row.
+//
+// A participant-lookup error is returned (not swallowed): silently degrading to
+// just the creator would mark completed as delivered, never build participant
+// rows, and leave the miss invisible to the sweep — participants would be lost
+// forever. The caller skips this run so a later trigger/sweep can retry.
+//
+// non-by-person: a single creator DM (本期口径). The task carries
+// OriginChannelID/OriginChannelType but 原群/thread 回发 is an explicit follow-up
+// enhancement and is intentionally NOT depended on here — every origin routes to
+// the creator DM fallback this phase.
+func (n *Notifier) resolveTargets(task model.SummaryTask) ([]deliveryTarget, error) {
+	mk := func(uid string) deliveryTarget {
+		return deliveryTarget{
+			ChannelID:   uid,
+			ChannelType: WireChannelDM,
+			TargetUID:   uid,
+			SpaceID:     task.SpaceID,
+		}
+	}
+
+	if task.SummaryMode == model.ModeByPerson {
+		// Union participant UIDs with the creator, dedup, skip empties.
+		seen := make(map[string]struct{})
+		var targets []deliveryTarget
+		add := func(uid string) {
+			if uid == "" {
+				return
+			}
+			if _, ok := seen[uid]; ok {
+				return
+			}
+			seen[uid] = struct{}{}
+			targets = append(targets, mk(uid))
+		}
+		if n != nil && n.db != nil {
+			// Only fan out to真正参与的人：排除 pending/declined，与生成阶段
+			// (personal_processor.go) 对齐，避免未接受/已拒绝成员误收完成通知。
+			var parts []model.SummaryParticipant
+			if err := n.db.Where("task_id = ? AND status NOT IN ?",
+				task.ID, []int{model.ParticipantPending, model.ParticipantDeclined}).
+				Find(&parts).Error; err != nil {
+				return nil, err
+			}
+			for _, p := range parts {
+				add(p.UserID)
+			}
+		}
+		add(task.CreatorID) // creator always in the completed fan-out
+		return targets, nil
+	}
+
+	// Non-by-person: single creator DM (empty creator → no target).
+	if task.CreatorID == "" {
+		return nil, nil
+	}
+	return []deliveryTarget{mk(task.CreatorID)}, nil
+}
+
+// creatorTarget resolves the single creator DM target used for the failed path
+// (failed notifications go only to the creator, never fanned out) and for the
+// sweep redeliver path which reconstructs a target for a specific recipient_uid.
+func (n *Notifier) creatorTarget(task model.SummaryTask) (deliveryTarget, bool) {
+	if task.CreatorID == "" {
+		return deliveryTarget{}, false
+	}
+	return deliveryTarget{
+		ChannelID:   task.CreatorID,
+		ChannelType: WireChannelDM,
+		TargetUID:   task.CreatorID,
+		SpaceID:     task.SpaceID,
+	}, true
+}
+
+// targetForUID rebuilds a DM target for an explicit recipient uid using the
+// task's SpaceID. Used by the sweep redeliver path where the recipient is read
+// back from the stored notification row rather than re-derived from the task.
+func targetForUID(task model.SummaryTask, uid string) (deliveryTarget, bool) {
+	if uid == "" {
+		return deliveryTarget{}, false
+	}
+	return deliveryTarget{
+		ChannelID:   uid,
+		ChannelType: WireChannelDM,
+		TargetUID:   uid,
+		SpaceID:     task.SpaceID,
+	}, true
+}

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -294,6 +294,11 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			EventType: "META_SUMMARY_UPDATED",
 		})
 
+		// Task durably reached Completed (saveLatestResultAndCompleteTask succeeded).
+		// The notifier dedups on UNIQUE(task_id, completed), so a meta re-run that
+		// produces a new version still only sends ONE completed notification.
+		m.proc.notifyTaskTerminal(taskID, model.StatusCompleted)
+
 		log.Printf("[meta-worker] task %d meta-summary version %d created (%d participants)",
 			taskID, result.Version, len(submitted))
 

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -213,6 +213,9 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 			Progress: 100,
 			Message:  "总结完成",
 		})
+		// Task durably reached Completed above (saveLatestResultAndCompleteTask /
+		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
+		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
@@ -439,6 +442,9 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 			Progress: 0,
 			Message:  sanitized,
 		})
+		// shouldNotify is set only when the task-level CAS to StatusFailed actually
+		// flipped the row (single-person terminal failure). Fire the notification.
+		p.notifyTaskTerminal(pr.TaskID, model.StatusFailed)
 	}
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }
@@ -896,6 +902,18 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		time.Since(totalStart).Milliseconds())
 
 	return finalContent, citations, targetMsgCount, totalTokens, p.llm.ModelVersion(), nil
+}
+
+// SanitizeErrorForUser is the canonical whitelist that maps a raw internal
+// error string to a user-safe Chinese string suitable for an IM DM.
+//
+// Exported so the notify package can wire it as the single render-point
+// sanitizer in Notifier.buildText (covers both the synchronous worker path
+// AND the sweep/redeliver path that reads task.ErrorMessage raw from the DB).
+// See PR#113 Jerry-Xin/OctoBoooot R3: sanitizing only at the worker call
+// sites left the sweep path leaking DSN/IP/stack to the user DM on retry.
+func SanitizeErrorForUser(errMsg string) string {
+	return sanitizeErrorForUser(errMsg)
 }
 
 func sanitizeErrorForUser(errMsg string) string {

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
@@ -44,6 +45,10 @@ type Processor struct {
 	// get dispatched) is observable without running the LLM personal pipeline.
 	// Production leaves it nil and the real pool/processPersonalSummary is used.
 	dispatchPersonalFn func(taskID, participantRefID int64)
+	// notifier delivers the terminal-state (Completed/Failed) IM-bot notification
+	// after a task's status is durably committed. nil = disabled (OnTaskTerminal
+	// is a no-op), so it is safe to call unconditionally.
+	notifier *notify.Notifier
 }
 
 // NewProcessor creates a new task processor.
@@ -104,6 +109,46 @@ func validateOctoSearchURL(raw string) error {
 		}
 	}
 	return nil
+}
+
+// SetNotifier wires the terminal-state IM-bot notifier. Optional: when unset,
+// notifyTaskTerminal is a no-op.
+func (p *Processor) SetNotifier(n *notify.Notifier) { p.notifier = n }
+
+// notifyTaskTerminal fires the terminal-state notification for a task that just
+// reached a terminal status. It reloads the committed task row so the
+// notification reflects the durable state (title, creator, origin channel,
+// trigger type, error_message). Best-effort: any failure is swallowed inside the
+// notifier and never affects the worker's completion path. Call this ONLY after
+// the terminal-status DB write has succeeded.
+//
+// The reloaded task.error_message is the RAW internal error string (may carry
+// DSN credentials, IPs, goroutine stack heads). It is intentionally persisted
+// raw in the DB so ops can root-cause from logs, but it MUST NOT reach a user
+// DM.
+//
+// Sanitization happens at a SINGLE render point inside notify.buildText (wired
+// via notify.WithErrorSanitizer(SanitizeErrorForUser) at construction in
+// cmd/summary-worker/main.go). That single intercept covers BOTH the
+// synchronous path here AND the asynchronous sweep/redeliver path
+// (notify.go: redeliver reloads task.ErrorMessage raw from DB). Pre-PR#113 R3,
+// sanitize was applied here only and the sweep path leaked raw errors to the
+// user DM — see Jerry-Xin/OctoBoooot R3 review. We deliberately pass the raw
+// errMsg through and let buildText scrub it once at the render boundary.
+func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
+	if p.notifier == nil {
+		return
+	}
+	var task model.SummaryTask
+	if err := p.db.First(&task, taskID).Error; err != nil {
+		log.Printf("[processor] notifyTaskTerminal: reload task %d failed: %v", taskID, err)
+		return
+	}
+	errMsg := ""
+	if task.ErrorMessage != nil {
+		errMsg = *task.ErrorMessage
+	}
+	p.notifier.OnTaskTerminal(task, status, errMsg)
 }
 
 // TriggerCh returns the channel for worker trigger requests.
@@ -250,6 +295,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			Status:  newStatus,
 			Message: errMsg,
 		})
+		if newStatus == model.StatusFailed {
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+		}
 		return
 	}
 
@@ -284,6 +332,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			Status:  newStatus,
 			Message: errMsg,
 		})
+		if newStatus == model.StatusFailed {
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+		}
 		return
 	}
 
@@ -323,6 +374,9 @@ func (p *Processor) processTask(task model.SummaryTask) {
 				Status:  newStatus,
 				Message: errMsg,
 			})
+			if newStatus == model.StatusFailed {
+				p.notifyTaskTerminal(task.ID, model.StatusFailed)
+			}
 			return
 		}
 		participantCount = 1

--- a/internal/worker/processor_notify_test.go
+++ b/internal/worker/processor_notify_test.go
@@ -1,0 +1,164 @@
+//go:build cgo
+
+package worker
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
+)
+
+// fakeNotifyDeliverer captures the SendMessage payloads so we can assert the
+// failure-reason text actually reaching the IM bot has been sanitized.
+type fakeNotifyDeliverer struct {
+	mu        sync.Mutex
+	sendCalls []notify.SendMessageRequest
+}
+
+func (f *fakeNotifyDeliverer) EnsureFriend(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (f *fakeNotifyDeliverer) SendMessage(_ context.Context, _ string, msg notify.SendMessageRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, msg)
+	return nil
+}
+
+// notifyTaskTerminal must run task.error_message through sanitizeErrorForUser
+// before it reaches the IM payload. This guards against raw internal errors
+// (DSN credentials, IPs, goroutine stack heads) being delivered to the user's
+// DM via the failure-reason line of buildText.
+//
+// Regression test for PR#113 review by Jerry-Xin (2026-06-29): the task-level
+// failure path previously fed *task.ErrorMessage straight to OnTaskTerminal,
+// so the user DM rendered raw internal errors. The personal failure path
+// already sanitized via markPersonalFailed; this brings the task path to
+// parity at the single-point intercept (notifyTaskTerminal).
+func TestNotifyTaskTerminal_SanitizesRawErrorBeforeDM(t *testing.T) {
+	cases := []struct {
+		name    string
+		rawErr  string
+		wantOut string // exact expected sanitized output
+		mustNot []string
+	}{
+		{
+			name:    "dsn-credentials",
+			rawErr:  "save task: dial mysql user:s3cret@tcp(10.0.0.1:3306)/summary failed",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"user:s3cret", "10.0.0.1:3306", "user:s3cret@tcp"},
+		},
+		{
+			name:    "ip-leak",
+			rawErr:  "dial tcp 192.168.1.5:8443: connect: connection refused",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"192.168.1.5", "8443"},
+		},
+		{
+			name:    "stack-trace-head",
+			rawErr:  "goroutine 17 [running]:\nmain.failPipeline(0xc0001a23c0)",
+			wantOut: "AI 处理失败，请稍后重试",
+			mustNot: []string{"goroutine 17 [running]", "main.failPipeline", "0xc0001a23c0"},
+		},
+		{
+			name:    "llm-api-error-mapped",
+			rawErr:  "LLM API error: status=401 body=invalid key bearer-abc123",
+			wantOut: "AI 服务暂时不可用，请稍后重试",
+			mustNot: []string{"bearer-abc123", "status=401", "invalid key"},
+		},
+		{
+			name:    "context-deadline-mapped",
+			rawErr:  "context deadline exceeded after 30s on llm.example.com:9443",
+			wantOut: "AI 处理超时，请稍后重试",
+			mustNot: []string{"llm.example.com", "9443"},
+		},
+		{
+			name:    "empty-error-message",
+			rawErr:  "",
+			wantOut: "", // empty errMsg → no "失败原因" line rendered (PR#113 R3 single-point sanitize)
+			mustNot: []string{"失败原因"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupProcessorTestDB(t)
+			// summary_notification lives in the same summary DB; AutoMigrate so
+			// the real Notifier's claim INSERT succeeds.
+			if err := db.AutoMigrate(&model.SummaryNotification{}); err != nil {
+				t.Fatalf("automigrate notification: %v", err)
+			}
+
+			errMsg := tc.rawErr
+			task := model.SummaryTask{
+				TaskNo:            "TST-SAN-" + tc.name,
+				Title:             "今日群聊",
+				SpaceID:           "space-1",
+				CreatorID:         "user-1",
+				Status:            model.StatusFailed,
+				TriggerType:       model.TriggerManual,
+				OriginChannelType: model.OriginChannelGlobal,
+				ErrorMessage:      &errMsg,
+			}
+			if err := db.Create(&task).Error; err != nil {
+				t.Fatalf("save task: %v", err)
+			}
+
+			fake := &fakeNotifyDeliverer{}
+			// Production wiring: cmd/summary-worker/main.go injects
+			// worker.SanitizeErrorForUser via WithErrorSanitizer so the single
+			// render-point sanitizer in notify.buildText covers both the
+			// synchronous and the sweep/redeliver paths. Mirror that wiring
+			// here so the test exercises the same behavior as production.
+			n := notify.New(db, nil, fake, notify.Config{Enabled: true, MaxAttempts: 3}).
+				WithErrorSanitizer(SanitizeErrorForUser)
+
+			p := &Processor{db: db}
+			p.SetNotifier(n)
+			p.notifyTaskTerminal(task.ID, model.StatusFailed)
+
+			if len(fake.sendCalls) != 1 {
+				t.Fatalf("expected exactly 1 SendMessage call, got %d", len(fake.sendCalls))
+			}
+			// octo-server recognizes a plain-text bot message by "content" (type=1),
+			// not "text"; assert against the server-recognized payload key.
+			text, _ := fake.sendCalls[0].Payload["content"].(string)
+			// The failure-reason line is "失败原因：<sanitized>" — assert the
+			// sanitized whitelist mapping is what landed in the IM payload.
+			if !strings.Contains(text, tc.wantOut) {
+				t.Fatalf("expected DM text to contain sanitized %q, got %q", tc.wantOut, text)
+			}
+			for _, bad := range tc.mustNot {
+				if strings.Contains(text, bad) {
+					t.Fatalf("DM text leaked raw substring %q (full text: %q)", bad, text)
+				}
+			}
+		})
+	}
+}
+
+// notifyTaskTerminal must remain a no-op when notifier is unset (production
+// wires nil when SUMMARY_NOTIFY_ENABLED=false). Guards against the sanitize
+// change accidentally introducing a nil-deref on the disabled path.
+func TestNotifyTaskTerminal_NilNotifierIsNoop(t *testing.T) {
+	db := setupProcessorTestDB(t)
+	errMsg := "irrelevant"
+	task := model.SummaryTask{
+		TaskNo:       "TST-SAN-NIL",
+		SpaceID:      "space-1",
+		CreatorID:    "user-1",
+		Status:       model.StatusFailed,
+		ErrorMessage: &errMsg,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("save task: %v", err)
+	}
+	p := &Processor{db: db}
+	// p.notifier intentionally nil
+	p.notifyTaskTerminal(task.ID, model.StatusFailed) // must not panic
+}

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/robfig/cron/v3"
@@ -21,13 +23,29 @@ var schedulerHTTPClient = &http.Client{Timeout: 5 * time.Second}
 // StartScheduler starts the 4 cron scan jobs (every 60s).
 // featureTeamSchedule, when true, lets multi-person schedules through the claim path
 // instead of disabling them (FEATURE_TEAM_SCHEDULE).
-func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int, featureTeamSchedule bool) *cron.Cron {
+func StartScheduler(db *gorm.DB, imDB *gorm.DB, maxRetry int, workerTriggerURL string, maxWindowDays int, featureTeamSchedule bool, notifier *notify.Notifier) *cron.Cron {
 	c := cron.New()
 
 	c.AddFunc("@every 60s", func() { scanPendingSchedules(db, imDB, maxWindowDays, featureTeamSchedule) })
 	c.AddFunc("@every 60s", func() { scanConfirmTimeouts(db) })
-	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry) })
+	c.AddFunc("@every 60s", func() { scanStuckTasks(db, maxRetry, notifier) })
 	c.AddFunc("@every 60s", func() { scanStuckPersonalTasks(db, workerTriggerURL) })
+	if notifier != nil {
+		// Background sweep for the notify state machine. Re-attempts rows stuck
+		// at status='failed' with retry budget remaining (the synchronous worker
+		// path is one-shot, so without this sweep MaxNotifyAttempts collapses
+		// to 1 for the common case) and reclaims rows stuck at status='pending'
+		// past their lease (worker crash mid-delivery). Both branches use atomic
+		// CAS, so they cannot double-send with a concurrent OnTaskTerminal call.
+		c.AddFunc("@every 60s", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 55*time.Second)
+			defer cancel()
+			notifier.Sweep(ctx)
+		})
+		c.Start()
+		log.Println("[scheduler] started with 5 scan jobs (every 60s)")
+		return c
+	}
 
 	c.Start()
 	log.Println("[scheduler] started with 4 scan jobs (every 60s)")
@@ -339,7 +357,9 @@ func scanConfirmTimeouts(db *gorm.DB) {
 
 // scanStuckTasks resets tasks stuck in processing past their deadline.
 // Increments retry_count; if max retries exceeded, marks as Failed.
-func scanStuckTasks(db *gorm.DB, maxRetry int) {
+// notifier (optional) is fired once per task that this sweep transitions to
+// Failed, AFTER the terminal-status write has committed.
+func scanStuckTasks(db *gorm.DB, maxRetry int, notifier *notify.Notifier) {
 	now := timezone.Now()
 
 	// Reset tasks that can still retry (also handle NULL deadline for legacy data)
@@ -355,18 +375,57 @@ func scanStuckTasks(db *gorm.DB, maxRetry int) {
 		log.Printf("[scheduler] reset %d stuck tasks (retry incremented)", result.RowsAffected)
 	}
 
-	// Fail tasks that exceeded max retries (also handle NULL deadline)
-	failResult := db.Model(&model.SummaryTask{}).
+	// Fail tasks that exceeded max retries. Two-step (snapshot IDs, then per-row
+	// CAS UPDATE) so we can attribute exactly which IDs *this* sweep flipped to
+	// Failed — a bulk UPDATE cannot return the rows, and a snapshot-then-bulk
+	// shape would miss any task that crossed the deadline between the snapshot
+	// and the UPDATE (review feedback P2-2: snapshot-then-update race could
+	// drop the notification for a late-crosser since on the next sweep its
+	// status is already Failed). The per-row CAS guards on the same predicates
+	// the snapshot used, so concurrent transitions are absorbed (RowsAffected==0
+	// means another worker / cancel got there first; we skip).
+	var toFail []int64
+	db.Model(&model.SummaryTask{}).
 		Where("status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
 			model.StatusProcessing, now, maxRetry-1).
-		Updates(map[string]interface{}{
-			"status":              model.StatusFailed,
-			"processing_deadline": nil,
-			"retry_count":         gorm.Expr("retry_count + 1"),
-			"error_message":       "exceeded max retries",
-		})
-	if failResult.RowsAffected > 0 {
-		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", failResult.RowsAffected)
+		Pluck("id", &toFail)
+
+	var failedIDs []int64
+	for _, id := range toFail {
+		res := db.Model(&model.SummaryTask{}).
+			Where("id = ? AND status = ? AND (processing_deadline IS NULL OR processing_deadline < ?) AND retry_count >= ?",
+				id, model.StatusProcessing, now, maxRetry-1).
+			Updates(map[string]interface{}{
+				"status":              model.StatusFailed,
+				"processing_deadline": nil,
+				"retry_count":         gorm.Expr("retry_count + 1"),
+				"error_message":       "exceeded max retries",
+			})
+		if res.Error == nil && res.RowsAffected == 1 {
+			failedIDs = append(failedIDs, id)
+		}
+	}
+	if len(failedIDs) > 0 {
+		log.Printf("[scheduler] failed %d stuck tasks (max retries exceeded)", len(failedIDs))
+	}
+
+	// Notify exactly the tasks this sweep transitioned. Reload each so the
+	// notification reflects the committed terminal row.
+	if notifier != nil {
+		for _, id := range failedIDs {
+			var task model.SummaryTask
+			if err := db.First(&task, id).Error; err != nil {
+				continue
+			}
+			if task.Status != model.StatusFailed {
+				continue
+			}
+			errMsg := ""
+			if task.ErrorMessage != nil {
+				errMsg = *task.ErrorMessage
+			}
+			notifier.OnTaskTerminal(task, model.StatusFailed, errMsg)
+		}
 	}
 }
 

--- a/migrations/sql/20260626-01-add-summary-notification.sql
+++ b/migrations/sql/20260626-01-add-summary-notification.sql
@@ -1,0 +1,19 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS `summary_notification` (
+    `id`            BIGINT       NOT NULL AUTO_INCREMENT,
+    `task_id`       BIGINT       NOT NULL,
+    `notify_kind`   VARCHAR(16)  NOT NULL COMMENT 'completed | failed',
+    `recipient_uid` VARCHAR(64)  NOT NULL DEFAULT '' COMMENT 'per-recipient dedup: one row per (task, kind, uid)',
+    `status`        VARCHAR(16)  NOT NULL DEFAULT 'pending' COMMENT 'pending | sent | failed',
+    `attempt_count` INT          NOT NULL DEFAULT 0,
+    `last_error`    VARCHAR(500)     NULL,
+    `created_at`    DATETIME     NOT NULL,
+    `updated_at`    DATETIME     NOT NULL,
+    `sent_at`       DATETIME         NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_task_kind_uid` (`task_id`, `notify_kind`, `recipient_uid`),
+    KEY `idx_sweep` (`status`, `updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_notification`;


### PR DESCRIPTION
## 背景 / Refs

Closes #96 —— 给智能总结补上「主动通知」能力：任务终态（成功/失败）时通知相关用户。

本 PR 是对历史 PR #126 方案的**投递层重构**：以 #126 的完整通知骨架（去重/扇出/重试/文案模板）为基座，**只替换发送层**——从「自建 bot + bot_token 直发」改为调用 octo-server 现成的内部通知接口 `POST /v1/internal/notify`（`X-Internal-Token` 鉴权），由 server 侧系统助手代发。

## 为什么换投递方式

原 #126 需自建 bot 身份、管理 bot_token、维护 bot↔user 好友关系（ensureFriend）、以及跨 Space DM 注入防御。改用 internal-notify 后：

- **零 server 改动** —— octo-server main 已有 `/v1/internal/notify` + `/notify/batch`，直接消费。
- 免去 bot 身份/token 生命周期、好友关系、跨 Space 防御等一整套复杂度。
- server 侧统一做成员校验、actor 去重、按收件人本地化。

## 主要改动

- **`internal/notify/`（新）**
  - `notify.go`：`OnTaskTerminal` 状态机——每收件人 claim/deliver/mark，`Sweep`（失败补投 + stale pending），`buildText`，错误 sanitize/truncate。
  - `target.go`：`resolveTargets`——by-person 扇出「参与者 ∪ 发起者」（排除 pending/declined、dedup）；非 by-person 仅通知发起者。
  - `dupkey.go`：唯一键去重（MySQL 1062 / gorm.ErrDuplicatedKey）。
  - `client.go`：`InternalNotifyDeliverer`——POST `/v1/internal/notify`，payload **原样透传**（`{type:1,content}`，server 直接转 IM 构造器）；**2xx 但 delivered 集合不含该收件人视为失败**驱动重试；`EnsureFriend` no-op。
- **`internal/model/notification.go`（新）**：`SummaryNotification`，UNIQUE(task_id, notify_kind, recipient_uid)。
- **`migrations/sql/20260626-01-...`（新）**：`summary_notification` 表。
- **worker hooks**：`processor.go` / `meta_processor.go` / `personal_processor.go` 终态出口触发（best-effort，不阻塞主流程）；`scheduler.go` 两步 CAS 精确归因超时失败 + `@every 60s` Sweep cron。
- **config**：`SUMMARY_NOTIFY_TOKEN`（区别于 matter 的命名；其值需与 server 端 `NOTIFY_INTERNAL_TOKEN` 一致，塞进 `X-Internal-Token` header）、`SUMMARY_WEB_BASE_URL`、`APP_ENV`；prod 启用但缺 token → fatal，dev 仅 warn。

## 设计口径（已与需求方确认）

- by-person：扇出参与者 + 发起者；非 by-person：仅发起者。
- 静默窗口：一期不做，manual/scheduled 一视同仁即时推。
- 文案模板复用 #126 设计（成功带结果链接、失败带错误上下文），仅换投递方式。

## 修复的关键缺陷（code-loops 两轮独立评审揪出）

- **C1（Critical）**：payload 形状契约错误——发送层曾把正确的 `{type:1,content}` 重组成 `{message_key,message}`，server 原样透传后 IM 渲染空白、却回 2xx → 状态机误标「已送达」→ 静默丢失。已改为 payload 原样透传。
- **M1（Medium）**：server 把收件人全过滤（非活跃成员）时仍返 200，客户端曾误标 sent。已改为解析 `delivered` 白名单，不在列表即返 error 驱动重试。

## 测试

- `go build ./...` OK，`go vet ./...` 干净。
- `go test ./...` 全 11 包 **0 FAIL**（含新增 `internal/notify` 投递/去重/扇出/重试测试，httptest 断言 `/v1/internal/notify` + `X-Internal-Token` + 单收件人 body 形状 + 非2xx/网络错返 error + delivered 白名单）。
- migration 在真实 MySQL 8.0 up 验证结构后 DROP。

## 部署前提

要真正发出通知，octo-server 部署需配置 `NOTIFY_INTERNAL_TOKEN`，其值与 summary 侧 `SUMMARY_NOTIFY_TOKEN` 一致。未配置时 server 会拒绝内部通知请求（代码有 warn）。