### PR TITLE
fix: install g++ for worker Docker build

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM golang:1.25-alpine AS builder
 
 # Install build dependencies for CGO
-RUN apk add --no-cache gcc musl-dev curl
+RUN apk add --no-cache gcc g++ musl-dev curl
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- Fix Docker Publish for `summary-worker` by installing `g++` in `Dockerfile.worker`.
- The worker links `libtokenizers.a` with `-lstdc++`; Alpine builder previously installed `gcc`, `musl-dev`, and `curl`, but not the C++ toolchain/runtime development package.

## Evidence

- Failed run: Docker Publish `v1.4.0` worker jobs for both `linux/amd64` and `linux/arm64` failed at `go build` with `cannot find -lstdc++`.
- Static validation: `git diff --check` passed.
- Local Docker build retry reached the external tokenizer asset download step, but local network download stalled/failed before `go build`; GitHub Actions CI for this PR passed after the Dockerfile change.

## Release impact

- Required before republishing `octo-smart-summary v1.4.0` Docker images.
