### PR TITLE
feat(timezone): 时区可通过 TZ 环境变量配置 (#136)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -42,6 +42,7 @@ All configuration is done via environment variables.
 | `FETCH_CONCURRENCY` | Parallel channel message fetch concurrency | No | `10` |
 | `CHANNEL_SCOPE_ENABLED` | Enable channel scope narrowing | No | `true` |
 | `TOOL_CALL_TIMEOUT` | Tool call per-attempt timeout in seconds | No | `30` |
+| `TZ` | Container / application timezone (IANA name). Empty preserves the default. | No | `Asia/Shanghai` |
 
 ## LLM Gateway Options
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export OCTO_SEARCH_URL=http://octo-search-batch:8080
 export OCTO_SEARCH_TOKEN=your-s2s-token
 export OCTO_SEARCH_POLL_INTERVAL_SECONDS=1
 export SUMMARY_LISTEN_ADDR=:8090
+export TZ=Asia/Shanghai  # optional; app timezone, defaults to Asia/Shanghai
 
 ./cmd serve
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,6 +50,7 @@ go build ./cmd
 export LLM_API_URL=https://api.example.com/v1
 export LLM_API_KEY=sk-your-key-here
 export SUMMARY_LISTEN_ADDR=:8090
+export TZ=Asia/Shanghai  # 可选；应用时区，缺省 Asia/Shanghai
 
 ./cmd serve
 ```

--- a/internal/timezone/timezone.go
+++ b/internal/timezone/timezone.go
@@ -1,33 +1,49 @@
-// Package timezone centralizes the project's wall-clock reference so that the
-// database, backend logic and frontend all agree on a single timezone:
-// Asia/Shanghai (Beijing time, UTC+8).
+// Package timezone centralizes the project's wall-clock reference so database,
+// backend logic and frontend agree on one zone. Default is Asia/Shanghai to
+// preserve historical behavior; set TZ at process start to override.
 //
 // Background: the scheduler previously mixed time.Now().UTC() with a DSN using
 // loc=Local (container TZ=Asia/Shanghai), causing an 8-hour skew between what
 // the frontend selected (e.g. 17:00 Beijing) and when tasks actually fired.
 // All "current time" reads must go through Now() so writes, reads, comparisons
-// and schedule math share the same Asia/Shanghai zone.
+// and schedule math share the same zone.
 package timezone
 
 import (
+	"log"
+	"os"
+	"strings"
 	"sync"
 	"time"
 )
 
-const Name = "Asia/Shanghai"
+// defaultZone is used when TZ env is empty; kept private so callers can't bake
+// the literal into unrelated code paths.
+const defaultZone = "Asia/Shanghai"
 
 var (
 	loc     *time.Location
 	locOnce sync.Once
 )
 
-// Location returns the Asia/Shanghai location. If the zoneinfo database is
-// unavailable it falls back to a fixed UTC+8 offset so behavior stays correct
-// (China has no DST, so a fixed +8 offset is exact).
+// Location returns the process timezone, resolved once at first call:
+//   - $TZ if set and loadable
+//   - otherwise Asia/Shanghai
+//   - if neither loads (missing zoneinfo / bad TZ value) fall back to a fixed
+//     UTC+8 offset and warn, so behavior stays correct instead of panicking
+//
+// sync.Once means the zone is captured once per process; runtime TZ changes are
+// intentionally not supported — restart the process to switch zones.
 func Location() *time.Location {
 	locOnce.Do(func() {
-		l, err := time.LoadLocation(Name)
+		tz := strings.TrimSpace(os.Getenv("TZ"))
+		name := tz
+		if name == "" {
+			name = defaultZone
+		}
+		l, err := time.LoadLocation(name)
 		if err != nil {
+			log.Printf("[WARN] TZ=%q 加载失败, 已回退 UTC+8: %v", tz, err)
 			l = time.FixedZone("CST", 8*60*60)
 		}
 		loc = l
@@ -35,13 +51,14 @@ func Location() *time.Location {
 	return loc
 }
 
-// Now returns the current time in Asia/Shanghai. Use this everywhere instead of
-// time.Now() / time.Now().UTC() so the whole pipeline shares one wall clock.
+// Now returns the current time in the configured zone. Use this everywhere
+// instead of time.Now() / time.Now().UTC() so the whole pipeline shares one
+// wall clock.
 func Now() time.Time {
 	return time.Now().In(Location())
 }
 
-// In converts t to Asia/Shanghai.
+// In converts t to the configured zone.
 func In(t time.Time) time.Time {
 	return t.In(Location())
 }

--- a/internal/timezone/timezone_test.go
+++ b/internal/timezone/timezone_test.go
@@ -1,0 +1,61 @@
+package timezone
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// resetLocation clears the sync.Once cache so each case re-resolves TZ from
+// scratch; without it Location() would return the first case's zone forever.
+func resetLocation(t *testing.T) {
+	t.Helper()
+	loc = nil
+	locOnce = sync.Once{}
+}
+
+// 验证默认行为不变: 未设 TZ 时仍解析为 Asia/Shanghai。
+func TestLocation_DefaultShanghai(t *testing.T) {
+	resetLocation(t)
+	t.Setenv("TZ", "")
+	if got := Location().String(); got != "Asia/Shanghai" {
+		t.Fatalf("default zone: got %q, want Asia/Shanghai", got)
+	}
+}
+
+// 验证合法 TZ 被采用: 覆盖默认, 解析成对应 zone。
+func TestLocation_ValidTZ(t *testing.T) {
+	resetLocation(t)
+	t.Setenv("TZ", "America/New_York")
+	if got := Location().String(); got != "America/New_York" {
+		t.Fatalf("valid TZ: got %q, want America/New_York", got)
+	}
+}
+
+// 验证非法 TZ 走兜底: 不 panic, 且落到固定 UTC+8 偏移(中国无 DST, +8 精确)。
+func TestLocation_InvalidTZFallsBackToUTC8(t *testing.T) {
+	resetLocation(t)
+	t.Setenv("TZ", "Invalid/NotAZone")
+	_, offset := time.Now().In(Location()).Zone()
+	if offset != 8*60*60 {
+		t.Fatalf("invalid TZ fallback offset: got %d, want %d", offset, 8*60*60)
+	}
+}
+
+// 验证兜底路径打出 WARN 日志: 原静默吞错已按老板要求改为可排查的告警。
+func TestLocation_InvalidTZLogsWarn(t *testing.T) {
+	resetLocation(t)
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("TZ", "Invalid/NotAZone")
+	_ = Location()
+
+	if !bytes.Contains(buf.Bytes(), []byte("[WARN]")) || !bytes.Contains(buf.Bytes(), []byte("TZ=")) {
+		t.Fatalf("expected WARN log with [WARN] and TZ= markers, got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
Closes #136

## 背景

时区当前写死在 `internal/timezone/timezone.go` 的 `const Name = "Asia/Shanghai"`，`Location()` / `Now()` / `In()` 全走它，不读环境变量——想换时区只能改代码重编。项目其它配置都走 `os.Getenv`（`internal/config/config.go` 的 `envStr/envInt/envBool`），时区是唯一例外。本 PR 让它与其余 env 驱动配置一致。

## 改动摘要

- **`internal/timezone/timezone.go`**：`Location()` 改读 `os.Getenv("TZ")`（`strings.TrimSpace` 判空）；三层兜底——空 → 私有 `defaultZone = "Asia/Shanghai"`；合法值 → `time.LoadLocation`；非法值 / 缺 zoneinfo → `time.FixedZone("CST", 8*60*60)` 并 `log.Printf("[WARN] TZ=%q 加载失败, 已回退 UTC+8: %v", ...)`，**绝不 panic**。原 `const Name` 下线为私有 `defaultZone`（全库零外部引用，`grep -rn "timezone.Name"` 验证）。`sync.Once` / `locOnce` 缓存原样保留——一进程一时区、启动读一次、不支持运行期热更新（要换时区重启）。`Now()` / `In()` 未动，63 处 `timezone.Now/In/Location` 调用点零改动。
- **Dockerfile**：`Dockerfile.api` / `Dockerfile.worker` **一个字未改**。`ENV TZ=Asia/Shanghai` 与 `ln -snf /usr/share/zoneinfo/$TZ /etc/localtime` 段全部原样保留——作 OS 层默认，兜住 39 处裸 `time.Now()` 依赖的 `time.Local`。运行时 `-e TZ=X` 覆盖 ENV 时，app 与 `time.Local` 同步切到 X。
- **文档**：`CONFIGURATION.md` 环境变量表新增 `TZ` 一行（可选、缺省 Asia/Shanghai）；`README.md` / `README.zh.md`「最小配置（环境变量）」段各补一行 `export TZ=Asia/Shanghai  # 可选`。无 `.env.example`，不新建。

## 部署前提 / 必配环境变量

**本 PR 不新增任何必配变量，`TZ` 为可选增强。**

- `TZ`（**可选**，IANA 时区名，如 `Asia/Shanghai` / `America/New_York` / `UTC`）
  - 不配 → 与今天完全一致，缺省 `Asia/Shanghai`（byte-for-byte 兼容）；
  - 配 `-e TZ=X` → 应用整体切到 X 时区，`time.Local` 亦同步（Dockerfile 内 zoneinfo 软链 `$TZ` 路径已就位）；
  - 非法值（如 `Invalid/NotAZone` 或缺 zoneinfo）→ 打出 `[WARN] TZ=... 加载失败, 已回退 UTC+8` 日志并使用 `FixedZone("CST", +8h)`，**不 panic**。

## 测试

新增 `internal/timezone/timezone_test.go`（白盒 `package timezone`，`resetLocation` 每 case 前重置 `loc = nil` + `locOnce = sync.Once{}` 绕开 `sync.Once` 缓存），四条断言覆盖：

1. 默认 `TZ=""` → `Location().String() == "Asia/Shanghai"`；
2. 合法 `TZ="America/New_York"` → `Location().String() == "America/New_York"`；
3. 非法 `TZ="Invalid/NotAZone"` → `offset == 8*60*60` 且不 panic；
4. 非法 → 日志同时含 `[WARN]` 与 `TZ=` 标记。

```
$ go test -race -count=2 ./internal/timezone
ok  	github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone	1.011s
```

8/8 PASS，`-race` 无告警，`-count=2` 校验 `sync.Once` reset 逻辑真的生效。`go build ./...` / `go vet ./...` 全绿。

## 改动范围

```
 CONFIGURATION.md                   |  1 +
 README.md                          |  1 +
 README.zh.md                       |  1 +
 internal/timezone/timezone.go      | 41 ++++++++++++++++++++++--------
 internal/timezone/timezone_test.go | 61 ++++++++++++++++++++++++++++++++++++++
 5 files changed, 93 insertions(+), 12 deletions(-)
```

`git diff upstream/main -- 'Dockerfile*'` 为空，确认 Dockerfile 零改动。
