### PR TITLE
feat(summary): add user summary templates

### DIFF
--- a/cmd/summary-api/main.go
+++ b/cmd/summary-api/main.go
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	// Public API server
-	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule)
+	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit)
 	publicSrv := &http.Server{
 		Addr:    ":" + cfg.APIPort,
 		Handler: publicRouter,

--- a/internal/api/handler/origin_channel_test.go
+++ b/internal/api/handler/origin_channel_test.go
@@ -403,11 +403,11 @@ func TestGetTemplates_ReturnsCorrectStructure(t *testing.T) {
 	data := resp["data"].(map[string]interface{})
 	templates := data["templates"].([]interface{})
 
-	if len(templates) != 4 {
-		t.Fatalf("expected 4 templates, got %d", len(templates))
+	if len(templates) != 8 {
+		t.Fatalf("expected 8 templates, got %d", len(templates))
 	}
 
-	expectedIDs := []string{"project_progress", "task_tracking", "weekly_report", "chat_content"}
+	expectedIDs := []string{"project_progress", "task_tracking", "weekly_report", "chat_content", "personal_weekly_report", "okr_alignment", "todo_extraction", "feedback_triage"}
 	for i, tmpl := range templates {
 		m := tmpl.(map[string]interface{})
 		if m["id"] != expectedIDs[i] {
@@ -427,18 +427,13 @@ func TestGetTemplates_ReturnsCorrectStructure(t *testing.T) {
 		}
 	}
 
-	// Verify parameterized template has placeholders
+	// Built-in templates use the two-field model; no parameterized placeholders are exposed.
 	taskTracking := templates[1].(map[string]interface{})
-	if taskTracking["type"] != "parameterized" {
-		t.Errorf("task_tracking type: want parameterized, got %v", taskTracking["type"])
+	if taskTracking["type"] != "fixed" {
+		t.Errorf("task_tracking type: want fixed, got %v", taskTracking["type"])
 	}
-	placeholders := taskTracking["placeholders"].([]interface{})
-	if len(placeholders) != 1 {
-		t.Fatalf("task_tracking placeholders: want 1, got %d", len(placeholders))
-	}
-	ph := placeholders[0].(map[string]interface{})
-	if ph["key"] != "task_name" {
-		t.Errorf("placeholder key: want task_name, got %v", ph["key"])
+	if _, ok := taskTracking["placeholders"]; ok {
+		t.Errorf("task_tracking placeholders should be omitted in two-field model")
 	}
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,16 +29,33 @@ import (
 // maxSourceCount is the maximum number of information sources allowed per task.
 const maxSourceCount = 30
 
+const defaultCustomTemplateLimit = 30
+
 // TaskHandler handles summary task endpoints.
 type TaskHandler struct {
-	db               *gorm.DB
-	imDB             *gorm.DB
-	workerTriggerURL string
+	db                  *gorm.DB
+	imDB                *gorm.DB
+	workerTriggerURL    string
+	customTemplateLimit int
 }
 
 // NewTaskHandler creates a new TaskHandler.
 func NewTaskHandler(db, imDB *gorm.DB, workerTriggerURL string) *TaskHandler {
-	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL}
+	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit}
+}
+
+func (h *TaskHandler) SetCustomTemplateLimit(limit int) {
+	if limit <= 0 {
+		limit = defaultCustomTemplateLimit
+	}
+	h.customTemplateLimit = limit
+}
+
+func (h *TaskHandler) getCustomTemplateLimit() int {
+	if h.customTemplateLimit <= 0 {
+		return defaultCustomTemplateLimit
+	}
+	return h.customTemplateLimit
 }
 
 // canAccessTask reports whether userID may read the task: creator or explicit
@@ -1020,61 +1039,424 @@ func (h *TaskHandler) InferScope(c *gin.Context) {
 	ok(c, result)
 }
 
-// GetTemplates handles GET /api/v1/summary-templates
-func (h *TaskHandler) GetTemplates(c *gin.Context) {
-	type placeholder struct {
-		Key      string `json:"key"`
-		Label    string `json:"label"`
-		Position []int  `json:"position,omitempty"`
-	}
-	type tmpl struct {
-		ID           string        `json:"id"`
-		Label        string        `json:"label"`
-		Icon         string        `json:"icon"`
-		Description  string        `json:"description"`
-		Type         string        `json:"type"`
-		Pattern      string        `json:"pattern"`
-		Placeholders []placeholder `json:"placeholders,omitempty"`
-	}
+type templatePlaceholder struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Position []int  `json:"position,omitempty"`
+}
 
-	templates := []tmpl{
+type topicTemplate struct {
+	ID           string                `json:"id"`
+	Label        string                `json:"label"`
+	Icon         string                `json:"icon"`
+	Description  string                `json:"description"`
+	Type         string                `json:"type"`
+	Pattern      string                `json:"pattern"`
+	Placeholders []templatePlaceholder `json:"placeholders,omitempty"`
+	IsCustom     bool                  `json:"is_custom,omitempty"`
+	IsOverridden bool                  `json:"is_overridden,omitempty"`
+	SortOrder    int                   `json:"sort_order,omitempty"`
+}
+
+func builtinTopicTemplates() []topicTemplate {
+	return []topicTemplate{
 		{
-			ID:           "project_progress",
-			Label:        "汇总项目进展",
-			Icon:         "FileText",
-			Description:  "与团队成员一起总结进展",
-			Type:         "parameterized",
-			Pattern:      "总结 {project_name} 的项目进展",
-			Placeholders: []placeholder{{Key: "project_name", Label: "输入项目名称", Position: []int{3, 9}}},
+			ID:          "project_progress",
+			Label:       "汇总项目进展",
+			Icon:        "FileText",
+			Description: "总结项目当前进展，按已完成、进行中、风险阻塞、下一步计划整理",
+			Type:        "fixed",
+			Pattern:     "总结项目当前进展，按已完成、进行中、风险阻塞、下一步计划整理",
 		},
 		{
-			ID:           "task_tracking",
-			Label:        "跟踪任务进度",
-			Icon:         "ListChecks",
-			Description:  "邀请同事汇总任务完成情况",
-			Type:         "parameterized",
-			Pattern:      "总结 {task_name} 的完成情况",
-			Placeholders: []placeholder{{Key: "task_name", Label: "输入任务名称", Position: []int{3, 9}}},
+			ID:          "task_tracking",
+			Label:       "跟踪任务进度",
+			Icon:        "ListChecks",
+			Description: "总结任务完成情况，按任务、负责人、当前状态、待办事项整理",
+			Type:        "fixed",
+			Pattern:     "总结任务完成情况，按任务、负责人、当前状态、待办事项整理",
 		},
 		{
 			ID:          "weekly_report",
 			Label:       "总结团队周报",
 			Icon:        "Calendar",
-			Description: "总结团队成员每周的工作",
+			Description: "总结团队成员每周工作，按成员、重点进展、成果产出、风险问题、下周计划整理",
 			Type:        "fixed",
-			Pattern:     "总结每周的工作周报",
+			Pattern:     "总结团队成员每周工作，按成员、重点进展、成果产出、风险问题、下周计划整理",
 		},
 		{
 			ID:          "chat_content",
 			Label:       "总结聊天内容",
 			Icon:        "MessageSquare",
-			Description: "总结指定聊天中的事情进展",
+			Description: "总结聊天中的关键内容、核心结论、待办事项和需要关注的问题",
 			Type:        "fixed",
-			Pattern:     "总结本群中的关键内容",
+			Pattern:     "总结聊天中的关键内容、核心结论、待办事项和需要关注的问题",
+		},
+		{
+			ID:          "personal_weekly_report",
+			Label:       "生成个人工作周报",
+			Icon:        "Calendar",
+			Description: "总结我最近一周的主要工作，按重点进展、完成事项、风险阻塞、下周计划分点整理",
+			Type:        "fixed",
+			Pattern:     "总结我最近一周的主要工作，按重点进展、完成事项、风险阻塞、下周计划分点整理",
+		},
+		{
+			ID:          "okr_alignment",
+			Label:       "OKR 进展对齐",
+			Icon:        "ListChecks",
+			Description: "根据聊天内容总结当前进展，并对照目标/OKR 分析已完成、未完成、风险差距和下一步动作",
+			Type:        "fixed",
+			Pattern:     "根据聊天内容总结当前进展，并对照目标/OKR 分析已完成、未完成、风险差距和下一步动作",
+		},
+		{
+			ID:          "todo_extraction",
+			Label:       "提取待办事项",
+			Icon:        "ListChecks",
+			Description: "从聊天内容中提取需要跟进的待办事项，按事项、负责人、截止时间、当前状态、上下文说明整理",
+			Type:        "fixed",
+			Pattern:     "从聊天内容中提取需要跟进的待办事项，按事项、负责人、截止时间、当前状态、上下文说明整理",
+		},
+		{
+			ID:          "feedback_triage",
+			Label:       "归类用户反馈",
+			Icon:        "MessageSquare",
+			Description: "整理聊天中的用户反馈、Bug、体验问题和改进建议，按问题类型、影响范围、优先级、建议动作分类",
+			Type:        "fixed",
+			Pattern:     "整理聊天中的用户反馈、Bug、体验问题和改进建议，按问题类型、影响范围、优先级、建议动作分类",
 		},
 	}
+}
 
-	ok(c, gin.H{"templates": templates})
+func findBuiltinTopicTemplate(id string) (topicTemplate, bool) {
+	for _, tpl := range builtinTopicTemplates() {
+		if tpl.ID == id {
+			return tpl, true
+		}
+	}
+	return topicTemplate{}, false
+}
+
+func applyTemplateOverride(tpl topicTemplate, rec model.SummaryUserTemplate) topicTemplate {
+	if strings.TrimSpace(rec.Label) != "" {
+		tpl.Label = rec.Label
+	}
+	if strings.TrimSpace(rec.Description) != "" {
+		tpl.Description = rec.Description
+	} else if strings.TrimSpace(rec.Pattern) != "" {
+		tpl.Description = rec.Pattern
+	}
+	if strings.TrimSpace(rec.Pattern) != "" {
+		tpl.Pattern = rec.Pattern
+	}
+	tpl.IsOverridden = true
+	tpl.Placeholders = nil
+	tpl.Type = "fixed"
+	return tpl
+}
+
+// GetTemplates handles GET /api/v1/summary-templates
+func (h *TaskHandler) GetTemplates(c *gin.Context) {
+	templates := builtinTopicTemplates()
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID != "" && userID != "" {
+		var records []model.SummaryUserTemplate
+		err := h.db.Where("space_id = ? AND user_id = ? AND deleted_at IS NULL", spaceID, userID).
+			Order("is_custom ASC, sort_order ASC, id ASC").Find(&records).Error
+		if err == nil {
+			var customs []topicTemplate
+			for _, rec := range records {
+				if rec.IsCustom {
+					customs = append(customs, topicTemplate{
+						ID:          rec.TemplateID,
+						Label:       rec.Label,
+						Icon:        "FileText",
+						Description: rec.Description,
+						Type:        "fixed",
+						Pattern:     rec.Pattern,
+						IsCustom:    true,
+						SortOrder:   rec.SortOrder,
+					})
+					continue
+				}
+				for i, tpl := range templates {
+					if tpl.ID == rec.TemplateID {
+						templates[i] = applyTemplateOverride(tpl, rec)
+						break
+					}
+				}
+			}
+			templates = append(templates, customs...)
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Printf("[handler] query summary_user_template failed: %v", err)
+		}
+	}
+
+	ok(c, gin.H{"templates": templates, "custom_template_limit": h.getCustomTemplateLimit()})
+}
+
+type customTemplateReq struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Pattern     string `json:"pattern"`
+}
+
+func validateTemplatePattern(c *gin.Context, pattern string) (string, bool) {
+	pattern = strings.TrimSpace(pattern)
+	if utf8.RuneCountInString(pattern) > 1000 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "pattern 不能超过 1000 字符"})
+		return "", false
+	}
+	return pattern, true
+}
+
+func validateCustomTemplateReq(c *gin.Context, req customTemplateReq) (customTemplateReq, bool) {
+	req.Label = strings.TrimSpace(req.Label)
+	req.Description = strings.TrimSpace(req.Description)
+	req.Pattern = strings.TrimSpace(req.Pattern)
+	if req.Pattern == "" {
+		req.Pattern = req.Description
+	}
+	pattern, valid := validateTemplatePattern(c, req.Pattern)
+	if !valid {
+		return req, false
+	}
+	req.Pattern = pattern
+	if req.Label == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "label 不能为空"})
+		return req, false
+	}
+	if req.Description == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "description 不能为空"})
+		return req, false
+	}
+	if utf8.RuneCountInString(req.Label) > 100 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "label 不能超过 100 字符"})
+		return req, false
+	}
+	if utf8.RuneCountInString(req.Description) > 200 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "description 不能超过 200 字符"})
+		return req, false
+	}
+	return req, true
+}
+
+func randomCustomTemplateID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "custom_" + hex.EncodeToString(b), nil
+}
+
+func templateFromRecord(rec model.SummaryUserTemplate) topicTemplate {
+	return topicTemplate{
+		ID:          rec.TemplateID,
+		Label:       rec.Label,
+		Icon:        "FileText",
+		Description: rec.Description,
+		Type:        "fixed",
+		Pattern:     rec.Pattern,
+		IsCustom:    rec.IsCustom,
+		SortOrder:   rec.SortOrder,
+	}
+}
+
+// UpdateMyTemplate handles PUT /api/v1/summary-templates/:id/my for built-in template overrides.
+func (h *TaskHandler) UpdateMyTemplate(c *gin.Context) {
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 4010, Message: "authentication required"})
+		return
+	}
+
+	templateID := c.Param("id")
+	builtin, exists := findBuiltinTopicTemplate(templateID)
+	if !exists {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "模板不存在"})
+		return
+	}
+
+	var req customTemplateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: err.Error()})
+		return
+	}
+	var valid bool
+	req, valid = validateCustomTemplateReq(c, req)
+	if !valid {
+		return
+	}
+
+	now := timezone.Now()
+	record := model.SummaryUserTemplate{
+		SpaceID:     spaceID,
+		UserID:      userID,
+		TemplateID:  templateID,
+		Label:       req.Label,
+		Description: req.Description,
+		Pattern:     req.Pattern,
+		IsCustom:    false,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := h.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "space_id"}, {Name: "user_id"}, {Name: "template_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"label", "description", "pattern", "is_custom", "deleted_at", "updated_at"}),
+	}).Create(&record).Error; err != nil {
+		log.Printf("[handler] upsert summary_user_template failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+
+	ok(c, gin.H{"template": applyTemplateOverride(builtin, record)})
+}
+
+// DeleteMyTemplate handles DELETE /api/v1/summary-templates/:id/my for built-in template overrides.
+func (h *TaskHandler) DeleteMyTemplate(c *gin.Context) {
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 4010, Message: "authentication required"})
+		return
+	}
+	templateID := c.Param("id")
+	builtin, exists := findBuiltinTopicTemplate(templateID)
+	if !exists {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "模板不存在"})
+		return
+	}
+
+	if err := h.db.Where("space_id = ? AND user_id = ? AND template_id = ? AND is_custom = 0", spaceID, userID, templateID).Delete(&model.SummaryUserTemplate{}).Error; err != nil {
+		log.Printf("[handler] delete summary_user_template failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+
+	ok(c, gin.H{"template": builtin})
+}
+
+// CreateCustomTemplate handles POST /api/v1/summary-templates/my.
+func (h *TaskHandler) CreateCustomTemplate(c *gin.Context) {
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 4010, Message: "authentication required"})
+		return
+	}
+	var req customTemplateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: err.Error()})
+		return
+	}
+	var valid bool
+	req, valid = validateCustomTemplateReq(c, req)
+	if !valid {
+		return
+	}
+	var count int64
+	if err := h.db.Model(&model.SummaryUserTemplate{}).
+		Where("space_id = ? AND user_id = ? AND is_custom = 1 AND deleted_at IS NULL", spaceID, userID).
+		Count(&count).Error; err != nil {
+		log.Printf("[handler] count custom templates failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+	limit := h.getCustomTemplateLimit()
+	if count >= int64(limit) {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: fmt.Sprintf("自定义模板不能超过 %d 个", limit)})
+		return
+	}
+	templateID, err := randomCustomTemplateID()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+	now := timezone.Now()
+	record := model.SummaryUserTemplate{
+		SpaceID:     spaceID,
+		UserID:      userID,
+		TemplateID:  templateID,
+		Label:       req.Label,
+		Description: req.Description,
+		Pattern:     req.Pattern,
+		IsCustom:    true,
+		SortOrder:   int(count) + 1,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := h.db.Create(&record).Error; err != nil {
+		log.Printf("[handler] create custom template failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+	ok(c, gin.H{"template": templateFromRecord(record)})
+}
+
+// UpdateCustomTemplate handles PUT /api/v1/summary-templates/my/:id.
+func (h *TaskHandler) UpdateCustomTemplate(c *gin.Context) {
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 4010, Message: "authentication required"})
+		return
+	}
+	var req customTemplateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: err.Error()})
+		return
+	}
+	var valid bool
+	req, valid = validateCustomTemplateReq(c, req)
+	if !valid {
+		return
+	}
+	templateID := c.Param("id")
+	now := timezone.Now()
+	updates := map[string]interface{}{"label": req.Label, "description": req.Description, "pattern": req.Pattern, "updated_at": now}
+	res := h.db.Model(&model.SummaryUserTemplate{}).
+		Where("space_id = ? AND user_id = ? AND template_id = ? AND is_custom = 1 AND deleted_at IS NULL", spaceID, userID, templateID).
+		Updates(updates)
+	if res.Error != nil {
+		log.Printf("[handler] update custom template failed: %v", res.Error)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: res.Error.Error()})
+		return
+	}
+	if res.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "模板不存在"})
+		return
+	}
+	var record model.SummaryUserTemplate
+	if err := h.db.Where("space_id = ? AND user_id = ? AND template_id = ?", spaceID, userID, templateID).First(&record).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+	ok(c, gin.H{"template": templateFromRecord(record)})
+}
+
+// DeleteCustomTemplate handles DELETE /api/v1/summary-templates/my/:id.
+func (h *TaskHandler) DeleteCustomTemplate(c *gin.Context) {
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 4010, Message: "authentication required"})
+		return
+	}
+	now := timezone.Now()
+	res := h.db.Model(&model.SummaryUserTemplate{}).
+		Where("space_id = ? AND user_id = ? AND template_id = ? AND is_custom = 1 AND deleted_at IS NULL", spaceID, userID, c.Param("id")).
+		Updates(map[string]interface{}{"deleted_at": now, "updated_at": now})
+	if res.Error != nil {
+		log.Printf("[handler] delete custom template failed: %v", res.Error)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: res.Error.Error()})
+		return
+	}
+	if res.RowsAffected == 0 {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "模板不存在"})
+		return
+	}
+	ok(c, gin.H{})
 }
 
 func (h *TaskHandler) triggerWorker(req model.WorkerTriggerRequest) {

--- a/internal/api/handler/template_test.go
+++ b/internal/api/handler/template_test.go
@@ -1,0 +1,261 @@
+//go:build cgo
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTemplateRouter(t *testing.T) *gin.Engine {
+	return setupTemplateRouterWithLimit(t, 0)
+}
+
+func setupTemplateRouterWithLimit(t *testing.T, limit int) *gin.Engine {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.SummaryUserTemplate{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	h := NewTaskHandler(db, nil, "")
+	if limit > 0 {
+		h.SetCustomTemplateLimit(limit)
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.GET("/api/v1/summary-templates", h.GetTemplates)
+	r.POST("/api/v1/summary-templates/my", h.CreateCustomTemplate)
+	r.PUT("/api/v1/summary-templates/my/:id", h.UpdateCustomTemplate)
+	r.DELETE("/api/v1/summary-templates/my/:id", h.DeleteCustomTemplate)
+	r.PUT("/api/v1/summary-templates/:id/my", h.UpdateMyTemplate)
+	r.DELETE("/api/v1/summary-templates/:id/my", h.DeleteMyTemplate)
+	return r
+}
+
+func doTemplateReq(r *gin.Engine, method, path string, body interface{}) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	var reader *bytes.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		reader = bytes.NewReader(b)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Token", "user1")
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func decodeTemplateMap(t *testing.T, w *httptest.ResponseRecorder) map[string]map[string]interface{} {
+	t.Helper()
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Templates []map[string]interface{} `json:"templates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, w.Body.String())
+	}
+	if resp.Code != 0 {
+		t.Fatalf("code=%d body=%s", resp.Code, w.Body.String())
+	}
+	out := map[string]map[string]interface{}{}
+	for _, tpl := range resp.Data.Templates {
+		out[tpl["id"].(string)] = tpl
+	}
+	return out
+}
+
+func decodeTemplate(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Template map[string]interface{} `json:"template"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, w.Body.String())
+	}
+	if resp.Code != 0 {
+		t.Fatalf("code=%d body=%s", resp.Code, w.Body.String())
+	}
+	return resp.Data.Template
+}
+
+func TestMyTemplateOverrideAndReset(t *testing.T) {
+	r := setupTemplateRouter(t)
+
+	customLabel := "项目进展复盘"
+	customDescription := "按点分清楚并详细说明风险、负责人和下一步计划"
+	w := doTemplateReq(r, http.MethodPut, "/api/v1/summary-templates/project_progress/my", map[string]string{
+		"label":       customLabel,
+		"description": customDescription,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("put status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = doTemplateReq(r, http.MethodGet, "/api/v1/summary-templates", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", w.Code, w.Body.String())
+	}
+	templates := decodeTemplateMap(t, w)
+	project := templates["project_progress"]
+	if got := project["label"]; got != customLabel {
+		t.Fatalf("label=%q want %q", got, customLabel)
+	}
+	if got := project["description"]; got != customDescription {
+		t.Fatalf("description=%q want %q", got, customDescription)
+	}
+	if got := project["pattern"]; got != customDescription {
+		t.Fatalf("pattern=%q want %q", got, customDescription)
+	}
+	if overridden, _ := project["is_overridden"].(bool); !overridden {
+		t.Fatalf("expected is_overridden=true, got %#v", project["is_overridden"])
+	}
+	if custom, _ := project["is_custom"].(bool); custom {
+		t.Fatalf("built-in override should not be is_custom, got %#v", project["is_custom"])
+	}
+
+	w = doTemplateReq(r, http.MethodDelete, "/api/v1/summary-templates/project_progress/my", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status=%d body=%s", w.Code, w.Body.String())
+	}
+	w = doTemplateReq(r, http.MethodGet, "/api/v1/summary-templates", nil)
+	templates = decodeTemplateMap(t, w)
+	if got := templates["project_progress"]["label"]; got == customLabel {
+		t.Fatalf("label still custom after reset: %q", got)
+	}
+	if got := templates["project_progress"]["description"]; got == customDescription {
+		t.Fatalf("description still custom after reset: %q", got)
+	}
+	if overridden, _ := templates["project_progress"]["is_overridden"].(bool); overridden {
+		t.Fatalf("expected is_overridden=false after reset")
+	}
+}
+
+func TestCustomTemplateCRUD(t *testing.T) {
+	r := setupTemplateRouter(t)
+
+	w := doTemplateReq(r, http.MethodPost, "/api/v1/summary-templates/my", map[string]string{
+		"label":       "风险复盘",
+		"description": "按风险点整理",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("post status=%d body=%s", w.Code, w.Body.String())
+	}
+	created := decodeTemplate(t, w)
+	id, _ := created["id"].(string)
+	if id == "" {
+		t.Fatalf("custom template id is empty: %#v", created)
+	}
+	if custom, _ := created["is_custom"].(bool); !custom {
+		t.Fatalf("expected is_custom=true, got %#v", created["is_custom"])
+	}
+	if got := created["pattern"]; got != "按风险点整理" {
+		t.Fatalf("created pattern=%q", got)
+	}
+
+	w = doTemplateReq(r, http.MethodGet, "/api/v1/summary-templates", nil)
+	templates := decodeTemplateMap(t, w)
+	if got := templates[id]["label"]; got != "风险复盘" {
+		t.Fatalf("custom label=%q", got)
+	}
+
+	w = doTemplateReq(r, http.MethodPut, "/api/v1/summary-templates/my/"+id, map[string]string{
+		"label":       "风险复盘 v2",
+		"description": "更新后的说明",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("put custom status=%d body=%s", w.Code, w.Body.String())
+	}
+	updated := decodeTemplate(t, w)
+	if got := updated["label"]; got != "风险复盘 v2" {
+		t.Fatalf("updated label=%q", got)
+	}
+	if got := updated["pattern"]; got != "更新后的说明" {
+		t.Fatalf("updated pattern=%q", got)
+	}
+
+	w = doTemplateReq(r, http.MethodDelete, "/api/v1/summary-templates/my/"+id, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete custom status=%d body=%s", w.Code, w.Body.String())
+	}
+	w = doTemplateReq(r, http.MethodGet, "/api/v1/summary-templates", nil)
+	templates = decodeTemplateMap(t, w)
+	if _, ok := templates[id]; ok {
+		t.Fatalf("deleted custom template still returned: %#v", templates[id])
+	}
+}
+
+func TestTemplateLimitResponseDefaultAndConfigured(t *testing.T) {
+	r := setupTemplateRouter(t)
+	w := doTemplateReq(r, http.MethodGet, "/api/v1/summary-templates", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			CustomTemplateLimit int `json:"custom_template_limit"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.CustomTemplateLimit != 30 {
+		t.Fatalf("custom_template_limit=%d want 30", resp.Data.CustomTemplateLimit)
+	}
+
+	r = setupTemplateRouterWithLimit(t, 2)
+	w = doTemplateReq(r, http.MethodGet, "/api/v1/summary-templates", nil)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.CustomTemplateLimit != 2 {
+		t.Fatalf("custom_template_limit=%d want 2", resp.Data.CustomTemplateLimit)
+	}
+}
+
+func TestCustomTemplateLimitConfigured(t *testing.T) {
+	r := setupTemplateRouterWithLimit(t, 1)
+
+	w := doTemplateReq(r, http.MethodPost, "/api/v1/summary-templates/my", map[string]string{
+		"label":       "模板一",
+		"description": "总结内容一",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("first post status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = doTemplateReq(r, http.MethodPost, "/api/v1/summary-templates/my", map[string]string{
+		"label":       "模板二",
+		"description": "总结内容二",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("second post status=%d want 400 body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "自定义模板不能超过 1 个") {
+		t.Fatalf("unexpected body=%s", w.Body.String())
+	}
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SetupPublic configures the public API router on :8080.
-func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool) *gin.Engine {
+func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -37,6 +37,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 
 	// API routes
 	taskH := handler.NewTaskHandler(db, imDB, workerTriggerURL)
+	taskH.SetCustomTemplateLimit(customTemplateLimit)
 	schedH := handler.NewScheduleHandlerWithFlag(db, featureTeamSchedule)
 	personalH := handler.NewPersonalHandler(db, workerTriggerURL, hub)
 	editH := handler.NewEditHandler(db)
@@ -68,6 +69,11 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.GET("/summary-member-candidates", handler.NewCandidateHandler(imDB, candidateQueryLimit).SearchCandidates)
 		v1.GET("/summary-chat-candidates", handler.NewCandidateHandler(imDB, candidateQueryLimit).SearchChatCandidates)
 		v1.GET("/summary-templates", taskH.GetTemplates)
+		v1.POST("/summary-templates/my", taskH.CreateCustomTemplate)
+		v1.PUT("/summary-templates/my/:id", taskH.UpdateCustomTemplate)
+		v1.DELETE("/summary-templates/my/:id", taskH.DeleteCustomTemplate)
+		v1.PUT("/summary-templates/:id/my", taskH.UpdateMyTemplate)
+		v1.DELETE("/summary-templates/:id/my", taskH.DeleteMyTemplate)
 
 		v1.POST("/summary-schedules", schedH.CreateSchedule)
 		v1.GET("/summary-schedules", schedH.ListSchedules)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,10 @@ type Config struct {
 	// Candidate search query limit (-1 = no limit, >0 = use as SQL LIMIT)
 	CandidateQueryLimit int
 
+	// SummaryCustomTemplateLimit caps per-user custom summary templates per space.
+	// Default 30. Values <=0 fall back to the default in handler.
+	SummaryCustomTemplateLimit int
+
 	// Fetch concurrency for parallel channel message retrieval
 	FetchConcurrency int
 
@@ -175,6 +179,8 @@ func Load() *Config {
 
 		CandidateQueryLimit: envInt("SUMMARY_CHAT_CANDIDATE_LIMIT", -1),
 
+		SummaryCustomTemplateLimit: envInt("SUMMARY_CUSTOM_TEMPLATE_LIMIT", 30),
+
 		FetchConcurrency: envInt("FETCH_CONCURRENCY", 10),
 
 		MessageFetchBackend: strings.ToLower(strings.TrimSpace(envStr("MESSAGE_FETCH_BACKEND", "batch"))),
@@ -198,7 +204,7 @@ func Load() *Config {
 		KimiAPIKey:             envStr("KIMI_API_KEY", ""),
 		TokenizerHTTPTimeout:   envInt("TOKENIZER_HTTP_TIMEOUT", 10),
 
-		NotifyEnabled:       envBool("SUMMARY_NOTIFY_ENABLED", false),
+		NotifyEnabled: envBool("SUMMARY_NOTIFY_ENABLED", false),
 		// Custom env name (老板拍板): distinct from matter's NOTIFY_INTERNAL_TOKEN.
 		// Header contract X-Internal-Token is unchanged; only the source env differs.
 		NotifyInternalToken: envStr("SUMMARY_NOTIFY_TOKEN", ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -82,3 +82,19 @@ func TestResolveCharsPerTokenCJK_ExplicitEnvOverride(t *testing.T) {
 		t.Errorf("ResolveCharsPerTokenCJK() with explicit env = %d, want 3", got)
 	}
 }
+
+func TestLoad_SummaryCustomTemplateLimit(t *testing.T) {
+	t.Setenv("SUMMARY_CUSTOM_TEMPLATE_LIMIT", "50")
+	cfg := Load()
+	if cfg.SummaryCustomTemplateLimit != 50 {
+		t.Fatalf("SummaryCustomTemplateLimit=%d want 50", cfg.SummaryCustomTemplateLimit)
+	}
+}
+
+func TestLoad_SummaryCustomTemplateLimitDefault(t *testing.T) {
+	t.Setenv("SUMMARY_CUSTOM_TEMPLATE_LIMIT", "")
+	cfg := Load()
+	if cfg.SummaryCustomTemplateLimit != 30 {
+		t.Fatalf("SummaryCustomTemplateLimit=%d want 30", cfg.SummaryCustomTemplateLimit)
+	}
+}

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -166,6 +166,33 @@ ALTER TABLE summary_personal_result ADD COLUMN workflow_stage varchar(32) NOT NU
 -- +migrate Down
 ALTER TABLE summary_personal_result DROP COLUMN workflow_stage;
 `)},
+	"20260706-01-summary-user-template.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+CREATE TABLE summary_user_template (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  space_id TEXT NOT NULL DEFAULT '',
+  user_id TEXT NOT NULL,
+  template_id TEXT NOT NULL,
+  label TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL DEFAULT '',
+  is_custom INTEGER NOT NULL DEFAULT 0,
+  pattern TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  deleted_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX uk_summary_user_template ON summary_user_template (space_id, user_id, template_id);
+CREATE INDEX idx_summary_user_template_user ON summary_user_template (space_id, user_id, is_custom, deleted_at);
+
+-- +migrate Down
+DROP TABLE IF EXISTS summary_user_template;
+`)},
+	"20260707-01-summary-user-template-compat.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+SELECT 1;
+
+-- +migrate Down
+SELECT 1;
+`)},
 }
 
 func testSource() migrate.MigrationSource {
@@ -191,14 +218,14 @@ func TestRunMigrations_NewDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 4 {
-		t.Fatalf("expected 4 migrations applied, got %d", n)
+	if n != 6 {
+		t.Fatalf("expected 6 migrations applied, got %d", n)
 	}
 
 	tables := []string{
 		"summary_chunk", "summary_event", "summary_participant",
 		"summary_personal_result", "summary_result", "summary_schedule",
-		"summary_source", "summary_task",
+		"summary_source", "summary_task", "summary_user_template",
 	}
 	for _, tbl := range tables {
 		var name string
@@ -208,7 +235,7 @@ func TestRunMigrations_NewDB(t *testing.T) {
 		}
 	}
 
-	indexes := []string{"idx_participant_task_user", "idx_event_task_id"}
+	indexes := []string{"idx_participant_task_user", "idx_event_task_id", "uk_summary_user_template", "idx_summary_user_template_user"}
 	for _, idx := range indexes {
 		var name string
 		err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='index' AND name=?", idx).Scan(&name)
@@ -221,6 +248,14 @@ func TestRunMigrations_NewDB(t *testing.T) {
 	err = db.QueryRow("SELECT name FROM pragma_table_info('summary_personal_result') WHERE name='workflow_stage'").Scan(&workflowStageCol)
 	if err != nil {
 		t.Fatalf("workflow_stage column not found: %v", err)
+	}
+
+	for _, col := range []string{"label", "description", "is_custom", "sort_order", "deleted_at"} {
+		var name string
+		err = db.QueryRow("SELECT name FROM pragma_table_info('summary_user_template') WHERE name=?", col).Scan(&name)
+		if err != nil {
+			t.Fatalf("summary_user_template column %s not found: %v", col, err)
+		}
 	}
 }
 
@@ -259,8 +294,8 @@ func TestRunMigrations_ExistingDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 3 {
-		t.Fatalf("expected 3 migrations applied (006+007+workflow_stage), got %d", n)
+	if n != 5 {
+		t.Fatalf("expected 5 migrations applied (006+007+workflow_stage+user_template+template_compat), got %d", n)
 	}
 }
 
@@ -285,8 +320,8 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
-	if n1 != 4 {
-		t.Fatalf("first run: expected 4, got %d", n1)
+	if n1 != 6 {
+		t.Fatalf("first run: expected 6, got %d", n1)
 	}
 
 	n2, err := runMigrationsCore(db, "sqlite3", testSource())

--- a/internal/model/user_template.go
+++ b/internal/model/user_template.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+// SummaryUserTemplate stores a per-user topic template. Rows with IsCustom=false
+// override a built-in template's pattern; rows with IsCustom=true are user-created
+// templates and carry their own label/description.
+type SummaryUserTemplate struct {
+	ID          int64      `gorm:"primaryKey;autoIncrement" json:"id"`
+	SpaceID     string     `gorm:"column:space_id;type:varchar(64);not null;default:'';uniqueIndex:uk_summary_user_template" json:"space_id"`
+	UserID      string     `gorm:"column:user_id;type:varchar(64);not null;uniqueIndex:uk_summary_user_template" json:"user_id"`
+	TemplateID  string     `gorm:"column:template_id;type:varchar(64);not null;uniqueIndex:uk_summary_user_template" json:"template_id"`
+	Label       string     `gorm:"column:label;type:varchar(100);not null;default:''" json:"label"`
+	Description string     `gorm:"column:description;type:varchar(200);not null;default:''" json:"description"`
+	IsCustom    bool       `gorm:"column:is_custom;type:tinyint;not null;default:0" json:"is_custom"`
+	Pattern     string     `gorm:"column:pattern;type:text;not null" json:"pattern"`
+	SortOrder   int        `gorm:"column:sort_order;type:int;not null;default:0" json:"sort_order"`
+	DeletedAt   *time.Time `gorm:"column:deleted_at;index" json:"deleted_at,omitempty"`
+	CreatedAt   time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt   time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+}
+
+func (SummaryUserTemplate) TableName() string { return "summary_user_template" }

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -81,15 +81,15 @@ type ThinkingParam struct {
 }
 
 type chatRequestWithTools struct {
-	Model              string                 `json:"model"`
-	Messages           []ChatMessage          `json:"messages"`
-	Temperature        float64                `json:"temperature"`
-	MaxTokens          int                    `json:"max_tokens"`
-	Tools              []Tool                 `json:"tools"`
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+	MaxTokens   int           `json:"max_tokens"`
+	Tools       []Tool        `json:"tools"`
 	// ToolChoice controls function calling behavior.
 	// For Kimi models: string "auto" (Kimi does not support forced function calling).
 	// For other models: ToolChoice struct with Type="function" and Function specification.
-	ToolChoice interface{} `json:"tool_choice"`
+	ToolChoice         interface{}            `json:"tool_choice"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
 }
@@ -414,10 +414,10 @@ func buildMapSystemPrompt(userName, topic string) string {
 ## 输出要求
 - 紧密围绕主题，与主题无关的闲聊、表情、寒暄等直接跳过
 - 提炼关键信息：讨论了什么、达成了什么结论、有什么待办、谁负责什么
-- 【强制】输出总长度不超过 2000 token（约 1500 字），超出时优先保留关键结论和待办事项，压缩次要细节
+- 默认输出总长度不超过 2000 token（约 1500 字）；如果总结主题明确要求详细说明、完整展开或逐项说明，可在模型输出预算内适当展开，但仍需避免无关内容和原文复述
 - 如果聊天记录中没有明确结论，如实说明"尚未达成共识"，不要编造
 - 有待办事项时，用 ` + "`- [ ] 内容（负责人）`" + ` 格式列出
-- 根据实际内容自行组织结构，不需要套用固定模板
+- 如果总结主题中包含输出结构、详细程度、分点方式、待办格式等要求，必须优先遵循；如果主题没有指定结构，再根据实际内容自行组织结构
 - 保持简洁，不要复述原文，用自己的话归纳
 
 ## 引用规则（必须严格遵守）
@@ -452,11 +452,11 @@ func buildReduceSystemPrompt(topic string) string {
 	sb.WriteString(`要求：
 - 合并相同主题，去除重复
 - 保留所有待办事项和责任人
-- 输出总长度不超过 2000 token（约 1500 字），超出时合并相似要点、压缩细节
+- 默认输出总长度不超过 2000 token（约 1500 字）；如果总结主题明确要求详细说明、完整展开或逐项说明，可在模型输出预算内适当展开，但仍需合并相似要点、压缩无关细节
 - 如有冲突信息，保留最新的
 - 保留所有 [n] 引用标记，不要删除或修改
 - 合并相同要点时，合并其引用编号
-- 根据实际内容自行组织结构，不需要套用固定模板
+- 如果总结主题中包含输出结构、详细程度、分点方式、待办格式等要求，必须优先遵循；如果主题没有指定结构，再根据实际内容自行组织结构
 - 用显示名称指代人，绝对不要输出 UID 或用户 ID
 - 输出语言与输入语言保持一致
 
@@ -526,7 +526,7 @@ func (c *LLMClient) CallReduce(ctx context.Context, chunkSummaries []string, sou
 
 // CallReduceByPerson merges participant-level summaries.
 // Each participant is assigned a [Pn] tag that the LLM should reference in the output.
-func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string) (string, int, error) {
+func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
 	var parts []string
 	for i, ps := range participantSummaries {
 		parts = append(parts, fmt.Sprintf("[P%d]【%s 的工作总结】\n%s", i+1, ps.Name, ps.Summary))
@@ -541,11 +541,11 @@ func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries
 - 每个要点末尾必须标注来源成员编号，格式为 [Pn]，例如 [P1]、[P2]
 - 多位成员贡献同一要点时，列出所有编号，如 [P1][P3]
 - 只引用真实存在的编号，不要捏造
-- 根据实际内容自行组织结构，不需要套用固定模板
+- 如果总结主题中包含输出结构、详细程度、分点方式、待办格式等要求，必须优先遵循；如果主题没有指定结构，再根据实际内容自行组织结构
 - 用显示名称指代人，绝对不要输出 UID 或用户 ID`
 
 	return c.Call(ctx, []ChatMessage{
 		{Role: "system", Content: system},
-		{Role: "user", Content: fmt.Sprintf("时间范围：%s ~ %s\n\n%s", startTime, endTime, text)},
+		{Role: "user", Content: fmt.Sprintf("总结主题：%s\n时间范围：%s ~ %s\n\n%s", topic, startTime, endTime, text)},
 	}, 0.1)
 }

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -201,7 +201,7 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			}
 
 			reduceStart := time.Now()
-			content, tokens, err := m.proc.llm.CallReduceByPerson(ctx, participantSummaries, startTime, endTime)
+			content, tokens, err := m.proc.llm.CallReduceByPerson(ctx, participantSummaries, startTime, endTime, task.Title)
 			reportKey := "team#" + strconv.FormatInt(taskID, 10)
 			timing.RecordLLMSince(reportKey, "团队汇总: 合并各成员总结", reduceStart, tokens)
 			timing.FlushReport(reportKey, time.Since(reduceStart).Milliseconds(), nil)

--- a/migrations/sql/20260706-01-summary-user-template.sql
+++ b/migrations/sql/20260706-01-summary-user-template.sql
@@ -1,0 +1,21 @@
+-- +migrate Up
+CREATE TABLE `summary_user_template` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `space_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `user_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `template_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `label` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `description` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `is_custom` tinyint NOT NULL DEFAULT 0,
+  `pattern` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sort_order` int NOT NULL DEFAULT 0,
+  `deleted_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_summary_user_template` (`space_id`,`user_id`,`template_id`),
+  KEY `idx_summary_user_template_user` (`space_id`,`user_id`,`is_custom`,`deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_user_template`;

--- a/migrations/sql/20260707-01-summary-user-template-compat.sql
+++ b/migrations/sql/20260707-01-summary-user-template-compat.sql
@@ -1,0 +1,78 @@
+-- +migrate Up
+-- Compatibility migration for environments that already ran the early
+-- 20260706-01-summary-user-template.sql before custom-template fields existed.
+SET @stmt = (
+  SELECT IF(COUNT(*) = 0,
+    'ALTER TABLE `summary_user_template` ADD COLUMN `label` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''''',
+    'SELECT 1'
+  )
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'summary_user_template' AND COLUMN_NAME = 'label'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @stmt = (
+  SELECT IF(COUNT(*) = 0,
+    'ALTER TABLE `summary_user_template` ADD COLUMN `description` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''''',
+    'SELECT 1'
+  )
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'summary_user_template' AND COLUMN_NAME = 'description'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @stmt = (
+  SELECT IF(COUNT(*) = 0,
+    'ALTER TABLE `summary_user_template` ADD COLUMN `is_custom` tinyint NOT NULL DEFAULT 0',
+    'SELECT 1'
+  )
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'summary_user_template' AND COLUMN_NAME = 'is_custom'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @stmt = (
+  SELECT IF(COUNT(*) = 0,
+    'ALTER TABLE `summary_user_template` ADD COLUMN `sort_order` int NOT NULL DEFAULT 0',
+    'SELECT 1'
+  )
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'summary_user_template' AND COLUMN_NAME = 'sort_order'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @stmt = (
+  SELECT IF(COUNT(*) = 0,
+    'ALTER TABLE `summary_user_template` ADD COLUMN `deleted_at` datetime DEFAULT NULL',
+    'SELECT 1'
+  )
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'summary_user_template' AND COLUMN_NAME = 'deleted_at'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @stmt = (
+  SELECT IF(COUNT(*) = 0,
+    'CREATE INDEX `idx_summary_user_template_user` ON `summary_user_template` (`space_id`, `user_id`, `is_custom`, `deleted_at`)',
+    'SELECT 1'
+  )
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'summary_user_template' AND INDEX_NAME = 'idx_summary_user_template_user'
+);
+PREPARE stmt FROM @stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- +migrate Down
+-- No-op: these columns are part of the canonical 20260706 schema for fresh databases.
+SELECT 1;


### PR DESCRIPTION
Add per-user summary templates and expand the built-in template scenarios.

The summary template API only exposed fixed built-in templates, so repeated user preferences such as structure, detail level, action-item extraction, or OKR alignment could not be persisted.

## Changes

- Add `summary_user_template` storage for user template overrides and custom templates.
- Add APIs for listing, overriding, resetting, creating, updating, and deleting templates.
- Add a configurable custom template limit with a default of 30.
- Expand built-in templates from four to eight scenarios.
- Normalize built-in templates to the label and description model while keeping `pattern` for compatibility.
- Update prompt handling to respect user-provided topic structure.
- Add a compatibility migration for environments that may have run an earlier version of the template table migration.

## Tests

- `go test ./internal/api/handler ./internal/db ./internal/service ./internal/config ./internal/api/router`
- `git diff --check`

## Impact

- Adds the `summary_user_template` table.
- Keeps `pattern` in API responses for compatibility.
- Existing built-in templates remain available with updated descriptions.

Closes #128