### PR TITLE
feat(schedule): validate source access on Create/Update schedule (#143)

### DIFF
--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/gin-gonic/gin"
@@ -21,13 +22,15 @@ import (
 
 // ScheduleHandler handles schedule endpoints.
 type ScheduleHandler struct {
-	db *gorm.DB
+	db   *gorm.DB
+	imDB *gorm.DB // IM database; used for user-access validation on write. nil = access check bypassed (test paths).
 	// featureTeamSchedule, when true, bypasses the multi-person rejection guards
 	// (FEATURE_TEAM_SCHEDULE). Default false keeps the existing 40015 behavior.
 	featureTeamSchedule bool
 }
 
 // NewScheduleHandler creates a new ScheduleHandler.
+// Retained for backwards compatibility with tests that don't need IM-DB access checks.
 func NewScheduleHandler(db *gorm.DB) *ScheduleHandler {
 	return &ScheduleHandler{db: db}
 }
@@ -35,8 +38,53 @@ func NewScheduleHandler(db *gorm.DB) *ScheduleHandler {
 // NewScheduleHandlerWithFlag creates a ScheduleHandler with the team-schedule
 // feature flag explicitly set. When featureTeamSchedule is true the multi-person
 // rejection guards are bypassed so multi-participant schedules can be created.
+// Retained for backwards compatibility with tests that don't need IM-DB access checks.
 func NewScheduleHandlerWithFlag(db *gorm.DB, featureTeamSchedule bool) *ScheduleHandler {
 	return &ScheduleHandler{db: db, featureTeamSchedule: featureTeamSchedule}
+}
+
+// NewScheduleHandlerWithIMDB is the production constructor; wires the IM DB so
+// Create/Update can run source-access validation. imDB==nil is tolerated and
+// disables the access check (see pipeline.ValidateUserAccessibleSources).
+func NewScheduleHandlerWithIMDB(db, imDB *gorm.DB, featureTeamSchedule bool) *ScheduleHandler {
+	return &ScheduleHandler{db: db, imDB: imDB, featureTeamSchedule: featureTeamSchedule}
+}
+
+// sourceReqsToPipelineRefs converts handler-private sourceReq entries into the
+// pipeline access-check shape. Kept inline so sourceReq stays package-private.
+func sourceReqsToPipelineRefs(in []sourceReq) []pipeline.SourceRef {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]pipeline.SourceRef, 0, len(in))
+	for _, s := range in {
+		out = append(out, pipeline.SourceRef{
+			SourceType: s.SourceType,
+			SourceID:   s.SourceID,
+			SourceName: s.SourceName,
+		})
+	}
+	return out
+}
+
+// respondSourceAccessDenied writes the canonical 40017 response for a
+// non-empty missing-sources list: HTTP 403, code 40017, generic message, and
+// data.missing_sources with per-entry (source_type, source_id, source_name)
+// so the frontend can pinpoint offenders without trusting client-supplied text.
+func respondSourceAccessDenied(c *gin.Context, missing []pipeline.SourceRef) {
+	items := make([]map[string]interface{}, 0, len(missing))
+	for _, m := range missing {
+		items = append(items, map[string]interface{}{
+			"source_type": m.SourceType,
+			"source_id":   m.SourceID,
+			"source_name": m.SourceName,
+		})
+	}
+	c.JSON(http.StatusForbidden, apiResponse{
+		Code:    40017,
+		Message: "存在无权访问或不存在的来源",
+		Data:    map[string]interface{}{"missing_sources": items},
+	})
 }
 
 type createScheduleReq struct {
@@ -533,6 +581,18 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		return
 	}
 	summaryMode := model.ModeByPerson
+
+	// Source-access check (same contract as UpdateSchedule): reject sources the
+	// user cannot see before persisting. imDB==nil bypasses (test path).
+	if len(req.Sources) > 0 {
+		if missing, err := pipeline.ValidateUserAccessibleSources(c.Request.Context(), userID, h.imDB, sourceReqsToPipelineRefs(req.Sources)); err != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "source access check failed: " + err.Error()})
+			return
+		} else if len(missing) > 0 {
+			respondSourceAccessDenied(c, missing)
+			return
+		}
+	}
 
 	var sourceConfig model.JSON
 	if len(req.Sources) > 0 {
@@ -1137,6 +1197,15 @@ func (h *ScheduleHandler) UpdateSchedule(c *gin.Context) {
 		updates["time_range_type"] = *req.TimeRangeType
 	}
 	if req.Sources != nil {
+		// Source-access check: reject sources the user cannot see (unbound / no
+		// membership / deleted / archived non-thread). imDB==nil bypasses (test path).
+		if missing, err := pipeline.ValidateUserAccessibleSources(c.Request.Context(), userID, h.imDB, sourceReqsToPipelineRefs(req.Sources)); err != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "source access check failed: " + err.Error()})
+			return
+		} else if len(missing) > 0 {
+			respondSourceAccessDenied(c, missing)
+			return
+		}
 		b, _ := json.Marshal(req.Sources)
 		updates["source_config"] = model.JSON(b)
 	}

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -586,7 +586,10 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 	// user cannot see before persisting. imDB==nil bypasses (test path).
 	if len(req.Sources) > 0 {
 		if missing, err := pipeline.ValidateUserAccessibleSources(c.Request.Context(), userID, h.imDB, sourceReqsToPipelineRefs(req.Sources)); err != nil {
-			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "source access check failed: " + err.Error()})
+			// Log the underlying cause server-side; response stays generic so we
+			// don't leak IM DB errors / SQL details to the caller.
+			log.Printf("[handler] CreateSchedule source access check: %v", err)
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "source access check unavailable"})
 			return
 		} else if len(missing) > 0 {
 			respondSourceAccessDenied(c, missing)
@@ -1200,7 +1203,8 @@ func (h *ScheduleHandler) UpdateSchedule(c *gin.Context) {
 		// Source-access check: reject sources the user cannot see (unbound / no
 		// membership / deleted / archived non-thread). imDB==nil bypasses (test path).
 		if missing, err := pipeline.ValidateUserAccessibleSources(c.Request.Context(), userID, h.imDB, sourceReqsToPipelineRefs(req.Sources)); err != nil {
-			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "source access check failed: " + err.Error()})
+			log.Printf("[handler] UpdateSchedule source access check: %v", err)
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "source access check unavailable"})
 			return
 		} else if len(missing) > 0 {
 			respondSourceAccessDenied(c, missing)

--- a/internal/api/handler/schedule_source_access_test.go
+++ b/internal/api/handler/schedule_source_access_test.go
@@ -1,0 +1,223 @@
+//go:build cgo
+
+package handler
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// The schedule source-access tests need the pipeline.GetUserChannels query set
+// to run under SQLite; that query joins with COLLATE utf8mb4_unicode_ci which
+// SQLite doesn't know about. Register a driver variant that knows it. Keeping
+// this local (rather than importing the pipeline test-helper) avoids leaking
+// _test.go symbols across packages.
+
+var accessCollateOnce sync.Once
+
+const accessCollateDriver = "sqlite3_handler_access_collate"
+
+func registerAccessCollateDriver() {
+	accessCollateOnce.Do(func() {
+		sql.Register(accessCollateDriver, &sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				return conn.RegisterCollation("utf8mb4_unicode_ci", func(a, b string) int {
+					switch {
+					case a < b:
+						return -1
+					case a > b:
+						return 1
+					default:
+						return 0
+					}
+				})
+			},
+		})
+	})
+}
+
+// newAccessTestIMDB stands up a minimal IM schema for the source-access check.
+func newAccessTestIMDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	registerAccessCollateDriver()
+	db, err := gorm.Open(sqlite.Dialector{DriverName: accessCollateDriver, DSN: ":memory:"}, &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open access im db: %v", err)
+	}
+	if sqlDB, e := db.DB(); e == nil {
+		sqlDB.SetMaxOpenConns(1)
+	}
+	db.Exec(`CREATE TABLE "group" (group_no TEXT NOT NULL, name TEXT, space_id TEXT, status INTEGER DEFAULT 1, creator TEXT, updated_at INTEGER DEFAULT 0)`)
+	db.Exec(`CREATE TABLE thread (id INTEGER PRIMARY KEY, short_id TEXT, name TEXT, group_no TEXT, status INTEGER DEFAULT 1, message_count INTEGER DEFAULT 0, creator_uid TEXT, updated_at INTEGER DEFAULT 0)`)
+	db.Exec(`CREATE TABLE thread_member (thread_id INTEGER NOT NULL, uid TEXT NOT NULL)`)
+	db.Exec(`CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0, role INTEGER DEFAULT 0)`)
+	db.Exec(`CREATE TABLE conversation_extra (uid TEXT, channel_id TEXT, channel_type INTEGER, updated_at INTEGER DEFAULT 0)`)
+	// Seed a single accessible group for uid1.
+	db.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp_ok','g',1)`)
+	db.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp_ok','u1',0)`)
+	return db
+}
+
+// newAccessTestRouter wires ScheduleHandler with a real IM DB so the access
+// check actually runs (in contrast to newScheduleTestRouter which uses nil imDB).
+func newAccessTestRouter(db, imDB *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	sh := NewScheduleHandlerWithIMDB(db, imDB, false)
+	r.POST("/api/v1/summary-schedules", sh.CreateSchedule)
+	r.PUT("/api/v1/summary-schedules/:id", sh.UpdateSchedule)
+	return r
+}
+
+// TestCreateSchedule_SourceAccessAccept: creating a schedule with an accessible
+// source succeeds and persists source_config.
+func TestCreateSchedule_SourceAccessAccept(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newAccessTestIMDB(t)
+	r := newAccessTestRouter(db, imDB)
+	taskID := seedScheduleTask(t, db, "T-acc-c1", "s1", "u1")
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"interval_days": 1, "run_time": "09:00",
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "grp_ok", "source_name": "g"}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	// Confirm persisted.
+	var sched model.SummarySchedule
+	if err := db.Where("space_id = ?", "s1").First(&sched).Error; err != nil {
+		t.Fatalf("schedule not persisted: %v", err)
+	}
+	if len(sched.SourceConfig) == 0 {
+		t.Fatalf("expected source_config persisted, got empty")
+	}
+}
+
+// TestCreateSchedule_SourceAccessDenied: creating a schedule with a source the
+// user has no membership on gets 403/40017 with data.missing_sources populated.
+func TestCreateSchedule_SourceAccessDenied(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newAccessTestIMDB(t)
+	r := newAccessTestRouter(db, imDB)
+	taskID := seedScheduleTask(t, db, "T-acc-c2", "s1", "u1")
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"interval_days": 1, "run_time": "09:00",
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "grp_forbidden", "source_name": "?"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    struct {
+			MissingSources []map[string]interface{} `json:"missing_sources"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Code != 40017 {
+		t.Fatalf("expected code 40017, got %d", resp.Code)
+	}
+	if len(resp.Data.MissingSources) != 1 {
+		t.Fatalf("expected 1 missing_sources entry, got %v", resp.Data.MissingSources)
+	}
+	if resp.Data.MissingSources[0]["source_id"] != "grp_forbidden" {
+		t.Fatalf("missing_sources[0].source_id=%v", resp.Data.MissingSources[0]["source_id"])
+	}
+	// Nothing persisted.
+	var count int64
+	db.Model(&model.SummarySchedule{}).Where("space_id = ?", "s1").Count(&count)
+	if count != 0 {
+		t.Fatalf("expected no schedule persisted, got %d", count)
+	}
+}
+
+// TestUpdateSchedule_SourceAccessAccept: editing an existing schedule to an
+// accessible source succeeds and updates source_config.
+func TestUpdateSchedule_SourceAccessAccept(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newAccessTestIMDB(t)
+	r := newAccessTestRouter(db, imDB)
+	taskID := seedScheduleTask(t, db, "T-acc-u1", "s1", "u1")
+
+	// Seed a schedule owned by u1 with no sources.
+	sched := model.SummarySchedule{
+		SpaceID: "s1", CreatorID: "u1", Title: "t",
+		SummaryMode: model.ModeByPerson, IntervalDays: 1, RunTime: "09:00",
+	}
+	if err := db.Create(&sched).Error; err != nil {
+		t.Fatalf("seed schedule: %v", err)
+	}
+	// Bind schedule to the seeded task so the UpdateSchedule tx path is happy.
+	db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("schedule_id", sched.ID)
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+strconv.FormatInt(sched.ID, 10), map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "grp_ok", "source_name": "g"}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var reloaded model.SummarySchedule
+	if err := db.First(&reloaded, sched.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(reloaded.SourceConfig) == 0 {
+		t.Fatalf("expected source_config populated, got empty")
+	}
+}
+
+// TestUpdateSchedule_SourceAccessDenied: editing an existing schedule to an
+// unaccessible source returns 403/40017 and does NOT modify source_config.
+func TestUpdateSchedule_SourceAccessDenied(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newAccessTestIMDB(t)
+	r := newAccessTestRouter(db, imDB)
+	taskID := seedScheduleTask(t, db, "T-acc-u2", "s1", "u1")
+
+	// Seed schedule with an existing (accessible) source.
+	prevSourceCfg, _ := json.Marshal([]map[string]interface{}{{"source_type": 1, "source_id": "grp_ok", "source_name": "g"}})
+	sched := model.SummarySchedule{
+		SpaceID: "s1", CreatorID: "u1", Title: "t",
+		SummaryMode: model.ModeByPerson, IntervalDays: 1, RunTime: "09:00",
+		SourceConfig: model.JSON(prevSourceCfg),
+	}
+	if err := db.Create(&sched).Error; err != nil {
+		t.Fatalf("seed schedule: %v", err)
+	}
+	db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("schedule_id", sched.ID)
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+strconv.FormatInt(sched.ID, 10), map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "grp_forbidden", "source_name": "?"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	var reloaded model.SummarySchedule
+	if err := db.First(&reloaded, sched.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	// source_config must remain unchanged.
+	if string(reloaded.SourceConfig) != string(prevSourceCfg) {
+		t.Fatalf("source_config mutated on denied update: got=%s want=%s", reloaded.SourceConfig, prevSourceCfg)
+	}
+}

--- a/internal/api/handler/schedule_source_access_test.go
+++ b/internal/api/handler/schedule_source_access_test.go
@@ -221,3 +221,35 @@ func TestUpdateSchedule_SourceAccessDenied(t *testing.T) {
 		t.Fatalf("source_config mutated on denied update: got=%s want=%s", reloaded.SourceConfig, prevSourceCfg)
 	}
 }
+
+// TestCreateSchedule_SourceAccessQueryFailure500 asserts that when the IM DB
+// itself errors (fail-closed strict path), the handler surfaces HTTP 500 with
+// a non-40017 code instead of leaking a false 40017. Regression guard for
+// reviewer thread e0640d10.
+func TestCreateSchedule_SourceAccessQueryFailure500(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newAccessTestIMDB(t)
+	// Drop the DM table so the strict helper's DM query fails; group query still
+	// succeeds (source is a group), but the DM sub-query error must propagate.
+	imDB.Exec(`DROP TABLE conversation_extra`)
+	r := newAccessTestRouter(db, imDB)
+	taskID := seedScheduleTask(t, db, "T-acc-err", "s1", "u1")
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"interval_days": 1, "run_time": "09:00",
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "grp_ok", "source_name": "g"}},
+	})
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on IM query failure, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Code == 40017 {
+		t.Fatalf("must not surface 40017 on IM failure (would be false-positive access denial)")
+	}
+}

--- a/internal/api/handler/schedule_source_access_test.go
+++ b/internal/api/handler/schedule_source_access_test.go
@@ -229,9 +229,10 @@ func TestUpdateSchedule_SourceAccessDenied(t *testing.T) {
 func TestCreateSchedule_SourceAccessQueryFailure500(t *testing.T) {
 	db := newScheduleTestDB(t)
 	imDB := newAccessTestIMDB(t)
-	// Drop the DM table so the strict helper's DM query fails; group query still
-	// succeeds (source is a group), but the DM sub-query error must propagate.
-	imDB.Exec(`DROP TABLE conversation_extra`)
+	// Drop the group table so the strict helper's group query fails. Any IM
+	// query error must propagate as 500, never surface as 40017 (which would
+	// let an IM outage synthesize a false access denial).
+	imDB.Exec("DROP TABLE `group`")
 	r := newAccessTestRouter(db, imDB)
 	taskID := seedScheduleTask(t, db, "T-acc-err", "s1", "u1")
 
@@ -251,5 +252,42 @@ func TestCreateSchedule_SourceAccessQueryFailure500(t *testing.T) {
 	}
 	if resp.Code == 40017 {
 		t.Fatalf("must not surface 40017 on IM failure (would be false-positive access denial)")
+	}
+}
+
+// TestCreateSchedule_SourceAccessNilIMDB500 asserts the end-to-end fail-closed
+// contract when the handler was wired without an IM DB (production behavior
+// when IM DB connection failed at startup — cmd/summary-api/main.go:61-64).
+// Any Create with sources must be rejected as HTTP 500, never accepted.
+// Regression guard for upstream review round-1 P1 (imDB==nil production
+// fail-open).
+func TestCreateSchedule_SourceAccessNilIMDB500(t *testing.T) {
+	db := newScheduleTestDB(t)
+	r := newAccessTestRouter(db, nil) // imDB=nil mirrors "IM DB unavailable" wiring
+	taskID := seedScheduleTask(t, db, "T-acc-nil", "s1", "u1")
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID,
+		"interval_days": 1, "run_time": "09:00",
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "grp_any", "source_name": "?"}},
+	})
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when imDB==nil (fail-closed), got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Code == 40017 {
+		t.Fatalf("must not surface 40017 when imDB is unavailable (would be a false access denial)")
+	}
+	// Response must not leak raw DB / err.Error() to caller. Sentinel: our
+	// canonical wording is "source access check unavailable"; the leaked form
+	// used to be "source access check failed: ...".
+	if want := "source access check unavailable"; resp.Message != want {
+		t.Fatalf("response Message should be the sanitized form %q, got %q", want, resp.Message)
 	}
 }

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -37,7 +37,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 
 	// API routes
 	taskH := handler.NewTaskHandler(db, imDB, workerTriggerURL)
-	schedH := handler.NewScheduleHandlerWithFlag(db, featureTeamSchedule)
+	schedH := handler.NewScheduleHandlerWithIMDB(db, imDB, featureTeamSchedule)
 	personalH := handler.NewPersonalHandler(db, workerTriggerURL, hub)
 	editH := handler.NewEditHandler(db)
 

--- a/internal/pipeline/access.go
+++ b/internal/pipeline/access.go
@@ -1,0 +1,106 @@
+package pipeline
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// Source-type encoding used by summary/schedule sourceReq:
+//   1 = group, 2 = thread, 3 = DM
+// pipeline ChannelType encoding used by GetUserChannels:
+//   1 = DM, 2 = group, 5 = thread
+// The mapping stays private to this file.
+
+// SourceRef is the pipeline-side view of a summary/schedule source entry.
+// It exists so callers (handlers) don't have to expose their private request
+// struct just to run the access check.
+type SourceRef struct {
+	SourceType int // 1=group, 2=thread, 3=DM
+	SourceID   string
+	SourceName string
+}
+
+// sourceKey normalizes a SourceRef into a lookup key comparable against the
+// keys produced from GetUserChannels output. DM ids are folded through
+// NormalizeDMChannelID so peer/peer@self/self@peer all collapse to one key.
+func (s SourceRef) sourceKey(selfUID string) (channelType int, channelID string) {
+	switch s.SourceType {
+	case 1: // group -> pipeline group
+		return 2, s.SourceID
+	case 2: // thread -> pipeline thread
+		return 5, s.SourceID
+	case 3: // DM -> pipeline DM (normalize peer id)
+		return 1, NormalizeDMChannelID(s.SourceID, selfUID, 1)
+	default:
+		return 0, s.SourceID
+	}
+}
+
+// ValidateUserAccessibleSources checks each entry in sources against the
+// authoritative user-accessible channel set (GetUserChannels). Returns the
+// subset that is NOT accessible; callers turn a non-empty missing list into
+// a 40017 business error.
+//
+// imDB==nil is a permissive fallback (mirrors ResolveSourceNameWithType) so
+// unit-test paths that skip the IM DB stay green. sources empty -> no work,
+// nil missing.
+func ValidateUserAccessibleSources(ctx context.Context, uid string, imDB *gorm.DB, sources []SourceRef) ([]SourceRef, error) {
+	if imDB == nil || len(sources) == 0 {
+		return nil, nil
+	}
+
+	// Pass explicitly-selected thread ids to GetUserChannels so an archived
+	// thread the user is legitimately editing (e.g. keeping it in a schedule)
+	// still shows up in the accessible set. Non-thread entries are ignored
+	// by the underlying query.
+	var selectedThreadIDs []string
+	for _, s := range sources {
+		if s.SourceType == 2 && s.SourceID != "" {
+			selectedThreadIDs = append(selectedThreadIDs, s.SourceID)
+		}
+	}
+
+	channels, err := GetUserChannels(ctx, uid, imDB, selectedThreadIDs...)
+	if err != nil {
+		return nil, err
+	}
+
+	// (channel_type, channel_id) set of what the user can see.
+	allowed := make(map[[2]string]struct{}, len(channels))
+	for _, ch := range channels {
+		key := [2]string{itoa2(ch.ChannelType), ch.ChannelID}
+		allowed[key] = struct{}{}
+	}
+
+	var missing []SourceRef
+	for _, s := range sources {
+		ct, cid := s.sourceKey(uid)
+		if ct == 0 {
+			// Unknown source_type is treated as inaccessible; handler-side
+			// validation should reject unknown types earlier, but fail closed
+			// here rather than silently pass.
+			missing = append(missing, s)
+			continue
+		}
+		if _, ok := allowed[[2]string{itoa2(ct), cid}]; !ok {
+			missing = append(missing, s)
+		}
+	}
+	return missing, nil
+}
+
+// itoa2 is a stdlib-free tiny int-to-string for our fixed set of channel
+// types (1/2/5). Avoids pulling strconv just for one call site.
+func itoa2(n int) string {
+	switch n {
+	case 1:
+		return "1"
+	case 2:
+		return "2"
+	case 5:
+		return "5"
+	default:
+		return "?"
+	}
+}

--- a/internal/pipeline/access.go
+++ b/internal/pipeline/access.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -61,7 +62,11 @@ func ValidateUserAccessibleSources(ctx context.Context, uid string, imDB *gorm.D
 		}
 	}
 
-	channels, err := GetUserChannels(ctx, uid, imDB, selectedThreadIDs...)
+	// Write path is fail-closed: any IM query failure short-circuits to an
+	// error (surfaced as HTTP 500 by callers) so a partial visibility set can't
+	// masquerade as "no access" and cause false 403/40017. Read paths keep the
+	// permissive GetUserChannels intact (see reviewer thread e0640d10).
+	channels, err := getUserChannelsStrict(ctx, uid, imDB, selectedThreadIDs...)
 	if err != nil {
 		return nil, err
 	}
@@ -103,4 +108,122 @@ func itoa2(n int) string {
 	default:
 		return "?"
 	}
+}
+
+// getUserChannelsStrict is the write-path variant of GetUserChannels: any
+// group/DM/thread query failure returns an error instead of the permissive
+// log-and-continue used by read paths. Kept in this file rather than folded
+// back into GetUserChannels because the five existing read-path callers rely
+// on the fail-open degradation to tolerate transient IM outages; changing that
+// contract would ripple far outside this fix (reviewer thread e0640d10).
+//
+// Semantics otherwise mirror GetUserChannels verbatim (same SQL, same
+// selectedThreadIDs scoping for archived threads, same DM normalization).
+func getUserChannelsStrict(ctx context.Context, uid string, imDB *gorm.DB, selectedThreadIDs ...string) ([]ChannelInfo, error) {
+	if imDB == nil {
+		return nil, fmt.Errorf("IM database not available")
+	}
+
+	var channels []ChannelInfo
+
+	// Groups
+	type groupRow struct {
+		ChannelID   string `gorm:"column:channel_id"`
+		ChannelType int    `gorm:"column:channel_type"`
+		ChannelName string `gorm:"column:channel_name"`
+		SpaceID     string `gorm:"column:space_id"`
+	}
+	var groups []groupRow
+	err := imDB.WithContext(ctx).Raw(`
+		SELECT g.group_no AS channel_id,
+		       2 AS channel_type,
+		       g.name AS channel_name,
+		       COALESCE(g.space_id, '') AS space_id
+		FROM `+"`group`"+` g
+		INNER JOIN group_member gm ON g.group_no = gm.group_no
+		WHERE gm.uid = ?
+		  AND gm.is_deleted = 0
+		  AND g.status = 1
+		ORDER BY g.updated_at DESC
+	`, uid).Scan(&groups).Error
+	if err != nil {
+		return nil, fmt.Errorf("query groups: %w", err)
+	}
+	for _, g := range groups {
+		channels = append(channels, ChannelInfo{
+			ChannelID:   g.ChannelID,
+			ChannelType: g.ChannelType,
+			ChannelName: g.ChannelName,
+			SpaceID:     g.SpaceID,
+		})
+	}
+
+	// DM channels — write path fails closed (contrast: GetUserChannels logs+continues).
+	type dmRow struct {
+		ChannelID string `gorm:"column:channel_id"`
+	}
+	var dms []dmRow
+	err = imDB.WithContext(ctx).Raw(`
+		SELECT channel_id
+		FROM conversation_extra
+		WHERE uid = ? AND channel_type = 1
+		GROUP BY channel_id
+		ORDER BY MAX(updated_at) DESC
+		LIMIT 200
+	`, uid).Scan(&dms).Error
+	if err != nil {
+		return nil, fmt.Errorf("query DM channels: %w", err)
+	}
+	for _, d := range dms {
+		peerUID := getPeerUID(d.ChannelID, uid)
+		normalized := NormalizeDMChannelID(d.ChannelID, uid, 1)
+		channels = append(channels, ChannelInfo{
+			ChannelID:   normalized,
+			ChannelType: 1,
+			ChannelName: fmt.Sprintf("私聊-%s", peerUID),
+			PeerUID:     peerUID,
+		})
+	}
+
+	// Thread channels (channelType=5) — write path fails closed.
+	type threadRow struct {
+		ChannelID   string `gorm:"column:channel_id"`
+		ChannelType int    `gorm:"column:channel_type"`
+		ChannelName string `gorm:"column:channel_name"`
+		SpaceID     string `gorm:"column:space_id"`
+	}
+	var threadChannels []threadRow
+	threadStatusCond := "t.status = 1"
+	threadArgs := []interface{}{uid}
+	if len(selectedThreadIDs) > 0 {
+		threadStatusCond = "(t.status = 1 OR (t.status = 2 AND CONCAT(t.group_no, '____', t.short_id) IN ?))"
+		threadArgs = append(threadArgs, selectedThreadIDs)
+	}
+	threadQuery := `
+		SELECT CONCAT(t.group_no, '____', t.short_id) AS channel_id,
+		       5 AS channel_type,
+		       CONCAT(t.name, ' · ', g.name) AS channel_name,
+		       COALESCE(g.space_id, '') AS space_id
+		FROM thread t
+		INNER JOIN ` + "`group`" + ` g ON g.group_no COLLATE utf8mb4_unicode_ci = t.group_no
+		INNER JOIN thread_member tm ON tm.thread_id = t.id
+		WHERE tm.uid = ?
+		  AND ` + threadStatusCond + `
+		  AND g.status = 1
+		ORDER BY t.updated_at DESC
+	`
+	err = imDB.WithContext(ctx).Raw(threadQuery, threadArgs...).Scan(&threadChannels).Error
+	if err != nil {
+		return nil, fmt.Errorf("query thread channels: %w", err)
+	}
+	for _, tc := range threadChannels {
+		channels = append(channels, ChannelInfo{
+			ChannelID:   tc.ChannelID,
+			ChannelType: 5,
+			ChannelName: tc.ChannelName,
+			SpaceID:     tc.SpaceID,
+		})
+	}
+
+	return channels, nil
 }

--- a/internal/pipeline/access.go
+++ b/internal/pipeline/access.go
@@ -23,8 +23,9 @@ type SourceRef struct {
 }
 
 // sourceKey normalizes a SourceRef into a lookup key comparable against the
-// keys produced from GetUserChannels output. DM ids are folded through
-// NormalizeDMChannelID so peer/peer@self/self@peer all collapse to one key.
+// keys produced from the accessible-channel query output. DM ids are folded
+// through NormalizeDMChannelID so peer/peer@self/self@peer all collapse to
+// one key.
 func (s SourceRef) sourceKey(selfUID string) (channelType int, channelID string) {
 	switch s.SourceType {
 	case 1: // group -> pipeline group
@@ -38,35 +39,48 @@ func (s SourceRef) sourceKey(selfUID string) (channelType int, channelID string)
 	}
 }
 
-// ValidateUserAccessibleSources checks each entry in sources against the
-// authoritative user-accessible channel set (GetUserChannels). Returns the
-// subset that is NOT accessible; callers turn a non-empty missing list into
-// a 40017 business error.
+// ValidateUserAccessibleSources rejects entries the user cannot see. Write
+// path only: fail-closed on any error, including imDB==nil. Read paths keep
+// the permissive GetUserChannels (see reviewer thread e0640d10).
 //
-// imDB==nil is a permissive fallback (mirrors ResolveSourceNameWithType) so
-// unit-test paths that skip the IM DB stay green. sources empty -> no work,
-// nil missing.
+// Empty sources short-circuits to (nil, nil). Otherwise returns the subset
+// of sources that are NOT accessible; callers turn a non-empty missing list
+// into a 40017 business error, or on err into an HTTP 500.
 func ValidateUserAccessibleSources(ctx context.Context, uid string, imDB *gorm.DB, sources []SourceRef) ([]SourceRef, error) {
-	if imDB == nil || len(sources) == 0 {
+	if len(sources) == 0 {
 		return nil, nil
 	}
+	// Fail-closed on missing IM DB: production wires imDB=nil when the IM
+	// connection failed at startup (cmd/summary-api/main.go:61-64). A permissive
+	// fallback here would let any Update/Create bypass the access check whenever
+	// the IM DB happens to be down — the exact IDOR this whole change closes.
+	// Callers surface this as HTTP 500 (not 40017), so an outage looks like an
+	// outage rather than a false "no access" verdict.
+	if imDB == nil {
+		return nil, fmt.Errorf("access check unavailable: IM DB not connected")
+	}
 
-	// Pass explicitly-selected thread ids to GetUserChannels so an archived
-	// thread the user is legitimately editing (e.g. keeping it in a schedule)
-	// still shows up in the accessible set. Non-thread entries are ignored
-	// by the underlying query.
+	// Gather the two id sets we need to probe:
+	//   * selectedThreadIDs -> archived-thread relaxation for the thread query
+	//   * dmIDs             -> targeted DM existence check (avoids the LIMIT 200
+	//                          truncation that a broad "list all my DMs" query
+	//                          would inherit for heavy users)
 	var selectedThreadIDs []string
+	var dmIDs []string
 	for _, s := range sources {
-		if s.SourceType == 2 && s.SourceID != "" {
-			selectedThreadIDs = append(selectedThreadIDs, s.SourceID)
+		switch s.SourceType {
+		case 2:
+			if s.SourceID != "" {
+				selectedThreadIDs = append(selectedThreadIDs, s.SourceID)
+			}
+		case 3:
+			if s.SourceID != "" {
+				dmIDs = append(dmIDs, NormalizeDMChannelID(s.SourceID, uid, 1))
+			}
 		}
 	}
 
-	// Write path is fail-closed: any IM query failure short-circuits to an
-	// error (surfaced as HTTP 500 by callers) so a partial visibility set can't
-	// masquerade as "no access" and cause false 403/40017. Read paths keep the
-	// permissive GetUserChannels intact (see reviewer thread e0640d10).
-	channels, err := getUserChannelsStrict(ctx, uid, imDB, selectedThreadIDs...)
+	channels, err := getUserChannelsStrict(ctx, uid, imDB, selectedThreadIDs, dmIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +88,7 @@ func ValidateUserAccessibleSources(ctx context.Context, uid string, imDB *gorm.D
 	// (channel_type, channel_id) set of what the user can see.
 	allowed := make(map[[2]string]struct{}, len(channels))
 	for _, ch := range channels {
-		key := [2]string{itoa2(ch.ChannelType), ch.ChannelID}
-		allowed[key] = struct{}{}
+		allowed[[2]string{itoa2(ch.ChannelType), ch.ChannelID}] = struct{}{}
 	}
 
 	var missing []SourceRef
@@ -112,21 +125,31 @@ func itoa2(n int) string {
 
 // getUserChannelsStrict is the write-path variant of GetUserChannels: any
 // group/DM/thread query failure returns an error instead of the permissive
-// log-and-continue used by read paths. Kept in this file rather than folded
-// back into GetUserChannels because the five existing read-path callers rely
-// on the fail-open degradation to tolerate transient IM outages; changing that
-// contract would ripple far outside this fix (reviewer thread e0640d10).
+// log-and-continue used by read paths. Kept private here (rather than folded
+// back into GetUserChannels) because the five existing read-path callers rely
+// on the fail-open degradation to tolerate transient IM outages; changing
+// that contract would ripple far outside this fix (reviewer thread e0640d10).
 //
-// Semantics otherwise mirror GetUserChannels verbatim (same SQL, same
-// selectedThreadIDs scoping for archived threads, same DM normalization).
-func getUserChannelsStrict(ctx context.Context, uid string, imDB *gorm.DB, selectedThreadIDs ...string) ([]ChannelInfo, error) {
+// Semantics deliberately diverge from GetUserChannels on two axes to match
+// the picker contract and avoid write-path false negatives:
+//   - Thread accessibility joins group_member (not thread_member) so any
+//     thread inside a user's group counts as accessible even if the user has
+//     never posted in it — mirroring candidates.go:188-190 (the picker the
+//     frontend actually shows). thread_member was too strict and produced
+//     false 40017 on a user's first source pick.
+//   - DM accessibility is a targeted existence check on the request's DM ids
+//     (no LIMIT), instead of listing the top-N most-recent DMs. The LIMIT
+//     200 in GetUserChannels' DM query is fine for read-path candidate
+//     surfacing but broke write-path validation for users with more than
+//     200 DMs (a legitimate DM #201+ would get judged missing).
+func getUserChannelsStrict(ctx context.Context, uid string, imDB *gorm.DB, selectedThreadIDs, dmIDs []string) ([]ChannelInfo, error) {
 	if imDB == nil {
 		return nil, fmt.Errorf("IM database not available")
 	}
 
 	var channels []ChannelInfo
 
-	// Groups
+	// Groups — pull all groups the user is an active member of.
 	type groupRow struct {
 		ChannelID   string `gorm:"column:channel_id"`
 		ChannelType int    `gorm:"column:channel_type"`
@@ -158,34 +181,40 @@ func getUserChannelsStrict(ctx context.Context, uid string, imDB *gorm.DB, selec
 		})
 	}
 
-	// DM channels — write path fails closed (contrast: GetUserChannels logs+continues).
-	type dmRow struct {
-		ChannelID string `gorm:"column:channel_id"`
-	}
-	var dms []dmRow
-	err = imDB.WithContext(ctx).Raw(`
-		SELECT channel_id
-		FROM conversation_extra
-		WHERE uid = ? AND channel_type = 1
-		GROUP BY channel_id
-		ORDER BY MAX(updated_at) DESC
-		LIMIT 200
-	`, uid).Scan(&dms).Error
-	if err != nil {
-		return nil, fmt.Errorf("query DM channels: %w", err)
-	}
-	for _, d := range dms {
-		peerUID := getPeerUID(d.ChannelID, uid)
-		normalized := NormalizeDMChannelID(d.ChannelID, uid, 1)
-		channels = append(channels, ChannelInfo{
-			ChannelID:   normalized,
-			ChannelType: 1,
-			ChannelName: fmt.Sprintf("私聊-%s", peerUID),
-			PeerUID:     peerUID,
-		})
+	// DM channels — targeted existence check on the request's DM ids, no LIMIT.
+	// See the function-doc note on why this diverges from GetUserChannels.
+	if len(dmIDs) > 0 {
+		type dmRow struct {
+			ChannelID string `gorm:"column:channel_id"`
+		}
+		var dms []dmRow
+		err = imDB.WithContext(ctx).Raw(`
+			SELECT channel_id
+			FROM conversation_extra
+			WHERE uid = ?
+			  AND channel_type = 1
+			  AND channel_id IN ?
+			GROUP BY channel_id
+		`, uid, dmIDs).Scan(&dms).Error
+		if err != nil {
+			return nil, fmt.Errorf("query DM channels: %w", err)
+		}
+		for _, d := range dms {
+			peerUID := getPeerUID(d.ChannelID, uid)
+			normalized := NormalizeDMChannelID(d.ChannelID, uid, 1)
+			channels = append(channels, ChannelInfo{
+				ChannelID:   normalized,
+				ChannelType: 1,
+				ChannelName: fmt.Sprintf("私聊-%s", peerUID),
+				PeerUID:     peerUID,
+			})
+		}
 	}
 
-	// Thread channels (channelType=5) — write path fails closed.
+	// Thread channels (channelType=5) — joined via group_member so any thread
+	// inside a group the user belongs to counts (see function-doc note aligning
+	// with picker candidates.go:188-190). Archived threads only surface when
+	// selectedThreadIDs explicitly names them (same relaxation as GetUserChannels).
 	type threadRow struct {
 		ChannelID   string `gorm:"column:channel_id"`
 		ChannelType int    `gorm:"column:channel_type"`
@@ -206,8 +235,9 @@ func getUserChannelsStrict(ctx context.Context, uid string, imDB *gorm.DB, selec
 		       COALESCE(g.space_id, '') AS space_id
 		FROM thread t
 		INNER JOIN ` + "`group`" + ` g ON g.group_no COLLATE utf8mb4_unicode_ci = t.group_no
-		INNER JOIN thread_member tm ON tm.thread_id = t.id
-		WHERE tm.uid = ?
+		INNER JOIN group_member gm ON gm.group_no COLLATE utf8mb4_unicode_ci = t.group_no
+		WHERE gm.uid = ?
+		  AND gm.is_deleted = 0
 		  AND ` + threadStatusCond + `
 		  AND g.status = 1
 		ORDER BY t.updated_at DESC

--- a/internal/pipeline/access_test.go
+++ b/internal/pipeline/access_test.go
@@ -1,44 +1,47 @@
+//go:build cgo
+
 package pipeline
 
 import (
 	"context"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 )
 
 // TestValidateUserAccessibleSources exercises the group/thread/DM membership
-// paths and the imDB==nil / empty-input escape hatches on top of the shared
-// pipeline in-memory IM schema.
+// paths on top of the shared pipeline in-memory IM schema.
+//
+// Note the thread contract: after review round-1 (issue #143, upstream PR
+// #145) the write-path helper judges thread accessibility via group_member
+// (not thread_member), to match the picker in candidates.go — any thread in
+// a user's group is accessible even if the user has never posted there.
+// thread_member rows are seeded here only to prove the check ignores them.
 func TestValidateUserAccessibleSources(t *testing.T) {
-	// imDB==nil -> permissive fallback: never treat anything as missing.
-	if missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", nil,
-		[]SourceRef{{SourceType: 1, SourceID: "grp1"}}); err != nil || len(missing) != 0 {
-		t.Fatalf("nil imDB should pass through: missing=%v err=%v", missing, err)
-	}
-
 	imDB := setupPipelineImDB(t)
 	// Seed:
-	//   user uid1 is member of grp1 (active) but NOT grp2 (member row soft-deleted).
-	//   thread t1 in grp1: uid1 is a thread_member; thread t2 in grp1: uid1 is NOT.
-	//   DM: uid1 has a conversation_extra row for channel "peerA" (peer format).
+	//   uid1 is member of grp1 (active) but NOT grp2 (member row soft-deleted).
+	//   two active threads under grp1; thread_member membership is intentionally
+	//   NOT seeded so we can prove group_member alone grants access.
+	//   DM: uid1 has a conversation_extra row for channel "peerA".
 	imDB.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp1','g1',1)`)
 	imDB.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp2','g2',1)`)
 	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1','uid1',0)`)
 	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp2','uid1',1)`) // soft-deleted -> not accessible
 	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (1,'sh1','th1','grp1',1)`)
-	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (2,'sh2','th2','grp1',1)`)
-	imDB.Exec(`INSERT INTO thread_member (thread_id, uid) VALUES (1,'uid1')`)
-	// DM: peer id stored under the WuKongIM ordering (normalized). We insert the raw
-	// peer form; the helper normalizes both stored and queried ids the same way, so
-	// the callers can pass the peer uid without knowing the storage convention.
-	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type) VALUES ('uid1','peerA',1)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (2,'sh2','th2','grp2',1)`)
+	// DM channel_id in conversation_extra is stored in the WuKongIM canonical
+	// form (CRC32-ordered "a@b"). The helper normalizes request ids the same
+	// way before probing, so we seed with the normalized form to match.
+	dmA := NormalizeDMChannelID("peerA", "uid1", 1)
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type) VALUES (?, ?, 1)`, "uid1", dmA)
 
 	sources := []SourceRef{
 		{SourceType: 1, SourceID: "grp1"},        // accessible group
-		{SourceType: 1, SourceID: "grp2"},        // group with is_deleted=1 member -> missing
-		{SourceType: 2, SourceID: "grp1____sh1"}, // accessible thread
-		{SourceType: 2, SourceID: "grp1____sh2"}, // thread without membership -> missing
+		{SourceType: 1, SourceID: "grp2"},        // is_deleted=1 -> missing
+		{SourceType: 2, SourceID: "grp1____sh1"}, // thread under grp1: group_member=ok -> accessible
+		{SourceType: 2, SourceID: "grp2____sh2"}, // thread under grp2: not a member -> missing
 		{SourceType: 3, SourceID: "peerA"},       // accessible DM
 		{SourceType: 3, SourceID: "peerZ"},       // DM never seen -> missing
 	}
@@ -47,7 +50,6 @@ func TestValidateUserAccessibleSources(t *testing.T) {
 		t.Fatalf("ValidateUserAccessibleSources: %v", err)
 	}
 
-	// Order-insensitive: sort by (source_type, source_id) then compare.
 	got := make([][2]string, 0, len(missing))
 	for _, m := range missing {
 		got = append(got, [2]string{itoaSrcType(m.SourceType), m.SourceID})
@@ -60,7 +62,7 @@ func TestValidateUserAccessibleSources(t *testing.T) {
 	})
 	want := [][2]string{
 		{"1", "grp2"},
-		{"2", "grp1____sh2"},
+		{"2", "grp2____sh2"},
 		{"3", "peerZ"},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -68,12 +70,102 @@ func TestValidateUserAccessibleSources(t *testing.T) {
 	}
 }
 
-// TestValidateUserAccessibleSources_Empty ensures empty input is a fast-path pass-through.
+// TestValidateUserAccessibleSources_Empty: empty input is a fast-path pass-through.
 func TestValidateUserAccessibleSources_Empty(t *testing.T) {
 	imDB := setupPipelineImDB(t)
 	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB, nil)
 	if err != nil || len(missing) != 0 {
 		t.Fatalf("empty sources should pass through: missing=%v err=%v", missing, err)
+	}
+}
+
+// TestValidateUserAccessibleSources_NilIMDBFailsClosed: after review round-1
+// (upstream PR #145) imDB==nil MUST NOT pass through — production wires
+// imDB=nil when IM DB is down (cmd/summary-api/main.go:61-64), and the old
+// permissive fallback would let any Update/Create bypass the access check
+// during an IM outage.
+func TestValidateUserAccessibleSources_NilIMDBFailsClosed(t *testing.T) {
+	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", nil,
+		[]SourceRef{{SourceType: 1, SourceID: "grp1"}})
+	if err == nil {
+		t.Fatalf("expected error when imDB is nil (fail-closed), got nil")
+	}
+}
+
+// TestValidateUserAccessibleSources_ThreadGroupOnly asserts the picker/validator
+// contract: a user who is a group_member but NOT a thread_member can still
+// select a thread inside that group and have it judged accessible.
+// (Regression guard for upstream review P1: thread strictness misalignment
+// with candidates.go picker.)
+func TestValidateUserAccessibleSources_ThreadGroupOnly(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp1','g1',1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1','uid1',0)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (1,'sh1','th1','grp1',1)`)
+	// Deliberately NOT seeding thread_member; the old strict helper's join on
+	// thread_member would have rejected this thread. Group-only join must pass.
+
+	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 2, SourceID: "grp1____sh1"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("thread in user's group must be accessible without thread_member row; missing=%v", missing)
+	}
+}
+
+// TestValidateUserAccessibleSources_DMBeyond200 asserts DM validation is not
+// truncated by the 200-row read-path cap: seed 250 DMs and probe one of the
+// later rows. Regression guard for upstream review Major: DM LIMIT 200.
+func TestValidateUserAccessibleSources_DMBeyond200(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	const n = 250
+	for i := 0; i < n; i++ {
+		peer := "peer_" + strconv.Itoa(i)
+		// updated_at ascending so peer_249 is newest, peer_0 oldest — mimics the
+		// distribution that made a "recency top-200" query drop the middle rows.
+		stored := NormalizeDMChannelID(peer, "uid1", 1)
+		imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type, updated_at) VALUES (?, ?, 1, ?)`,
+			"uid1", stored, i)
+	}
+	// Probe an entry that would fall outside the top-200-by-recency (peer_0 is
+	// oldest -> would be #250 if the query had a LIMIT). It must still be
+	// judged accessible now that the DM check is a targeted existence query.
+	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 3, SourceID: "peer_0"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("DM #250 by recency must be accessible (no LIMIT truncation); missing=%v", missing)
+	}
+}
+
+// TestValidateUserAccessibleSources_DMQueryFail asserts write-path fail-closed
+// on IM DM query error. (Regression guard for reviewer thread e0640d10.)
+func TestValidateUserAccessibleSources_DMQueryFail(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	imDB.Exec(`DROP TABLE conversation_extra`)
+
+	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 3, SourceID: "peerX"}})
+	if err == nil {
+		t.Fatalf("expected error when DM query fails, got nil")
+	}
+}
+
+// TestValidateUserAccessibleSources_ThreadQueryFail: same guard for the thread
+// sub-query. After the group_member switch, drop \`thread\` itself (the query
+// no longer references thread_member).
+func TestValidateUserAccessibleSources_ThreadQueryFail(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	imDB.Exec(`DROP TABLE thread`)
+
+	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 2, SourceID: "grp1____sh1"}})
+	if err == nil {
+		t.Fatalf("expected error when thread query fails, got nil")
 	}
 }
 
@@ -87,35 +179,5 @@ func itoaSrcType(n int) string {
 		return "3"
 	default:
 		return "?"
-	}
-}
-
-// TestValidateUserAccessibleSources_DMQueryFail asserts write-path fail-closed
-// on IM DM query error: dropping conversation_extra makes the DM sub-query fail,
-// the strict helper must surface the error instead of returning a partial
-// allowed-set (which would let a legitimate DM look like "missing" and cause
-// false 40017/403). Regression guard for reviewer thread e0640d10.
-func TestValidateUserAccessibleSources_DMQueryFail(t *testing.T) {
-	imDB := setupPipelineImDB(t)
-	// Drop conversation_extra so the DM query hits "no such table".
-	imDB.Exec(`DROP TABLE conversation_extra`)
-
-	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
-		[]SourceRef{{SourceType: 3, SourceID: "peerX"}})
-	if err == nil {
-		t.Fatalf("expected error when DM query fails, got nil")
-	}
-}
-
-// TestValidateUserAccessibleSources_ThreadQueryFail: same guard for the thread
-// sub-query — dropping thread_member makes the join fail.
-func TestValidateUserAccessibleSources_ThreadQueryFail(t *testing.T) {
-	imDB := setupPipelineImDB(t)
-	imDB.Exec(`DROP TABLE thread_member`)
-
-	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
-		[]SourceRef{{SourceType: 2, SourceID: "grp1____sh1"}})
-	if err == nil {
-		t.Fatalf("expected error when thread query fails, got nil")
 	}
 }

--- a/internal/pipeline/access_test.go
+++ b/internal/pipeline/access_test.go
@@ -89,3 +89,33 @@ func itoaSrcType(n int) string {
 		return "?"
 	}
 }
+
+// TestValidateUserAccessibleSources_DMQueryFail asserts write-path fail-closed
+// on IM DM query error: dropping conversation_extra makes the DM sub-query fail,
+// the strict helper must surface the error instead of returning a partial
+// allowed-set (which would let a legitimate DM look like "missing" and cause
+// false 40017/403). Regression guard for reviewer thread e0640d10.
+func TestValidateUserAccessibleSources_DMQueryFail(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	// Drop conversation_extra so the DM query hits "no such table".
+	imDB.Exec(`DROP TABLE conversation_extra`)
+
+	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 3, SourceID: "peerX"}})
+	if err == nil {
+		t.Fatalf("expected error when DM query fails, got nil")
+	}
+}
+
+// TestValidateUserAccessibleSources_ThreadQueryFail: same guard for the thread
+// sub-query — dropping thread_member makes the join fail.
+func TestValidateUserAccessibleSources_ThreadQueryFail(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	imDB.Exec(`DROP TABLE thread_member`)
+
+	_, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 2, SourceID: "grp1____sh1"}})
+	if err == nil {
+		t.Fatalf("expected error when thread query fails, got nil")
+	}
+}

--- a/internal/pipeline/access_test.go
+++ b/internal/pipeline/access_test.go
@@ -1,0 +1,91 @@
+package pipeline
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestValidateUserAccessibleSources exercises the group/thread/DM membership
+// paths and the imDB==nil / empty-input escape hatches on top of the shared
+// pipeline in-memory IM schema.
+func TestValidateUserAccessibleSources(t *testing.T) {
+	// imDB==nil -> permissive fallback: never treat anything as missing.
+	if missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", nil,
+		[]SourceRef{{SourceType: 1, SourceID: "grp1"}}); err != nil || len(missing) != 0 {
+		t.Fatalf("nil imDB should pass through: missing=%v err=%v", missing, err)
+	}
+
+	imDB := setupPipelineImDB(t)
+	// Seed:
+	//   user uid1 is member of grp1 (active) but NOT grp2 (member row soft-deleted).
+	//   thread t1 in grp1: uid1 is a thread_member; thread t2 in grp1: uid1 is NOT.
+	//   DM: uid1 has a conversation_extra row for channel "peerA" (peer format).
+	imDB.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp1','g1',1)`)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp2','g2',1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1','uid1',0)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp2','uid1',1)`) // soft-deleted -> not accessible
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (1,'sh1','th1','grp1',1)`)
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (2,'sh2','th2','grp1',1)`)
+	imDB.Exec(`INSERT INTO thread_member (thread_id, uid) VALUES (1,'uid1')`)
+	// DM: peer id stored under the WuKongIM ordering (normalized). We insert the raw
+	// peer form; the helper normalizes both stored and queried ids the same way, so
+	// the callers can pass the peer uid without knowing the storage convention.
+	imDB.Exec(`INSERT INTO conversation_extra (uid, channel_id, channel_type) VALUES ('uid1','peerA',1)`)
+
+	sources := []SourceRef{
+		{SourceType: 1, SourceID: "grp1"},        // accessible group
+		{SourceType: 1, SourceID: "grp2"},        // group with is_deleted=1 member -> missing
+		{SourceType: 2, SourceID: "grp1____sh1"}, // accessible thread
+		{SourceType: 2, SourceID: "grp1____sh2"}, // thread without membership -> missing
+		{SourceType: 3, SourceID: "peerA"},       // accessible DM
+		{SourceType: 3, SourceID: "peerZ"},       // DM never seen -> missing
+	}
+	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB, sources)
+	if err != nil {
+		t.Fatalf("ValidateUserAccessibleSources: %v", err)
+	}
+
+	// Order-insensitive: sort by (source_type, source_id) then compare.
+	got := make([][2]string, 0, len(missing))
+	for _, m := range missing {
+		got = append(got, [2]string{itoaSrcType(m.SourceType), m.SourceID})
+	}
+	sort.Slice(got, func(i, j int) bool {
+		if got[i][0] != got[j][0] {
+			return got[i][0] < got[j][0]
+		}
+		return got[i][1] < got[j][1]
+	})
+	want := [][2]string{
+		{"1", "grp2"},
+		{"2", "grp1____sh2"},
+		{"3", "peerZ"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("missing mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+// TestValidateUserAccessibleSources_Empty ensures empty input is a fast-path pass-through.
+func TestValidateUserAccessibleSources_Empty(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB, nil)
+	if err != nil || len(missing) != 0 {
+		t.Fatalf("empty sources should pass through: missing=%v err=%v", missing, err)
+	}
+}
+
+func itoaSrcType(n int) string {
+	switch n {
+	case 1:
+		return "1"
+	case 2:
+		return "2"
+	case 3:
+		return "3"
+	default:
+		return "?"
+	}
+}

--- a/internal/pipeline/access_test.go
+++ b/internal/pipeline/access_test.go
@@ -169,6 +169,48 @@ func TestValidateUserAccessibleSources_ThreadQueryFail(t *testing.T) {
 	}
 }
 
+// TestValidateUserAccessibleSources_ArchivedThreadSelected exercises the
+// selectedThreadIDs archived-thread relaxation on the write path: an archived
+// thread (t.status=2) is normally excluded from GetUserChannels output, but
+// when the caller explicitly names it (its id shows up in the current sources
+// list), it must still be judged accessible. Regression guard so a legitimate
+// edit that preserves an archived thread source doesn't get false-403'd.
+func TestValidateUserAccessibleSources_ArchivedThreadSelected(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	imDB.Exec(`INSERT INTO "group" (group_no, name, status) VALUES ('grp1','g1',1)`)
+	imDB.Exec(`INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp1','uid1',0)`)
+	// status=2 (archived) — excluded by the default t.status=1 predicate,
+	// only admitted when the id appears in selectedThreadIDs.
+	imDB.Exec(`INSERT INTO thread (id, short_id, name, group_no, status) VALUES (10,'sh_arch','archived','grp1',2)`)
+
+	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 2, SourceID: "grp1____sh_arch"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("archived thread named in sources must be accessible; missing=%v", missing)
+	}
+}
+
+// TestValidateUserAccessibleSources_UnknownSourceTypeFailsClosed pins the
+// fail-closed default for sourceKey's ct==0 branch: an unknown source_type
+// bypasses every allowed-set lookup and must land in the missing slice
+// (caller returns 403/40017), not be silently accepted.
+func TestValidateUserAccessibleSources_UnknownSourceTypeFailsClosed(t *testing.T) {
+	imDB := setupPipelineImDB(t)
+	// No seed needed: the check should reject before any allowed-set lookup.
+
+	missing, err := ValidateUserAccessibleSources(context.Background(), "uid1", imDB,
+		[]SourceRef{{SourceType: 99, SourceID: "whatever"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) != 1 || missing[0].SourceType != 99 || missing[0].SourceID != "whatever" {
+		t.Fatalf("unknown source_type must fail closed into missing; got=%v", missing)
+	}
+}
+
 func itoaSrcType(n int) string {
 	switch n {
 	case 1:

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -28,16 +28,6 @@ type scheduleParticipantConfig struct {
 	UserName string `json:"user_name"`
 }
 
-func syncScheduledTaskConfig(tx *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, task model.SummaryTask, now time.Time) error {
-	if err := syncScheduledTaskSources(tx, imDB, task.ID, sched.SourceConfig); err != nil {
-		return err
-	}
-	if err := syncScheduledTaskParticipants(tx, task, sched.ParticipantConfig, now); err != nil {
-		return err
-	}
-	return nil
-}
-
 // buildScheduledTaskChildren creates the source / participant / personal_result
 // subtable rows for a freshly INSERTed scheduled task. Under the 1->N model every
 // run is a brand-new task_id, so its three subtables start empty and must be
@@ -208,37 +198,6 @@ func materializeAcceptedParticipant(tx *gorm.DB, task model.SummaryTask, userID,
 		return err
 	}
 	return tx.Model(&row).Update("personal_result_id", pr.ID).Error
-}
-
-func syncScheduledTaskSources(tx *gorm.DB, imDB *gorm.DB, taskID int64, raw model.JSON) error {
-	if len(raw) == 0 {
-		return nil
-	}
-
-	var sources []scheduleSourceConfig
-	if err := json.Unmarshal(raw, &sources); err != nil {
-		return service.NewBizError(40000, "定时来源配置无效", http.StatusBadRequest)
-	}
-	if err := tx.Where("task_id = ?", taskID).Delete(&model.SummarySource{}).Error; err != nil {
-		return err
-	}
-	for _, src := range sources {
-		if src.SourceID == "" {
-			return fmt.Errorf("scheduled source_id is required")
-		}
-		// Always resolve the canonical source name from the IM DB; never trust a
-		// client-supplied source_name (see buildScheduledTaskSources).
-		sourceName := service.ResolveSourceNameWithType(src.SourceID, src.SourceType, imDB)
-		if err := tx.Create(&model.SummarySource{
-			TaskID:     taskID,
-			SourceType: src.SourceType,
-			SourceID:   src.SourceID,
-			SourceName: sourceName,
-		}).Error; err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func syncScheduledTaskParticipants(tx *gorm.DB, task model.SummaryTask, raw model.JSON, now time.Time) error {

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -31,9 +31,9 @@ type scheduleParticipantConfig struct {
 // buildScheduledTaskChildren creates the source / participant / personal_result
 // subtable rows for a freshly INSERTed scheduled task. Under the 1->N model every
 // run is a brand-new task_id, so its three subtables start empty and must be
-// rebuilt from the schedule config (the source of truth). This is the same shape
-// as syncScheduledTaskConfig but assumes no pre-existing children (no deletes) and
-// always materializes the creator participant even when ParticipantConfig is empty.
+// rebuilt from the schedule config (the source of truth). Assumes no
+// pre-existing children (no deletes) and always materializes the creator
+// participant even when ParticipantConfig is empty.
 //
 // Returns the number of Accepted participants materialized. For a V5 CONFIRM
 // schedule this is the count of already-confirmed members this round; 0 means the


### PR DESCRIPTION
## 概要
`UpdateSchedule` 直接把 `req.Sources` 写入 `source_config`（`internal/api/handler/schedule.go`），并未校验用户对新来源是否有访问权限；`CreateSchedule` 同样漏洞。攻击者/越权者可以把定时任务的来源改成自己无权访问的群/子区/私聊，等下次触发时越权拉取消息。

本 PR：
- 新增 `pipeline.ValidateUserAccessibleSources`，复用现有权威的 `pipeline.GetUserChannels` 拉全集再 diff。`imDB==nil` 直接放行（测试路径）。source_type（1群/2子区/3私聊）↔ pipeline ChannelType（2/5/1）映射封在 helper 内部；DM 归一化沿用 `NormalizeDMChannelID` 消除 peer/peer@self/self@peer 三形态。
- `ScheduleHandler` 加 `imDB` 字段 + 新构造 `NewScheduleHandlerWithIMDB`；router 切到新构造。旧 `NewScheduleHandler` / `NewScheduleHandlerWithFlag` 保留兼容既有测试。
- `UpdateSchedule` + `CreateSchedule` 在写库前调用 helper；不通过则 HTTP 403 / `Code: 40017 / Message: "存在无权访问或不存在的来源"`，`data.missing_sources` 逐项返回 `{source_type, source_id, source_name}`，前端可精确定位。message 保持通用文案避免文案注入面。
- 顺手清理死代码 `syncScheduledTaskConfig` / `syncScheduledTaskSources`（`internal/worker/scheduled_replace_helpers.go`）：`grep -RIn` 双确认无 caller、无测试引用；1→N 模型下每次触发都通过 `buildScheduledTaskChildren` 全量重建，原地增量路径不可达。

## 验收
- 编辑定时任务把来源改成用户**有权访问**的群 → 200 保存成功，`source_config` 更新。
- 改成用户**无权访问**的群 → 403 / 40017，`source_config` 不变。
- 创建定时任务给**有权/无权**来源 → 同样规则。

## 测试
- `internal/pipeline/access_test.go`：群/子区/DM 命中 + 未命中；`imDB==nil` 与空 sources 快速通道。
- `internal/api/handler/schedule_source_access_test.go`：Create × 有权/无权、Update × 有权/无权，共四条端到端 case，覆盖「拒绝路径下 `source_config` 不被改动」不变式。
- `go test ./internal/...` 全绿；`go vet ./...` 干净。

## 部署前提 / 必配环境变量
无新增环境变量。

## 关联
Fixes #143
