### PR TITLE
feat(notify): append summary detail deep link to completed notifications (#150)

### DIFF
--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -113,6 +113,7 @@ func main() {
 			notifier = notify.New(summaryDB, imDB, deliverer, notify.Config{
 				Enabled:     true,
 				MaxAttempts: cfg.MaxNotifyAttempts,
+				WebBaseURL:  cfg.SummaryWebBaseURL,
 			}).WithErrorSanitizer(worker.SanitizeErrorForUser)
 			log.Printf("[worker] terminal-state notifications ENABLED (internal-notify transport)")
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,8 +126,8 @@ type Config struct {
 	// summary_notification.last_error. Prod + NotifyEnabled but empty => startup
 	// fatal (fail-fast on misconfig); dev only warns.
 	NotifyInternalToken string
-	// SummaryWebBaseURL is the base for a result link in the notification text.
-	// Empty => no link appended.
+	// SummaryWebBaseURL is the front-end base for the completed-notification
+	// detail deep link. Empty => no link appended.
 	SummaryWebBaseURL string
 	// AppEnv is the deployment environment ("prod" | "dev"). Drives the
 	// prod-fatal / dev-warn handling of a missing NotifyInternalToken.

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -37,6 +37,9 @@ import (
 type Config struct {
 	Enabled     bool
 	MaxAttempts int
+	// WebBaseURL is the front-end base for the completed-notification detail
+	// deep link; empty disables it (safe plain-text fallback).
+	WebBaseURL string
 }
 
 // Notifier wires the dedup state machine (summary DB) to the bot Deliverer.
@@ -393,8 +396,7 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 		// - 参与成员：多人任务的成员数（单人任务无意义，省略）；
 		// - 消息数量：本次总结处理的消息条数；
 		// - 生成时间：结果产出的本地时间。
-		// 之前这里追加的是「查看结果：<link>」外链，但该链接与前端真实入口
-		// （WKApp 内部路由 /summary/detail?taskId=）三重错位、根本打不开，已移除。
+		// 详情深链在元信息之后追加：仅 completed 加，且 WebBaseURL 为空时不加。
 		if tr := formatTimeRange(task); tr != "" {
 			fmt.Fprintf(&b, "\n时间范围：%s", tr)
 		}
@@ -407,6 +409,9 @@ func (n *Notifier) buildText(task model.SummaryTask, kind, errMsg string) string
 		}
 		if !meta.generatedAt.IsZero() {
 			fmt.Fprintf(&b, "\n生成时间：%s", timezone.In(meta.generatedAt).Format("2006-01-02 15:04"))
+		}
+		if strings.TrimSpace(n.cfg.WebBaseURL) != "" {
+			fmt.Fprintf(&b, "\n查看详情：%s/summary/detail?taskId=%d", strings.TrimRight(n.cfg.WebBaseURL, "/"), task.ID)
 		}
 		return b.String()
 	case model.NotifyKindFailed:

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -114,10 +114,10 @@ func TestOnTaskTerminal_CompletedDelivers(t *testing.T) {
 	if !strings.Contains(text, "今日群聊") {
 		t.Fatalf("completed text missing title: %q", text)
 	}
-	// The unreachable WKApp-internal result link was removed (see notify.go
-	// buildText); success notifications must NOT carry a browser URL anymore.
-	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") {
-		t.Fatalf("completed text must not carry a result link anymore: %q", text)
+	// WebBaseURL is empty here, so the detail deep link must NOT be appended
+	// (safe plain-text fallback); the old unreachable WKApp result link is gone too.
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") || strings.Contains(text, "/summary/detail?taskId=") {
+		t.Fatalf("completed text must not carry a link when WebBaseURL is empty: %q", text)
 	}
 	// octo-server recognizes a plain-text bot message by ContentType type=1 (Text)
 	// carrying "content"; a bare {"text":...} renders empty. Assert the wire shape.
@@ -800,8 +800,45 @@ func TestBuildText_CompletedIncludesSpaceAndTitle(t *testing.T) {
 	if !strings.Contains(text, "总结「今日群聊」") {
 		t.Fatalf("completed text missing title: %q", text)
 	}
-	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") {
-		t.Fatalf("completed text must not carry a result link anymore: %q", text)
+	// WebBaseURL empty -> no detail link appended (plain-text fallback).
+	if strings.Contains(text, "http://") || strings.Contains(text, "https://") || strings.Contains(text, "查看结果") || strings.Contains(text, "/summary/detail?taskId=") {
+		t.Fatalf("completed text must not carry a link when WebBaseURL is empty: %q", text)
+	}
+}
+
+// TestBuildText_CompletedIncludesDetailLink 验证 WebBaseURL 已配置时 completed
+// 通知正文追加详情深链，且 taskId 正确（base 末尾斜杠会被裁掉）。
+func TestBuildText_CompletedIncludesDetailLink(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://web.example.com/"})
+
+	n.OnTaskTerminal(baseTask(701, model.TriggerManual), model.StatusCompleted, "")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	want := "查看详情：https://web.example.com/summary/detail?taskId=701"
+	if !strings.Contains(text, want) {
+		t.Fatalf("completed text missing detail link %q: %q", want, text)
+	}
+}
+
+// TestBuildText_FailedOmitsDetailLink 验证即便 WebBaseURL 已配置，failed 通知也不追加详情链接。
+func TestBuildText_FailedOmitsDetailLink(t *testing.T) {
+	db := setupNotifyTestDB(t)
+	d := &fakeDeliverer{}
+	n := newTestNotifier(db, d, Config{Enabled: true, WebBaseURL: "https://web.example.com"})
+
+	n.OnTaskTerminal(baseTask(702, model.TriggerManual), model.StatusFailed, "boom")
+
+	if len(d.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(d.sendCalls))
+	}
+	text, _ := d.sendCalls[0].Payload["content"].(string)
+	if strings.Contains(text, "/summary/detail?taskId=") || strings.Contains(text, "查看详情") {
+		t.Fatalf("failed text must not carry the detail link: %q", text)
 	}
 }
 


### PR DESCRIPTION
## What & why
`Closes #150` (worker side).

The completed-summary notification now appends a browser-openable detail deep link so users can jump straight to the summary. Pairs with the octo-web landing handler (Mininglamp-OSS/octo-web #150) that consumes `${origin}/summary/detail?taskId=<id>` on boot.

## Change
- `internal/notify/notify.go`: add `Config.WebBaseURL`; `buildText` appends `查看详情：${WebBaseURL trimmed}/summary/detail?taskId=<task.ID>` after the meta lines. **Only** for `completed`; `failed` never gets it; empty `WebBaseURL` => no link (plain-text fallback).
- `cmd/summary-worker/main.go`: wire `WebBaseURL: cfg.SummaryWebBaseURL` into the notifier config.
- `internal/notify/notify_test.go`: assert empty-base omits the link; add `TestBuildText_CompletedIncludesDetailLink` and `TestBuildText_FailedOmitsDetailLink`.

## Deploy prerequisite (env vars) — worker container
- **`SUMMARY_WEB_BASE_URL=<web origin>`** (default empty). Empty => completed notifications carry **no** detail link (safe degrade, non-fatal). Set it to the web deployment origin for the link to appear and open the detail page. Trailing slash is trimmed automatically.
- (unchanged, still required for notifications at all) `SUMMARY_NOTIFY_ENABLED=true`, `SUMMARY_NOTIFY_TOKEN`, `OCTO_API_URL`.

## Tests
`go test ./internal/notify/... ./internal/config/...` → ok.
