### PR TITLE
fix(schedule): 定时任务编辑消息来源加可访问性/权限校验 (#143 后端)

### DIFF
--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -22,21 +23,174 @@ import (
 // ScheduleHandler handles schedule endpoints.
 type ScheduleHandler struct {
 	db *gorm.DB
+	// imDB is the IM database used to verify that a user actually has access to
+	// the group/thread sources they attach to a schedule (#143). When nil the
+	// source-access check is skipped (fail-open) with a warning; production
+	// wiring in router.SetupPublic always injects it, so fail-open is limited to
+	// tests/tools that construct the handler without an IM DB.
+	imDB *gorm.DB
 	// featureTeamSchedule, when true, bypasses the multi-person rejection guards
 	// (FEATURE_TEAM_SCHEDULE). Default false keeps the existing 40015 behavior.
 	featureTeamSchedule bool
+	// collate is the SQL COLLATE clause used for cross-table group_no comparisons
+	// in the IM DB (MySQL collation mismatch between `thread`/`group` and their
+	// member tables). Production wiring uses scheduleSourceCollate; tests against
+	// sqlite set it to "" so the thread/group-status path can actually run (sqlite
+	// rejects the MySQL-only COLLATE name). Mirrors CandidateHandler.collate.
+	collate string
 }
 
 // NewScheduleHandler creates a new ScheduleHandler.
+//
+// Deprecated for production wiring: it leaves imDB nil, which disables the
+// source-access check. Kept for tests/tools; production must use
+// NewScheduleHandlerWithIMDB / NewScheduleHandlerWithFlag so imDB is injected.
 func NewScheduleHandler(db *gorm.DB) *ScheduleHandler {
-	return &ScheduleHandler{db: db}
+	return &ScheduleHandler{db: db, collate: scheduleSourceCollate}
 }
 
 // NewScheduleHandlerWithFlag creates a ScheduleHandler with the team-schedule
 // feature flag explicitly set. When featureTeamSchedule is true the multi-person
 // rejection guards are bypassed so multi-participant schedules can be created.
+//
+// Deprecated for production wiring: prefer NewScheduleHandlerWithIMDB which also
+// injects imDB for the source-access check. Retained for existing test callers.
 func NewScheduleHandlerWithFlag(db *gorm.DB, featureTeamSchedule bool) *ScheduleHandler {
-	return &ScheduleHandler{db: db, featureTeamSchedule: featureTeamSchedule}
+	return &ScheduleHandler{db: db, featureTeamSchedule: featureTeamSchedule, collate: scheduleSourceCollate}
+}
+
+// NewScheduleHandlerWithIMDB creates a ScheduleHandler with both the IM DB (for
+// the #143 source-access check) and the team-schedule feature flag. This is the
+// constructor production wiring must use so schedule sources are validated
+// against real group/thread membership.
+func NewScheduleHandlerWithIMDB(db *gorm.DB, imDB *gorm.DB, featureTeamSchedule bool) *ScheduleHandler {
+	return &ScheduleHandler{db: db, imDB: imDB, featureTeamSchedule: featureTeamSchedule, collate: scheduleSourceCollate}
+}
+
+// scheduleSourceCollate is the COLLATE clause required for cross-table group_no
+// comparisons in the IM DB (MySQL collation mismatch between `thread`/`group`
+// and `group_member`). Mirrors CandidateHandler.collate and the raw SQL in
+// pipeline/resolve_channel.go and service/summary.go. Production wiring passes
+// this via ScheduleHandler.collate; sqlite tests pass "" (see F3).
+const scheduleSourceCollate = " COLLATE utf8mb4_unicode_ci"
+
+// validateSourcesAccessible verifies that userID may access every source in the
+// list, using IM DB membership. Fail-closed: any source the user cannot be
+// shown to access returns an error. When imDB is nil the check is skipped
+// (fail-open) with a warning — production always injects imDB.
+//
+// collate is the cross-table COLLATE clause (scheduleSourceCollate in production,
+// "" under sqlite tests) applied to every group_no join, mirroring
+// pipeline/fetch.go (GetUserChannels) and candidates.go so the same membership
+// semantics are enforced here.
+//
+//   - source_type=1 (group): user must be a non-deleted member of a live group
+//     (g.status=1). source_id may carry a "____{space_id}" suffix; only the
+//     group_no prefix is used (see ResolveSourceNameWithType case 1).
+//   - source_type=2 (thread/子区): source_id is "{group_no}____{short_id}"; the
+//     user must be a member of a non-deleted thread (t.status IN (1,2), i.e.
+//     Active|Archived, NOT Deleted=3) whose parent group is live (g.status=1).
+//     group_no is compared across tables with COLLATE. A deleted thread with a
+//     residual thread_member row is rejected (F2).
+//   - source_type=3 (DM): fail-closed. An empty source_id is rejected (F1); a
+//     non-empty peer must be a conversation the user actually holds — verified
+//     against conversation_extra (uid=current, channel_id=peer, channel_type=1),
+//     the same DM-ownership source of truth as GetUserChannels. Unknown types
+//     are rejected fail-closed.
+func validateSourcesAccessible(imDB *gorm.DB, collate string, userID string, sources []sourceReq) error {
+	if imDB == nil {
+		log.Printf("[schedule] validateSourcesAccessible: imDB not injected, skipping source-access check (fail-open) for user=%q sources=%d", userID, len(sources))
+		return nil
+	}
+	if userID == "" {
+		return errors.New("missing user id for source access check")
+	}
+	for _, s := range sources {
+		switch s.SourceType {
+		case 1: // group
+			groupNo := s.SourceID
+			if idx := strings.Index(groupNo, "____"); idx > 0 {
+				groupNo = groupNo[:idx]
+			}
+			if groupNo == "" {
+				return errors.New("invalid group source id")
+			}
+			var cnt int64
+			// Membership + live-group guard (mirrors GetUserChannels: g.status=1 and
+			// gm.is_deleted=0). group_no is compared across `group`/group_member with
+			// COLLATE, matching candidates.go's group-thread joins.
+			if err := imDB.Raw(
+				"SELECT 1 FROM group_member gm "+
+					"INNER JOIN `group` g ON g.group_no"+collate+" = gm.group_no "+
+					"WHERE gm.uid = ? AND gm.group_no = ? AND gm.is_deleted = 0 AND g.status = 1 "+
+					"LIMIT 1",
+				userID, groupNo,
+			).Scan(&cnt).Error; err != nil {
+				log.Printf("[schedule] validateSourcesAccessible: group query failed user=%q group=%q: %v", userID, groupNo, err)
+				return err
+			}
+			if cnt == 0 {
+				return errors.New("user not a member of group source")
+			}
+		case 2: // thread / 子区
+			parts := strings.SplitN(s.SourceID, "____", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				return errors.New("invalid thread source id")
+			}
+			groupNo := parts[0]
+			shortID := parts[1]
+			var cnt int64
+			// Membership of a NON-DELETED thread whose parent group is live (F2):
+			//   - t.status IN (1,2): Active|Archived; Deleted=3 is excluded so a
+			//     residual thread_member row on a deleted thread no longer passes.
+			//   - g.status=1: parent group must still be live.
+			// group_no is compared across `group`/thread with COLLATE, matching
+			// GetUserChannels' thread join. The literal group_no bind on t.group_no
+			// disambiguates the (group_no, short_id) composite key.
+			if err := imDB.Raw(
+				"SELECT 1 FROM thread t "+
+					"INNER JOIN thread_member tm ON tm.thread_id = t.id "+
+					"INNER JOIN `group` g ON g.group_no"+collate+" = t.group_no "+
+					"WHERE tm.uid = ? AND t.group_no"+collate+" = ? AND t.short_id = ? "+
+					"AND t.status IN (1, 2) AND g.status = 1 "+
+					"LIMIT 1",
+				userID, groupNo, shortID,
+			).Scan(&cnt).Error; err != nil {
+				log.Printf("[schedule] validateSourcesAccessible: thread query failed user=%q group=%q short=%q: %v", userID, groupNo, shortID, err)
+				return err
+			}
+			if cnt == 0 {
+				return errors.New("user not a member of thread source")
+			}
+		case 3: // DM / 私聊
+			// F1 fail-closed: never accept an empty DM peer id (empty id would also
+			// break later source materialization). source_id is the peer uid, matching
+			// ResolveSourceNameWithType case 3 and conversation_extra.channel_id.
+			peer := s.SourceID
+			if peer == "" {
+				return errors.New("invalid dm source id")
+			}
+			var cnt int64
+			// Deep ownership check: the current user must actually hold this P2P
+			// conversation. conversation_extra(uid=current, channel_id=peer,
+			// channel_type=1) is the same DM source of truth GetUserChannels reads
+			// (internal/pipeline/fetch.go). No arbitrary/other users' DM peer can be
+			// attached.
+			if err := imDB.Raw(
+				"SELECT 1 FROM conversation_extra WHERE uid = ? AND channel_id = ? AND channel_type = 1 LIMIT 1",
+				userID, peer,
+			).Scan(&cnt).Error; err != nil {
+				log.Printf("[schedule] validateSourcesAccessible: dm query failed user=%q peer=%q: %v", userID, peer, err)
+				return err
+			}
+			if cnt == 0 {
+				return errors.New("user does not own dm source conversation")
+			}
+		default:
+			return errors.New("unknown source type")
+		}
+	}
+	return nil
 }
 
 type createScheduleReq struct {
@@ -536,6 +690,11 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 
 	var sourceConfig model.JSON
 	if len(req.Sources) > 0 {
+		if err := validateSourcesAccessible(h.imDB, h.collate, userID, req.Sources); err != nil {
+			log.Printf("[schedule] CreateSchedule: source access denied user=%q: %v", userID, err)
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40004, Message: "无权将来源修改为无权访问的群/子区"})
+			return
+		}
 		b, _ := json.Marshal(req.Sources)
 		sourceConfig = b
 	}
@@ -1137,6 +1296,11 @@ func (h *ScheduleHandler) UpdateSchedule(c *gin.Context) {
 		updates["time_range_type"] = *req.TimeRangeType
 	}
 	if req.Sources != nil {
+		if err := validateSourcesAccessible(h.imDB, h.collate, userID, req.Sources); err != nil {
+			log.Printf("[schedule] UpdateSchedule: source access denied user=%q sched=%d: %v", userID, schedID, err)
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40004, Message: "无权将来源修改为无权访问的群/子区"})
+			return
+		}
 		b, _ := json.Marshal(req.Sources)
 		updates["source_config"] = model.JSON(b)
 	}

--- a/internal/api/handler/schedule_behavior_test.go
+++ b/internal/api/handler/schedule_behavior_test.go
@@ -1296,3 +1296,326 @@ func TestUpdateSchedule_ManualToScheduled_BackfillsTaskParticipants(t *testing.T
 		t.Errorf("manual->confirm conversion must reset everyone to unconfirmed, got %+v", cfg.Participants)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #143: schedule "source" access/permission validation on create/update.
+//
+// A schedule creator must not be able to point a schedule at a group/thread they
+// have no access to (which would later let the scheduler pull those channels'
+// messages on their behalf). These tests seed a minimal IM DB (group_member /
+// thread / thread_member) in sqlite and drive the HTTP contract.
+// ---------------------------------------------------------------------------
+
+// newSourceAccessIMDB returns an in-memory sqlite DB shaped like the minimal
+// slice of the IM schema the source-access check reads from.
+func newSourceAccessIMDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	imDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open imDB: %v", err)
+	}
+	stmts := []string{
+		"CREATE TABLE `group` (group_no TEXT, status INTEGER DEFAULT 1)",
+		"CREATE TABLE group_member (uid TEXT, group_no TEXT, is_deleted INTEGER DEFAULT 0)",
+		// thread carries status (1=Active,2=Archived,3=Deleted) so the F2 status
+		// filter can be exercised; short_id + group_no form the composite key.
+		"CREATE TABLE thread (id INTEGER PRIMARY KEY, group_no TEXT, short_id TEXT, status INTEGER DEFAULT 1)",
+		"CREATE TABLE thread_member (thread_id INTEGER, uid TEXT)",
+		// conversation_extra is the DM (P2P) ownership source of truth (channel_type=1).
+		"CREATE TABLE conversation_extra (uid TEXT, channel_id TEXT, channel_type INTEGER DEFAULT 1)",
+	}
+	for _, s := range stmts {
+		if err := imDB.Exec(s).Error; err != nil {
+			t.Fatalf("create im table: %v", err)
+		}
+	}
+	return imDB
+}
+
+// newScheduleTestRouterWithIMDB wires the schedule handler with an injected IM
+// DB so the #143 source-access check is active.
+func newScheduleTestRouterWithIMDB(db, imDB *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	sh := NewScheduleHandlerWithIMDB(db, imDB, true)
+	// sqlite rejects the MySQL-only " COLLATE utf8mb4_unicode_ci" name; blank the
+	// collate so the group/thread status joins run under the test harness (F3).
+	sh.collate = ""
+	r.POST("/api/v1/summary-schedules", sh.CreateSchedule)
+	r.PUT("/api/v1/summary-schedules/:id", sh.UpdateSchedule)
+	return r
+}
+
+// seedScheduleWithSource creates a bound schedule (via handler create) whose
+// source_config is a single group the creator IS a member of, and returns it.
+func seedAccessibleSchedule(t *testing.T, db, imDB *gorm.DB, r *gin.Engine) model.SummarySchedule {
+	t.Helper()
+	taskID := seedScheduleTask(t, db, "T143", "s1", "u1")
+	// u1 is a member of the live "old" group so the initial create passes the check.
+	imDB.Exec("INSERT INTO `group` (group_no, status) VALUES (?, 1)", "gOld")
+	imDB.Exec("INSERT INTO group_member (uid, group_no, is_deleted) VALUES (?, ?, 0)", "u1", "gOld")
+	wc := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID, "interval_days": 1, "run_time": "09:00",
+		"confirm_policy": 0,
+		"sources":        []map[string]interface{}{{"source_type": 1, "source_id": "gOld", "source_name": "Old"}},
+	})
+	if wc.Code != http.StatusOK {
+		t.Fatalf("seed create schedule: %d %s", wc.Code, wc.Body.String())
+	}
+	var sched model.SummarySchedule
+	db.Where("creator_id = ?", "u1").First(&sched)
+	return sched
+}
+
+func TestUpdateSchedule_SourceAccess_AllowedGroupUpdates(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+
+	// u1 is also a member of the new live target group "gNew" -> allowed.
+	imDB.Exec("INSERT INTO `group` (group_no, status) VALUES (?, 1)", "gNew")
+	imDB.Exec("INSERT INTO group_member (uid, group_no, is_deleted) VALUES (?, ?, 0)", "u1", "gNew")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "gNew", "source_name": "New"}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 updating to accessible group, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if !bytes.Contains(got.SourceConfig, []byte("gNew")) {
+		t.Fatalf("source_config should have been updated to gNew, got %s", string(got.SourceConfig))
+	}
+}
+
+func TestUpdateSchedule_SourceAccess_DeniedGroupRejected(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+	before := string(sched.SourceConfig)
+
+	// u1 is NOT a member of "gSecret" -> fail-closed 403, source_config unchanged.
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "gSecret", "source_name": "Secret"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for inaccessible group, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if string(got.SourceConfig) != before {
+		t.Fatalf("source_config must NOT change on denied update; before=%s after=%s", before, string(got.SourceConfig))
+	}
+	if bytes.Contains(got.SourceConfig, []byte("gSecret")) {
+		t.Fatalf("BUG: inaccessible source gSecret leaked into source_config: %s", string(got.SourceConfig))
+	}
+}
+
+func TestUpdateSchedule_SourceAccess_NilIMDBSkipsCheck(t *testing.T) {
+	db := newScheduleTestDB(t)
+	// Router without imDB -> fail-open (check skipped), must not panic.
+	r := newScheduleTestRouterWithFlag(db, true)
+	taskID := seedScheduleTask(t, db, "T143N", "s1", "u1")
+	wc := scheduleReq(t, r, "u1", "s1", http.MethodPost, "/api/v1/summary-schedules", map[string]interface{}{
+		"scope": "task", "task_id": taskID, "interval_days": 1, "run_time": "09:00", "confirm_policy": 0,
+	})
+	if wc.Code != http.StatusOK {
+		t.Fatalf("seed create: %d %s", wc.Code, wc.Body.String())
+	}
+	var sched model.SummarySchedule
+	db.Where("creator_id = ?", "u1").First(&sched)
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 1, "source_id": "gAnything", "source_name": "X"}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("nil imDB should skip check and allow update, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #143 R2: thread (source_type=2) access, thread status filtering (F2), and the
+// "all-or-nothing" mixed-source contract. These run with collate="" so the
+// group/thread status joins execute under sqlite (F3).
+// ---------------------------------------------------------------------------
+
+// seedThread inserts a thread row (+ optional membership) and its live parent
+// group into the source-access IM DB.
+func seedThread(t *testing.T, imDB *gorm.DB, id int64, groupNo, shortID string, status int, memberUID string) {
+	t.Helper()
+	imDB.Exec("INSERT OR IGNORE INTO `group` (group_no, status) VALUES (?, 1)", groupNo)
+	imDB.Exec("INSERT INTO thread (id, group_no, short_id, status) VALUES (?, ?, ?, ?)", id, groupNo, shortID, status)
+	if memberUID != "" {
+		imDB.Exec("INSERT INTO thread_member (thread_id, uid) VALUES (?, ?)", id, memberUID)
+	}
+}
+
+// thread the user is an active member of -> update to it is allowed.
+func TestUpdateSchedule_SourceAccess_ThreadActiveAllowed(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+
+	// Active thread (status=1) in live group gT1, u1 is a member.
+	seedThread(t, imDB, 1, "gT1", "th1", 1, "u1")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 2, "source_id": "gT1____th1", "source_name": "Th1"}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for active thread the user belongs to, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if !bytes.Contains(got.SourceConfig, []byte("gT1____th1")) {
+		t.Fatalf("source_config should have been updated to the thread, got %s", string(got.SourceConfig))
+	}
+}
+
+// user is NOT a member of the thread -> 403, source_config unchanged.
+func TestUpdateSchedule_SourceAccess_ThreadNoMembershipRejected(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+	before := string(sched.SourceConfig)
+
+	// Active thread but only "other" is a member; u1 is not.
+	seedThread(t, imDB, 2, "gT2", "th2", 1, "other")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 2, "source_id": "gT2____th2", "source_name": "Th2"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for thread the user is not in, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if string(got.SourceConfig) != before {
+		t.Fatalf("source_config must NOT change on denied thread update; before=%s after=%s", before, string(got.SourceConfig))
+	}
+}
+
+// F2: a DELETED thread (status=3) with a residual thread_member row must be
+// rejected even though membership exists.
+func TestUpdateSchedule_SourceAccess_DeletedThreadRejected(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+	before := string(sched.SourceConfig)
+
+	// Deleted thread (status=3) but u1 still has a residual membership row.
+	seedThread(t, imDB, 3, "gT3", "th3", 3, "u1")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 2, "source_id": "gT3____th3", "source_name": "Th3"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for DELETED thread (status=3) despite residual membership, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if string(got.SourceConfig) != before {
+		t.Fatalf("source_config must NOT change for a deleted thread; before=%s after=%s", before, string(got.SourceConfig))
+	}
+}
+
+// Mixed "all-or-nothing": one accessible group + one inaccessible group in the
+// same update must reject the WHOLE request (403) and leave source_config intact.
+func TestUpdateSchedule_SourceAccess_MixedSourcesAllOrNothing(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+	before := string(sched.SourceConfig)
+
+	// gOK is live and u1 is a member; gDenied is one u1 cannot access.
+	imDB.Exec("INSERT INTO `group` (group_no, status) VALUES (?, 1)", "gOK")
+	imDB.Exec("INSERT INTO group_member (uid, group_no, is_deleted) VALUES (?, ?, 0)", "u1", "gOK")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{
+			{"source_type": 1, "source_id": "gOK", "source_name": "OK"},
+			{"source_type": 1, "source_id": "gDenied", "source_name": "Denied"},
+		},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 rejecting the whole mixed request, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if string(got.SourceConfig) != before {
+		t.Fatalf("all-or-nothing: source_config must be unchanged; before=%s after=%s", before, string(got.SourceConfig))
+	}
+	if bytes.Contains(got.SourceConfig, []byte("gOK")) || bytes.Contains(got.SourceConfig, []byte("gDenied")) {
+		t.Fatalf("BUG: partial mixed source leaked into source_config: %s", string(got.SourceConfig))
+	}
+}
+
+// F1: DM (source_type=3) with an EMPTY source_id must be rejected (fail-closed).
+func TestUpdateSchedule_SourceAccess_DMEmptyIDRejected(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+	before := string(sched.SourceConfig)
+
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 3, "source_id": "", "source_name": "DM"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for empty DM source_id (fail-closed), got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if string(got.SourceConfig) != before {
+		t.Fatalf("source_config must NOT change for empty DM id; before=%s after=%s", before, string(got.SourceConfig))
+	}
+}
+
+// F1: DM (source_type=3) the user does NOT own (no conversation_extra row) must
+// be rejected (fail-closed deep check).
+func TestUpdateSchedule_SourceAccess_DMNotOwnedRejected(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+	before := string(sched.SourceConfig)
+
+	// A conversation between OTHER users; u1 holds no such conversation.
+	imDB.Exec("INSERT INTO conversation_extra (uid, channel_id, channel_type) VALUES (?, ?, 1)", "other", "peerX")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 3, "source_id": "peerX", "source_name": "DM"}},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for a DM the user does not own, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if string(got.SourceConfig) != before {
+		t.Fatalf("source_config must NOT change for an unowned DM; before=%s after=%s", before, string(got.SourceConfig))
+	}
+}
+
+// F1 counterpart: a DM the user DOES own (conversation_extra row present) passes.
+func TestUpdateSchedule_SourceAccess_DMOwnedAllowed(t *testing.T) {
+	db := newScheduleTestDB(t)
+	imDB := newSourceAccessIMDB(t)
+	r := newScheduleTestRouterWithIMDB(db, imDB)
+	sched := seedAccessibleSchedule(t, db, imDB, r)
+
+	// u1 holds the P2P conversation with peerA (channel_type=1).
+	imDB.Exec("INSERT INTO conversation_extra (uid, channel_id, channel_type) VALUES (?, ?, 1)", "u1", "peerA")
+	w := scheduleReq(t, r, "u1", "s1", http.MethodPut, "/api/v1/summary-schedules/"+sid(sched.ID), map[string]interface{}{
+		"sources": []map[string]interface{}{{"source_type": 3, "source_id": "peerA", "source_name": "DM"}},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a DM the user owns, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.SummarySchedule
+	db.First(&got, sched.ID)
+	if !bytes.Contains(got.SourceConfig, []byte("peerA")) {
+		t.Fatalf("source_config should have been updated to the owned DM, got %s", string(got.SourceConfig))
+	}
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -38,7 +38,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	// API routes
 	taskH := handler.NewTaskHandler(db, imDB, workerTriggerURL)
 	taskH.SetCustomTemplateLimit(customTemplateLimit)
-	schedH := handler.NewScheduleHandlerWithFlag(db, featureTeamSchedule)
+	schedH := handler.NewScheduleHandlerWithIMDB(db, imDB, featureTeamSchedule)
 	personalH := handler.NewPersonalHandler(db, workerTriggerURL, hub)
 	editH := handler.NewEditHandler(db)
 


### PR DESCRIPTION
## 背景 / Issue
Fixes #143 后端部分：定时任务编辑「消息来源」缺少可访问性/权限校验。

`CreateSchedule` / `UpdateSchedule` 此前把用户传入的 `sources` 直接写入 `source_config`，**未校验该用户是否有权访问这些群/子区/DM**。用户可把定时任务来源改成自己无权访问的渠道，后续定时触发即越权拉取那些渠道消息。

## 改动
对每个来源做 **fail-closed** 可访问性校验（`validateSourcesAccessible`），任一来源无权则整体 403（全或无），`source_config` 不落库：

- **群 (type=1)**：`group_member` 成员 + `group.status=1`（活跃群）。
- **子区 (type=2)**：`thread_member` 成员 + `thread.status IN (1,2)`（排除已删=3）+ 父群 `status=1`。
- **DM (type=3)**：`conversation_extra(uid,channel_id,channel_type=1)` 归属校验（与 `GetUserChannels` DM 发现路径同源），并拒绝空 `source_id`。
- 未知 type → 拒绝。
- `ScheduleHandler` 注入 `imDB` + 可注入 `collate`（生产默认 MySQL COLLATE，测试置空以兼容 sqlite）。
- Create/Update 两路复用同一校验函数。

## 测试
新增 10 个用例（合并进 `schedule_behavior_test.go`）：群有权/无权、子区有权/无权/已删、混合来源全或无、DM 空 id/非本人/本人、imDB=nil 跳过。`go build ./...` 与 `go test ./internal/api/handler/... -run "Schedule|SourceAccess"` 全绿。

## 部署前提 / 必配环境变量
无新增环境变量、**无 DB schema 变更 / 无新 migration**。仅要求 API 容器的 IM 数据库连接（`imDB`）已正常注入（现有 `SetupPublic` 已具备），线上默认满足。

## 说明
- 纯 API 侧校验逻辑，worker 未改动。
- 错误信息统一为「无权将来源修改为无权访问的群/子区」，不泄漏具体资源是否存在。
