### PR TITLE
feat(summary): expose personal workflow stage during summary generation

### DIFF
--- a/internal/api/handler/personal.go
+++ b/internal/api/handler/personal.go
@@ -255,7 +255,10 @@ func (h *PersonalHandler) Accept(c *gin.Context) {
 				prCompleted = true
 			} else if pr.WorkerStatus != model.PersonalStatusPending {
 				if err := tx.Model(&model.PersonalResult{}).Where("id = ?", pr.ID).
-					Update("worker_status", model.PersonalStatusPending).Error; err != nil {
+					Updates(map[string]interface{}{
+						"worker_status":  model.PersonalStatusPending,
+						"workflow_stage": "",
+					}).Error; err != nil {
 					return err
 				}
 			}
@@ -417,22 +420,24 @@ func (h *PersonalHandler) GetPersonal(c *gin.Context) {
 	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
 		// Not found → return default
 		ok(c, gin.H{
-			"worker_status": 0,
-			"content":       "",
-			"submitted_at":  nil,
-			"generated_at":  nil,
-			"msg_count":     0,
+			"worker_status":  0,
+			"workflow_stage": "",
+			"content":        "",
+			"submitted_at":   nil,
+			"generated_at":   nil,
+			"msg_count":      0,
 		})
 		return
 	}
 
 	result := gin.H{
-		"worker_status": pr.WorkerStatus,
-		"content":       pr.Content,
-		"citations":     pr.GetCitations(),
-		"submitted_at":  nil,
-		"generated_at":  nil,
-		"msg_count":     pr.MsgCount,
+		"worker_status":  pr.WorkerStatus,
+		"workflow_stage": pr.WorkflowStage,
+		"content":        pr.Content,
+		"citations":      pr.GetCitations(),
+		"submitted_at":   nil,
+		"generated_at":   nil,
+		"msg_count":      pr.MsgCount,
 	}
 	if pr.SubmittedAt != nil {
 		result["submitted_at"] = pr.SubmittedAt.Format(time.RFC3339)

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -768,13 +768,15 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 
 	var pr model.PersonalResult
 	personalOut := gin.H{
-		"worker_status": 0,
-		"content":       "",
-		"submitted_at":  nil,
+		"worker_status":  0,
+		"workflow_stage": "",
+		"content":        "",
+		"submitted_at":   nil,
 	}
 	if userID != "" {
 		if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err == nil {
 			personalOut["worker_status"] = pr.WorkerStatus
+			personalOut["workflow_stage"] = pr.WorkflowStage
 			personalOut["content"] = pr.Content
 			if pr.SubmittedAt != nil {
 				personalOut["submitted_at"] = pr.SubmittedAt.Format(time.RFC3339)
@@ -962,6 +964,7 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		}
 		if err := tx.Model(&model.PersonalResult{}).Where("task_id = ?", taskID).Updates(map[string]interface{}{
 			"worker_status":  model.PersonalStatusPending,
+			"workflow_stage": "",
 			"content":        "",
 			"citations_json": "",
 			"error_message":  nil,

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -160,6 +160,12 @@ SELECT 1;
 -- +migrate Down
 SELECT 1;
 `)},
+	"20260703-01-add-personal-workflow-stage.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+ALTER TABLE summary_personal_result ADD COLUMN workflow_stage varchar(32) NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE summary_personal_result DROP COLUMN workflow_stage;
+`)},
 }
 
 func testSource() migrate.MigrationSource {
@@ -185,8 +191,8 @@ func TestRunMigrations_NewDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 3 {
-		t.Fatalf("expected 3 migrations applied, got %d", n)
+	if n != 4 {
+		t.Fatalf("expected 4 migrations applied, got %d", n)
 	}
 
 	tables := []string{
@@ -209,6 +215,12 @@ func TestRunMigrations_NewDB(t *testing.T) {
 		if err != nil {
 			t.Errorf("index %s not found: %v", idx, err)
 		}
+	}
+
+	var workflowStageCol string
+	err = db.QueryRow("SELECT name FROM pragma_table_info('summary_personal_result') WHERE name='workflow_stage'").Scan(&workflowStageCol)
+	if err != nil {
+		t.Fatalf("workflow_stage column not found: %v", err)
 	}
 }
 
@@ -247,8 +259,8 @@ func TestRunMigrations_ExistingDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 2 {
-		t.Fatalf("expected 2 migrations applied (006+007), got %d", n)
+	if n != 3 {
+		t.Fatalf("expected 3 migrations applied (006+007+workflow_stage), got %d", n)
 	}
 }
 
@@ -273,8 +285,8 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
-	if n1 != 3 {
-		t.Fatalf("first run: expected 3, got %d", n1)
+	if n1 != 4 {
+		t.Fatalf("first run: expected 4, got %d", n1)
 	}
 
 	n2, err := runMigrationsCore(db, "sqlite3", testSource())

--- a/internal/model/personal_result.go
+++ b/internal/model/personal_result.go
@@ -13,6 +13,14 @@ const (
 	PersonalStatusFailed     = 3
 )
 
+const (
+	WorkflowStageUnderstandQuestion  = "understand_question"
+	WorkflowStageFindRelevantChats   = "find_relevant_chats"
+	WorkflowStageFilterUsefulContent = "filter_useful_content"
+	WorkflowStageAnalyzeChatContent  = "analyze_chat_content"
+	WorkflowStageGenerateSummary     = "generate_summary"
+)
+
 // Participant status constants for by-person mode.
 const (
 	ParticipantPending    = 0
@@ -35,6 +43,7 @@ type PersonalResult struct {
 	TotalTokenUsed   int        `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
 	ModelVersion     string     `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
 	WorkerStatus     int        `gorm:"column:worker_status;type:tinyint;not null;default:0" json:"worker_status"`
+	WorkflowStage    string     `gorm:"column:workflow_stage;type:varchar(32);not null;default:''" json:"workflow_stage"`
 	RetryCount       int        `gorm:"column:retry_count;type:tinyint;not null;default:0" json:"retry_count"`
 	ErrorMessage     *string    `gorm:"column:error_message;type:varchar(500)" json:"error_message"`
 	EditedAt         *time.Time `gorm:"column:edited_at" json:"edited_at"`

--- a/internal/model/personal_result_test.go
+++ b/internal/model/personal_result_test.go
@@ -64,3 +64,18 @@ func TestWorkerTriggerRequestTypes(t *testing.T) {
 		t.Error("expected participant_ref_id 456")
 	}
 }
+
+func TestWorkflowStageConstants(t *testing.T) {
+	tests := []string{
+		WorkflowStageUnderstandQuestion,
+		WorkflowStageFindRelevantChats,
+		WorkflowStageFilterUsefulContent,
+		WorkflowStageAnalyzeChatContent,
+		WorkflowStageGenerateSummary,
+	}
+	for _, stage := range tests {
+		if stage == "" {
+			t.Fatal("workflow stage must not be empty")
+		}
+	}
+}

--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"gorm.io/gorm"
 )
 
@@ -701,10 +702,13 @@ func FilterMessagesByRelevance(messages []Message, topic string, participantUIDs
 // - Target persons (for post-fetch filtering)
 //
 // Returns messages, intent result (for target person filtering), and error.
-func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, participantUIDs []string, participantNames []string, specifiedSources []map[string]interface{}, topic string, timeStart, timeEnd time.Time, imDB *gorm.DB, octoClient octoSearchClient, messageFetchBackend string, toolCallFn LLMToolCallFn, llmFn LLMCallFn, tableCount int, maxPerChannel int, fetchConcurrency int, octoSearchPollSec int, channelScopeOpts *ChannelScopeOptions) ([]Message, *IntentResult, error) {
+func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, participantUIDs []string, participantNames []string, specifiedSources []map[string]interface{}, topic string, timeStart, timeEnd time.Time, imDB *gorm.DB, octoClient octoSearchClient, messageFetchBackend string, toolCallFn LLMToolCallFn, llmFn LLMCallFn, tableCount int, maxPerChannel int, fetchConcurrency int, octoSearchPollSec int, channelScopeOpts *ChannelScopeOptions, reportStage func(string)) ([]Message, *IntentResult, error) {
 	maxDays := DefaultTimeRangeDays
 	if timeEnd.Sub(timeStart) > time.Duration(maxDays)*24*time.Hour {
 		return nil, nil, fmt.Errorf("时间范围不能超过 %d 天", maxDays)
+	}
+	if reportStage != nil {
+		reportStage(model.WorkflowStageUnderstandQuestion)
 	}
 
 	pipelineStart := time.Now()
@@ -766,6 +770,9 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 	}
 	log.Printf("[pipeline-personal] Intent recognition took %dms (skipped=%v)",
 		time.Since(intentStart).Milliseconds(), intentResult.Skipped)
+	if reportStage != nil {
+		reportStage(model.WorkflowStageFindRelevantChats)
+	}
 
 	// Apply time range from intent
 	if intentResult.TimeRange.Narrowed {
@@ -804,6 +811,9 @@ func ResolveAndFetchMessagesForPersonal(ctx context.Context, creatorUID string, 
 	}
 	log.Printf("[pipeline-personal] Layer 4 (%s): fetched %d messages from %d candidates in %dms",
 		messageFetchBackend, len(allMessages), len(candidates), time.Since(fetchStart).Milliseconds())
+	if reportStage != nil {
+		reportStage(model.WorkflowStageFilterUsefulContent)
+	}
 
 	// Layer 4.5: mutual activity filter
 	l45Start := time.Now()

--- a/internal/pipeline/fetch_archive_test.go
+++ b/internal/pipeline/fetch_archive_test.go
@@ -216,7 +216,7 @@ func TestResolveAndFetch_SelectedArchivedThread_ProducesMessages(t *testing.T) {
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, specifiedSources, "",
-		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, 1, nil,
+		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, 1, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -246,7 +246,7 @@ func TestResolveAndFetch_MySQLBackend_UsesLegacyMessageFilter(t *testing.T) {
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, specifiedSources, "",
-		start, end, db, nil, "mysql", nil, nil, 1, 0, 2, 1, nil,
+		start, end, db, nil, "mysql", nil, nil, 1, 0, 2, 1, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -270,7 +270,7 @@ func TestResolveAndFetch_NoSources_ArchivedExcluded(t *testing.T) {
 	// No explicit sources -> auto discovery -> only the active thread's message.
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", nil, nil, nil, "",
-		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, 1, nil,
+		start, end, db, echoOctoClient(), "batch", nil, nil, 1, 0, 2, 1, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)
@@ -377,7 +377,7 @@ func TestResolveAndFetch_MultiPerson_SelectedArchivedThread_Retained(t *testing.
 
 	msgs, _, err := ResolveAndFetchMessagesForPersonal(
 		context.Background(), "user1", []string{"user2"}, nil, specifiedSources, "",
-		start, end, db, echoOctoClient("user1", "user2"), "batch", nil, nil, 1, 0, 2, 1, nil,
+		start, end, db, echoOctoClient("user1", "user2"), "batch", nil, nil, 1, 0, 2, 1, nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("ResolveAndFetchMessagesForPersonal: %v", err)

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -218,6 +218,17 @@ func FlushReport(taskNo string, totalMs int64, extraStages []StageMs) {
 	ts := timezone.Now().Format(time.RFC3339)
 	fmt.Fprintf(&b, "==== 智能总结汇总报告 task_no=%s time=%s ====\n", taskNo, ts)
 
+	if ctx.TaskCreatedToWorkerStartMs > 0 || ctx.PersonalResultCreatedToWorkerStartMs > 0 || ctx.ParticipantCreatedToWorkerStartMs > 0 {
+		fmt.Fprintf(&b, "前置等待: 任务创建→worker开始=%dms 个人结果创建→worker开始=%dms 参与者创建→worker开始=%dms\n",
+			ctx.TaskCreatedToWorkerStartMs, ctx.PersonalResultCreatedToWorkerStartMs, ctx.ParticipantCreatedToWorkerStartMs)
+	}
+	if len(ctx.WorkflowStages) > 0 {
+		b.WriteString("Workflow阶段上报:\n")
+		for _, ws := range ctx.WorkflowStages {
+			fmt.Fprintf(&b, "  stage=%s  距worker开始=%dms  距上一阶段=%dms\n", ws.Stage, ws.SinceWorkerStartMs, ws.DeltaMs)
+		}
+	}
+
 	// Intent recognition section
 	if ctx.IntentSkipped {
 		fmt.Fprintf(&b, "意图识别: 短路=是 原因=%s\n", ctx.IntentSkipReason)
@@ -279,6 +290,13 @@ type StageMs struct {
 	Ms   int64
 }
 
+// WorkflowStageMs records when a user-visible workflow stage was reported.
+type WorkflowStageMs struct {
+	Stage              string
+	SinceWorkerStartMs int64
+	DeltaMs            int64
+}
+
 // ---------------------------------------------------------------------------
 // TaskContext: unified task context for enhanced reporting.
 //
@@ -293,6 +311,14 @@ type StageMs struct {
 type TaskContext struct {
 	mu     sync.Mutex // guards all fields below
 	TaskNo string
+
+	// Pre-worker waiting
+	TaskCreatedToWorkerStartMs           int64 // summary_task.created_at -> personal worker start
+	PersonalResultCreatedToWorkerStartMs int64 // summary_personal_result.created_at -> personal worker start
+	ParticipantCreatedToWorkerStartMs    int64 // summary_participant.created_at -> personal worker start
+
+	// User-visible workflow stages
+	WorkflowStages []WorkflowStageMs
 
 	// Intent recognition
 	IntentSkipped    bool   // true if short-circuited (no LLM)
@@ -327,19 +353,24 @@ func (c *TaskContext) Update(fn func(*TaskContext)) {
 func (c *TaskContext) Snapshot() TaskContext {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	workflowStages := append([]WorkflowStageMs(nil), c.WorkflowStages...)
 	return TaskContext{
-		TaskNo:            c.TaskNo,
-		IntentSkipped:     c.IntentSkipped,
-		IntentSkipReason:  c.IntentSkipReason,
-		IntentLLMCalls:    c.IntentLLMCalls,
-		ChannelCount:      c.ChannelCount,
-		MessagesRetrieved: c.MessagesRetrieved,
-		MessagesFinal:     c.MessagesFinal,
-		TargetPersonCount: c.TargetPersonCount,
-		FilteredCount:     c.FilteredCount,
-		UsedMapReduce:     c.UsedMapReduce,
-		ChunkCount:        c.ChunkCount,
-		TotalTokens:       c.TotalTokens,
+		TaskNo:                               c.TaskNo,
+		TaskCreatedToWorkerStartMs:           c.TaskCreatedToWorkerStartMs,
+		PersonalResultCreatedToWorkerStartMs: c.PersonalResultCreatedToWorkerStartMs,
+		ParticipantCreatedToWorkerStartMs:    c.ParticipantCreatedToWorkerStartMs,
+		WorkflowStages:                       workflowStages,
+		IntentSkipped:                        c.IntentSkipped,
+		IntentSkipReason:                     c.IntentSkipReason,
+		IntentLLMCalls:                       c.IntentLLMCalls,
+		ChannelCount:                         c.ChannelCount,
+		MessagesRetrieved:                    c.MessagesRetrieved,
+		MessagesFinal:                        c.MessagesFinal,
+		TargetPersonCount:                    c.TargetPersonCount,
+		FilteredCount:                        c.FilteredCount,
+		UsedMapReduce:                        c.UsedMapReduce,
+		ChunkCount:                           c.ChunkCount,
+		TotalTokens:                          c.TotalTokens,
 	}
 }
 
@@ -388,4 +419,3 @@ func RecordSkip(taskNo, stage, reason string) {
 	})
 	log.Printf("[timing] task=%s skipped %s (%s)", taskNo, stage, reason)
 }
-

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -54,7 +54,8 @@ func shouldSkipScheduledPlaceholderResult(triggerType int, content string) bool 
 
 func completedPersonalResultUpdates(pr model.PersonalResult, content string, citations []model.Citation, msgCount, totalTokens int, modelVer string, genAt time.Time, skipContent bool) map[string]interface{} {
 	updates := map[string]interface{}{
-		"worker_status": model.PersonalStatusCompleted,
+		"worker_status":  model.PersonalStatusCompleted,
+		"workflow_stage": model.WorkflowStageGenerateSummary,
 	}
 	if skipContent {
 		return updates
@@ -67,6 +68,17 @@ func completedPersonalResultUpdates(pr model.PersonalResult, content string, cit
 	updates["model_version"] = modelVer
 	updates["generated_at"] = genAt
 	return updates
+}
+
+func (p *Processor) updatePersonalWorkflowStage(personalResultID int64, stage string) {
+	if personalResultID == 0 || stage == "" {
+		return
+	}
+	if err := p.db.Model(&model.PersonalResult{}).
+		Where("id = ? AND worker_status = ?", personalResultID, model.PersonalStatusProcessing).
+		Update("workflow_stage", stage).Error; err != nil {
+		log.Printf("[personal-worker] update workflow stage pr=%d stage=%s: %v", personalResultID, stage, err)
+	}
 }
 
 func (p *Processor) processPersonalSummary(ctx context.Context, taskID, participantRefID int64) {
@@ -131,8 +143,54 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		return
 	}
 
+	nonNegativeMs := func(start time.Time) int64 {
+		if start.IsZero() {
+			return 0
+		}
+		d := now.Sub(start)
+		if d < 0 {
+			return 0
+		}
+		return d.Milliseconds()
+	}
+	taskWaitMs := nonNegativeMs(task.CreatedAt)
+	prWaitMs := nonNegativeMs(pr.CreatedAt)
+	participantWaitMs := nonNegativeMs(participant.CreatedAt)
+	timing.GetContext(task.TaskNo).Update(func(c *timing.TaskContext) {
+		c.TaskCreatedToWorkerStartMs = taskWaitMs
+		c.PersonalResultCreatedToWorkerStartMs = prWaitMs
+		c.ParticipantCreatedToWorkerStartMs = participantWaitMs
+	})
+	log.Printf("[personal-worker] pre-worker wait task=%s task_created_to_start=%dms personal_result_created_to_start=%dms participant_created_to_start=%dms",
+		task.TaskNo, taskWaitMs, prWaitMs, participantWaitMs)
+
+	workerStartAt := now
+	lastWorkflowStageAt := workerStartAt
+	reportStage := func(stage string) {
+		stageAt := timezone.Now()
+		sinceWorkerStartMs := stageAt.Sub(workerStartAt).Milliseconds()
+		deltaMs := stageAt.Sub(lastWorkflowStageAt).Milliseconds()
+		if sinceWorkerStartMs < 0 {
+			sinceWorkerStartMs = 0
+		}
+		if deltaMs < 0 {
+			deltaMs = 0
+		}
+		lastWorkflowStageAt = stageAt
+		timing.GetContext(task.TaskNo).Update(func(c *timing.TaskContext) {
+			c.WorkflowStages = append(c.WorkflowStages, timing.WorkflowStageMs{
+				Stage:              stage,
+				SinceWorkerStartMs: sinceWorkerStartMs,
+				DeltaMs:            deltaMs,
+			})
+		})
+		log.Printf("[personal-worker] workflow stage task=%s pr=%d stage=%s since_worker_start=%dms delta=%dms",
+			task.TaskNo, pr.ID, stage, sinceWorkerStartMs, deltaMs)
+		p.updatePersonalWorkflowStage(pr.ID, stage)
+	}
+
 	// Execute pipeline
-	content, citations, msgCount, totalTokens, modelVer, err := p.executePersonalPipeline(ctx, task, participant.UserID)
+	content, citations, msgCount, totalTokens, modelVer, err := p.executePersonalPipeline(ctx, task, participant.UserID, reportStage)
 	if err != nil {
 		log.Printf("[personal-worker] pipeline error task=%d user=%s: %v", taskID, participant.UserID, err)
 		p.markPersonalFailed(&pr, &participant, err.Error())
@@ -345,8 +403,9 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 			// retry_count was already atomically incremented above; only the remaining
 			// columns are written here (do not re-set retry_count to an app-layer value).
 			if err := tx.Model(pr).Updates(map[string]interface{}{
-				"worker_status": model.PersonalStatusPending,
-				"error_message": &sanitized,
+				"worker_status":  model.PersonalStatusPending,
+				"workflow_stage": "",
+				"error_message":  &sanitized,
 			}).Error; err != nil {
 				return err
 			}
@@ -449,7 +508,7 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }
 
-func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string) (string, []model.Citation, int, int, string, error) {
+func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string)) (string, []model.Citation, int, int, string, error) {
 	totalStart := time.Now()
 	taskNo := task.TaskNo
 	defer func() {
@@ -510,7 +569,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		task.TimeRangeStart, task.TimeRangeEnd,
 		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn,
 		p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency, p.cfg.OctoSearchPollSec,
-		channelScopeOpts,
+		channelScopeOpts, reportStage,
 	)
 	timing.Observe(taskNo, "fetch_messages", fetchStart)
 	if err != nil {
@@ -648,6 +707,10 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		targetMsgCount = len(userMessages)
 	}
 
+	if reportStage != nil {
+		reportStage(model.WorkflowStageAnalyzeChatContent)
+	}
+
 	// Create tokenizer for token counting
 	tokCfg := tokenizer.Config{
 		CharsPerTokenCJK:   p.cfg.ResolveCharsPerTokenCJK(),
@@ -760,6 +823,10 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 				escapeCitationMarkers(m.Content)))
 		}
 
+		if reportStage != nil {
+			reportStage(model.WorkflowStageGenerateSummary)
+		}
+
 		mapStart := time.Now()
 		mapCallStart := time.Now()
 		var err error
@@ -795,6 +862,12 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		results := make([]chunkResult, len(chunks))
 		mapSem := make(chan struct{}, concurrency)
 		var mapWg sync.WaitGroup
+
+		if len(chunks) == 1 && reportStage != nil {
+			// Single-chunk fast path: the Map call produces the final user-facing summary.
+			// Attribute its latency to generate_summary instead of analyze_chat_content.
+			reportStage(model.WorkflowStageGenerateSummary)
+		}
 
 		mapStart := time.Now()
 		for i, chunk := range chunks {
@@ -861,6 +934,10 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		}
 		if len(chunkSummaries) == 0 && len(results) > 0 {
 			return "", nil, 0, 0, "", fmt.Errorf("all %d chunk(s) failed during Map phase (LLM unreachable)", len(results))
+		}
+
+		if len(chunks) > 1 && reportStage != nil {
+			reportStage(model.WorkflowStageGenerateSummary)
 		}
 
 		// Reduce phase

--- a/internal/worker/personal_processor_test.go
+++ b/internal/worker/personal_processor_test.go
@@ -90,6 +90,18 @@ func TestDecidePersonalMessages_FilteredEmpty_SelfPlusOther_FallsBackToAll(t *te
 	}
 }
 
+func TestCompletedPersonalResultUpdates_SetGenerateStageOnAllPaths(t *testing.T) {
+	now := time.Now()
+	full := completedPersonalResultUpdates(model.PersonalResult{}, "content", nil, 3, 10, "model", now, false)
+	if full["workflow_stage"] != model.WorkflowStageGenerateSummary {
+		t.Fatalf("full workflow_stage=%v", full["workflow_stage"])
+	}
+	skip := completedPersonalResultUpdates(model.PersonalResult{}, "content", nil, 3, 10, "model", now, true)
+	if skip["workflow_stage"] != model.WorkflowStageGenerateSummary {
+		t.Fatalf("skip workflow_stage=%v", skip["workflow_stage"])
+	}
+}
+
 // normalizeTargetMsgCount mirrors the F1 fix in executePersonalPipeline: on
 // untrimmed / fallback paths no message has IsTargetUser set, so the accumulated
 // count is 0 and must be normalized to the full message count.
@@ -306,6 +318,7 @@ func seedFailFixture(t *testing.T, db *gorm.DB, taskNo string, participantCount,
 		pr := model.PersonalResult{
 			TaskID: task.ID, ParticipantRefID: part.ID, UserID: userIDForIdx(i),
 			WorkerStatus: model.PersonalStatusProcessing, RetryCount: retryCount,
+			WorkflowStage: model.WorkflowStageFilterUsefulContent,
 		}
 		if err := db.Create(&pr).Error; err != nil {
 			t.Fatalf("create personal_result: %v", err)
@@ -336,6 +349,9 @@ func TestMarkPersonalFailed_UnderMaxRetry_ResetsToPending(t *testing.T) {
 	if gotPR.RetryCount != 1 {
 		t.Errorf("retry_count=%d, want 1", gotPR.RetryCount)
 	}
+	if gotPR.WorkflowStage != "" {
+		t.Errorf("workflow_stage=%q, want empty after retry reset", gotPR.WorkflowStage)
+	}
 	var gotPart model.SummaryParticipant
 	db.First(&gotPart, part.ID)
 	if gotPart.Status != model.ParticipantAccepted {
@@ -343,6 +359,41 @@ func TestMarkPersonalFailed_UnderMaxRetry_ResetsToPending(t *testing.T) {
 	}
 	if gotPart.WorkerStartedAt != nil {
 		t.Errorf("worker_started_at should be cleared on retry reset, got %v", gotPart.WorkerStartedAt)
+	}
+}
+
+func TestUpdatePersonalWorkflowStage_GuardsProcessingStatus(t *testing.T) {
+	db := newSchedulerTestDB(t)
+	now := time.Now()
+	processing := model.PersonalResult{
+		TaskID: 1, ParticipantRefID: 1, UserID: "u1",
+		WorkerStatus: model.PersonalStatusProcessing,
+		CreatedAt:    now, UpdatedAt: now,
+	}
+	completed := model.PersonalResult{
+		TaskID: 1, ParticipantRefID: 2, UserID: "u2",
+		WorkerStatus: model.PersonalStatusCompleted,
+		CreatedAt:    now, UpdatedAt: now,
+	}
+	if err := db.Create(&processing).Error; err != nil {
+		t.Fatalf("create processing pr: %v", err)
+	}
+	if err := db.Create(&completed).Error; err != nil {
+		t.Fatalf("create completed pr: %v", err)
+	}
+
+	p := &Processor{db: db}
+	p.updatePersonalWorkflowStage(processing.ID, model.WorkflowStageFindRelevantChats)
+	p.updatePersonalWorkflowStage(completed.ID, model.WorkflowStageFindRelevantChats)
+
+	var gotProcessing, gotCompleted model.PersonalResult
+	db.First(&gotProcessing, processing.ID)
+	db.First(&gotCompleted, completed.ID)
+	if gotProcessing.WorkflowStage != model.WorkflowStageFindRelevantChats {
+		t.Fatalf("processing workflow_stage=%q", gotProcessing.WorkflowStage)
+	}
+	if gotCompleted.WorkflowStage != "" {
+		t.Fatalf("completed workflow_stage=%q, want unchanged", gotCompleted.WorkflowStage)
 	}
 }
 
@@ -476,7 +527,7 @@ func TestMarkPersonalFailed_ConcurrentRetry_NoLostIncrement(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			prCopy := pr           // each worker gets its own struct (mirrors real workers)
+			prCopy := pr // each worker gets its own struct (mirrors real workers)
 			partCopy := part
 			p.markPersonalFailed(&prCopy, &partCopy, "LLM API error: boom")
 		}()

--- a/internal/worker/personal_workflow_stage_nocgo_test.go
+++ b/internal/worker/personal_workflow_stage_nocgo_test.go
@@ -1,0 +1,22 @@
+//go:build !cgo
+
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+func TestCompletedPersonalResultUpdates_WorkflowStageNoCGO(t *testing.T) {
+	now := time.Now()
+	full := completedPersonalResultUpdates(model.PersonalResult{}, "content", nil, 3, 10, "model", now, false)
+	if full["workflow_stage"] != model.WorkflowStageGenerateSummary {
+		t.Fatalf("full workflow_stage=%v", full["workflow_stage"])
+	}
+	skip := completedPersonalResultUpdates(model.PersonalResult{}, "content", nil, 3, 10, "model", now, true)
+	if skip["workflow_stage"] != model.WorkflowStageGenerateSummary {
+		t.Fatalf("skip workflow_stage=%v", skip["workflow_stage"])
+	}
+}

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -754,7 +754,7 @@ func (p *Processor) executePipeline(task model.SummaryTask) error {
 		ctx, task.CreatorID, participantUIDs, participantNames, specifiedSources, task.Title,
 		task.TimeRangeStart, task.TimeRangeEnd,
 		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn, p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency, p.cfg.OctoSearchPollSec,
-		channelScopeOpts,
+		channelScopeOpts, nil,
 	)
 	timing.Observe(task.TaskNo, "fetch_messages", fetchStart)
 	if err != nil {

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -444,7 +444,10 @@ func scanStuckPersonalTasks(db *gorm.DB, workerTriggerURL string) {
 		// Reset personal_result to PENDING
 		db.Model(&model.PersonalResult{}).
 			Where("participant_ref_id = ? AND worker_status = ?", p.ID, model.PersonalStatusProcessing).
-			Update("worker_status", model.PersonalStatusPending)
+			Updates(map[string]interface{}{
+				"worker_status":  model.PersonalStatusPending,
+				"workflow_stage": "",
+			})
 		// Reset participant to accepted
 		db.Model(&p).Updates(map[string]interface{}{
 			"status":            model.ParticipantAccepted,

--- a/migrations/sql/20260703-01-add-personal-workflow-stage.sql
+++ b/migrations/sql/20260703-01-add-personal-workflow-stage.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE `summary_personal_result`
+  ADD COLUMN `workflow_stage` varchar(32) NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE `summary_personal_result`
+  DROP COLUMN `workflow_stage`;


### PR DESCRIPTION
Closes #141

## Summary
Adds a `workflow_stage` field so the frontend can show which step of personal summary generation is currently running. The worker reports each stage as it progresses, and the value is exposed through the personal-result and summary-detail APIs.

## Root Cause
The five-step summary flow only persisted coarse `worker_status`. Long-running LLM steps (topic resolution, Map summarization) leave no fine-grained signal, so the UI cannot reflect the active step and appears idle during those seconds.

## Changes
- **Model**: add `WorkflowStage*` constants and a `workflow_stage varchar(32) NOT NULL DEFAULT ''` column on the personal result.
- **Migration** (`20260703-01-add-personal-workflow-stage.sql`): add the column; Down drops it.
- **Worker**: `reportStage` records timing and updates `workflow_stage` (only for rows whose worker_status is PROCESSING); stages reported across fetch (understand/find/filter) and processor (analyze/generate).
- **Reset paths**: clear `workflow_stage` on accept/re-accept (Accept), regenerate (Regenerate), stuck-task rescan (scanStuckPersonalTasks), and retry reset (markPersonalFailed willRetry branch).
- **API**: `GetPersonal` and `GetSummary` return `workflow_stage` (defaults to "" when absent).

## Testing
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go test ./internal/...`
- Focused: `go test ./internal/timing ./internal/worker ./internal/model ./internal/pipeline`

## Impact / Risk
Additive column with a safe default; no behavior change for existing consumers. Frontend can opt in to read the field.