### PR TITLE
feat(summary): stream smart summary generation output

### DIFF
--- a/cmd/summary-api/main.go
+++ b/cmd/summary-api/main.go
@@ -94,8 +94,13 @@ func main() {
 		})
 	}
 
-	// Public API server
-	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit)
+	// Public API server. Refine is optional: existing API deployments can still start
+	// without LLM envs, while /summaries/:id/refine returns 503 until configured.
+	var refineLLM *service.LLMClient
+	if cfg.LLMApiURL != "" && cfg.LLMApiKey != "" && cfg.LLMModel != "" {
+		refineLLM = service.NewLLMClient(cfg.LLMApiURL, cfg.LLMApiKey, cfg.LLMModel, cfg.LLMTimeout, cfg.LLMMaxToken, cfg.LLMEnableThinking, cfg.ToolCallTimeout)
+	}
+	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit, refineLLM)
 	publicSrv := &http.Server{
 		Addr:    ":" + cfg.APIPort,
 		Handler: publicRouter,

--- a/cmd/summary-api/main.go
+++ b/cmd/summary-api/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 )
 
 func main() {
@@ -68,8 +69,10 @@ func main() {
 	httpResolver := auth.NewHTTPTokenResolver(cfg.OctoAPIURL)
 	authResolver := auth.NewCachedResolver(httpResolver, 30*time.Second, 10000)
 
-	// Init WebSocket hub
+	// Init realtime hubs. streamHub is in-memory and Phase 1 requires summary-api single-replica
+	// deployment (or sticky routing); multi-replica needs Redis Pub/Sub.
 	hub := ws.NewHub(summaryDB)
+	streamHub := streaming.NewHub(60 * time.Second)
 
 	// Inject IM DB resolvers
 	if imDB != nil {
@@ -100,14 +103,14 @@ func main() {
 	if cfg.LLMApiURL != "" && cfg.LLMApiKey != "" && cfg.LLMModel != "" {
 		refineLLM = service.NewLLMClient(cfg.LLMApiURL, cfg.LLMApiKey, cfg.LLMModel, cfg.LLMTimeout, cfg.LLMMaxToken, cfg.LLMEnableThinking, cfg.ToolCallTimeout)
 	}
-	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit, refineLLM)
+	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit, streamHub, refineLLM)
 	publicSrv := &http.Server{
 		Addr:    ":" + cfg.APIPort,
 		Handler: publicRouter,
 	}
 
 	// Internal callback server (Docker network accessible for worker callbacks)
-	internalRouter, _ := router.SetupInternal(hub)
+	internalRouter, _ := router.SetupInternal(hub, streamHub)
 	internalSrv := &http.Server{
 		Addr:    ":" + cfg.APIInternalPort,
 		Handler: internalRouter,

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -372,6 +372,180 @@ func (h *EditHandler) RefineSummary(c *gin.Context) {
 	})
 }
 
+func (h *EditHandler) RefineSummaryStream(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	var req refineSummaryReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "仅创建者可调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	baseResult, err := queryDisplayResult(h.db, taskID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "总结结果不存在"})
+		return
+	}
+	if baseResult.ID != req.BaseResultID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	w := c.Writer
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	_ = writeSSE(w, "start", gin.H{"type": "start", "task_id": taskID, "scope": "team"})
+	w.Flush()
+
+	writeStreamError := func(message string) {
+		_ = writeSSE(w, "error", gin.H{"type": "error", "task_id": taskID, "scope": "team", "message": message})
+		w.Flush()
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.CallStream(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", baseResult.Content, feedback)},
+	}, 0.1, func(delta string) error {
+		if delta == "" {
+			return nil
+		}
+		if err := writeSSE(w, "delta", gin.H{"type": "delta", "task_id": taskID, "scope": "team", "delta": delta}); err != nil {
+			return err
+		}
+		w.Flush()
+		return nil
+	})
+	if err != nil {
+		log.Printf("[refine-stream] llm error task=%d result=%d: %v", taskID, baseResult.ID, err)
+		writeStreamError("调整失败，请稍后重试")
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		writeStreamError("调整结果为空")
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		writeStreamError("调整结果超过 500KB 限制")
+		return
+	}
+
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, baseResult.GetCitations())
+	cleanedTeamCitations := cleanUnreferencedTeamCitations(newContent, baseResult.GetTeamCitations())
+	newResult := model.SummaryResult{
+		TaskID:         taskID,
+		Content:        newContent,
+		TotalMsgCount:  baseResult.TotalMsgCount,
+		TotalTokenUsed: baseResult.TotalTokenUsed + tokens,
+		ModelVersion:   h.llm.ModelVersion(),
+		OperationType:  "refine",
+		OperationNote:  feedback,
+		ParentResultID: &baseResult.ID,
+		CreatedBy:      userID,
+		GeneratedAt:    timezone.Now(),
+	}
+	newResult.SetCitations(cleanedCitations)
+	newResult.SetTeamCitations(cleanedTeamCitations)
+
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var taskCheck model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
+		latest, err := queryDisplayResult(tx, taskID)
+		if err != nil {
+			return err
+		}
+		if latest.ID != baseResult.ID {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		if taskCheck.Status != model.StatusCompleted {
+			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
+		}
+		nextVer, err := service.GetNextVersion(tx, taskID)
+		if err != nil {
+			return err
+		}
+		newResult.Version = nextVer
+		if err := tx.Create(&newResult).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", newResult.ID).Error; err != nil {
+			return err
+		}
+		if err := service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit); err != nil {
+			return err
+		}
+		return appendBoundScheduleGenerationInstruction(tx, taskCheck, feedback)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			writeStreamError(bizError.Message)
+			return
+		}
+		log.Printf("[refine-stream] transaction error task=%d: %v", taskID, err)
+		writeStreamError("internal error")
+		return
+	}
+
+	_ = writeSSE(w, "done", gin.H{
+		"type":             "done",
+		"task_id":          taskID,
+		"scope":            "team",
+		"result_id":        newResult.ID,
+		"version":          newResult.Version,
+		"content":          newResult.Content,
+		"citations":        newResult.GetCitations(),
+		"team_citations":   newResult.GetTeamCitations(),
+		"total_msg_count":  newResult.TotalMsgCount,
+		"total_token_used": newResult.TotalTokenUsed,
+		"model_version":    newResult.ModelVersion,
+		"operation_type":   newResult.OperationType,
+		"operation_note":   newResult.OperationNote,
+		"parent_result_id": newResult.ParentResultID,
+		"generated_at":     newResult.GeneratedAt.Format(time.RFC3339),
+	})
+	w.Flush()
+}
+
 func (h *EditHandler) ListSummaryVersions(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const maxContentBytes = 500 * 1024
@@ -309,16 +310,16 @@ func (h *EditHandler) RefineSummary(c *gin.Context) {
 	newResult.SetCitations(cleanedCitations)
 
 	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var taskCheck model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
 		latest, err := queryDisplayResult(tx, taskID)
 		if err != nil {
 			return err
 		}
 		if latest.ID != baseResult.ID {
 			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
-		}
-		var taskCheck model.SummaryTask
-		if err := tx.Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
-			return err
 		}
 		if taskCheck.Status != model.StatusCompleted {
 			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
@@ -503,11 +504,33 @@ func (h *EditHandler) RestoreSummaryVersion(c *gin.Context) {
 		return
 	}
 	err = h.db.Transaction(func(tx *gorm.DB) error {
-		return tx.Model(&model.SummaryTask{}).
+		var taskCheck model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
+		if taskCheck.Status != model.StatusCompleted {
+			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
+		}
+		res := tx.Model(&model.SummaryTask{}).
 			Where("id = ? AND status = ?", taskID, model.StatusCompleted).
-			Update("current_result_id", source.ID).Error
+			Update("current_result_id", source.ID)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
 	})
 	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+			return
+		}
 		log.Printf("[restore] transaction error task=%d result=%d: %v", taskID, resultID, err)
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
 		return

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -294,20 +294,21 @@ func (h *EditHandler) RefineSummary(c *gin.Context) {
 	}
 
 	cleanedCitations := service.CleanUnreferencedCitations(newContent, baseResult.GetCitations())
+	cleanedTeamCitations := cleanUnreferencedTeamCitations(newContent, baseResult.GetTeamCitations())
 	newResult := model.SummaryResult{
-		TaskID:            taskID,
-		Content:           newContent,
-		TeamCitationsJSON: baseResult.TeamCitationsJSON,
-		TotalMsgCount:     baseResult.TotalMsgCount,
-		TotalTokenUsed:    baseResult.TotalTokenUsed + tokens,
-		ModelVersion:      h.llm.ModelVersion(),
-		OperationType:     "refine",
-		OperationNote:     feedback,
-		ParentResultID:    &baseResult.ID,
-		CreatedBy:         userID,
-		GeneratedAt:       timezone.Now(),
+		TaskID:         taskID,
+		Content:        newContent,
+		TotalMsgCount:  baseResult.TotalMsgCount,
+		TotalTokenUsed: baseResult.TotalTokenUsed + tokens,
+		ModelVersion:   h.llm.ModelVersion(),
+		OperationType:  "refine",
+		OperationNote:  feedback,
+		ParentResultID: &baseResult.ID,
+		CreatedBy:      userID,
+		GeneratedAt:    timezone.Now(),
 	}
 	newResult.SetCitations(cleanedCitations)
+	newResult.SetTeamCitations(cleanedTeamCitations)
 
 	err = h.db.Transaction(func(tx *gorm.DB) error {
 		var taskCheck model.SummaryTask
@@ -539,6 +540,27 @@ func (h *EditHandler) RestoreSummaryVersion(c *gin.Context) {
 		return
 	}
 	ok(c, gin.H{"task_id": taskID, "result_id": source.ID, "version": source.Version})
+}
+
+func cleanUnreferencedTeamCitations(content string, citations []model.TeamCitation) []model.TeamCitation {
+	if len(citations) == 0 {
+		return []model.TeamCitation{}
+	}
+	kept := make([]model.TeamCitation, 0, len(citations))
+	seen := make(map[int]bool, len(citations))
+	for _, citation := range citations {
+		if citation.Index <= 0 || seen[citation.Index] {
+			continue
+		}
+		if strings.Contains(content, fmt.Sprintf("[P%d]", citation.Index)) {
+			kept = append(kept, citation)
+			seen[citation.Index] = true
+		}
+	}
+	if kept == nil {
+		return []model.TeamCitation{}
+	}
+	return kept
 }
 
 func buildRefineSystemPrompt() string {

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -335,7 +335,10 @@ func (h *EditHandler) RefineSummary(c *gin.Context) {
 		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", newResult.ID).Error; err != nil {
 			return err
 		}
-		return service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit)
+		if err := service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit); err != nil {
+			return err
+		}
+		return appendBoundScheduleGenerationInstruction(tx, taskCheck, feedback)
 	})
 	if err != nil {
 		if bizError, isBiz := err.(*service.BizError); isBiz {

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -1,11 +1,14 @@
 package handler
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
@@ -16,13 +19,19 @@ import (
 )
 
 const maxContentBytes = 500 * 1024
+const maxFeedbackRunes = 2000
 
 type EditHandler struct {
-	db *gorm.DB
+	db  *gorm.DB
+	llm *service.LLMClient
 }
 
-func NewEditHandler(db *gorm.DB) *EditHandler {
-	return &EditHandler{db: db}
+func NewEditHandler(db *gorm.DB, llm ...*service.LLMClient) *EditHandler {
+	h := &EditHandler{db: db}
+	if len(llm) > 0 {
+		h.llm = llm[0]
+	}
+	return h
 }
 
 type editSummaryReq struct {
@@ -193,4 +202,338 @@ func (h *EditHandler) EditSummary(c *gin.Context) {
 	}
 
 	ok(c, gin.H{"edited_at": now.Format(time.RFC3339)})
+}
+
+type refineSummaryReq struct {
+	Feedback     string `json:"feedback"`
+	BaseResultID int64  `json:"base_result_id"`
+}
+
+type summaryVersionItem struct {
+	ResultID       int64  `json:"result_id"`
+	Version        int    `json:"version"`
+	OperationType  string `json:"operation_type"`
+	OperationNote  string `json:"operation_note"`
+	ParentResultID *int64 `json:"parent_result_id,omitempty"`
+	CreatedBy      string `json:"created_by"`
+	GeneratedAt    string `json:"generated_at"`
+	EditedAt       any    `json:"edited_at"`
+}
+
+func (h *EditHandler) RefineSummary(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	var req refineSummaryReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "仅创建者可调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	baseResult, err := queryDisplayResult(h.db, taskID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "总结结果不存在"})
+		return
+	}
+	if baseResult.ID != req.BaseResultID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.Call(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", baseResult.Content, feedback)},
+	}, 0.1)
+	if err != nil {
+		log.Printf("[refine] llm error task=%d result=%d: %v", taskID, baseResult.ID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整失败，请稍后重试"})
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整结果为空"})
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "调整结果超过 500KB 限制"})
+		return
+	}
+
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, baseResult.GetCitations())
+	newResult := model.SummaryResult{
+		TaskID:            taskID,
+		Content:           newContent,
+		TeamCitationsJSON: baseResult.TeamCitationsJSON,
+		TotalMsgCount:     baseResult.TotalMsgCount,
+		TotalTokenUsed:    baseResult.TotalTokenUsed + tokens,
+		ModelVersion:      h.llm.ModelVersion(),
+		OperationType:     "refine",
+		OperationNote:     feedback,
+		ParentResultID:    &baseResult.ID,
+		CreatedBy:         userID,
+		GeneratedAt:       timezone.Now(),
+	}
+	newResult.SetCitations(cleanedCitations)
+
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		latest, err := queryDisplayResult(tx, taskID)
+		if err != nil {
+			return err
+		}
+		if latest.ID != baseResult.ID {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		var taskCheck model.SummaryTask
+		if err := tx.Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
+		if taskCheck.Status != model.StatusCompleted {
+			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
+		}
+		nextVer, err := service.GetNextVersion(tx, taskID)
+		if err != nil {
+			return err
+		}
+		newResult.Version = nextVer
+		if err := tx.Create(&newResult).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", newResult.ID).Error; err != nil {
+			return err
+		}
+		return service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		log.Printf("[refine] transaction error task=%d: %v", taskID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+
+	ok(c, gin.H{
+		"task_id":          taskID,
+		"result_id":        newResult.ID,
+		"version":          newResult.Version,
+		"content":          newResult.Content,
+		"citations":        newResult.GetCitations(),
+		"team_citations":   newResult.GetTeamCitations(),
+		"total_msg_count":  newResult.TotalMsgCount,
+		"total_token_used": newResult.TotalTokenUsed,
+		"model_version":    newResult.ModelVersion,
+		"operation_type":   newResult.OperationType,
+		"operation_note":   newResult.OperationNote,
+		"parent_result_id": newResult.ParentResultID,
+		"generated_at":     newResult.GeneratedAt.Format(time.RFC3339),
+	})
+}
+
+func (h *EditHandler) ListSummaryVersions(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	limit := 3
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= service.SummaryResultVersionKeepLimit {
+			limit = n
+		}
+	}
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		var participantCount int64
+		if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, userID).Count(&participantCount).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+			return
+		}
+		if participantCount == 0 {
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权查看版本"})
+			return
+		}
+	}
+	var rows []model.SummaryResult
+	if err := h.db.Where("task_id = ?", taskID).Order("version DESC").Order("id DESC").Limit(limit).Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	items := make([]summaryVersionItem, 0, len(rows))
+	for _, row := range rows {
+		var editedAt any
+		if row.EditedAt != nil {
+			editedAt = row.EditedAt.Format(time.RFC3339)
+		}
+		items = append(items, summaryVersionItem{
+			ResultID:       row.ID,
+			Version:        row.Version,
+			OperationType:  row.OperationType,
+			OperationNote:  row.OperationNote,
+			ParentResultID: row.ParentResultID,
+			CreatedBy:      row.CreatedBy,
+			GeneratedAt:    row.GeneratedAt.Format(time.RFC3339),
+			EditedAt:       editedAt,
+		})
+	}
+	ok(c, gin.H{"versions": items, "keep_limit": service.SummaryResultVersionKeepLimit})
+}
+
+func (h *EditHandler) GetSummaryVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	resultID, err := strconv.ParseInt(c.Param("result_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid result id"})
+		return
+	}
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		var participantCount int64
+		if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, userID).Count(&participantCount).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+			return
+		}
+		if participantCount == 0 {
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权查看版本"})
+			return
+		}
+	}
+	var row model.SummaryResult
+	if err := h.db.Where("id = ? AND task_id = ?", resultID, taskID).First(&row).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	var editedAt any
+	if row.EditedAt != nil {
+		editedAt = row.EditedAt.Format(time.RFC3339)
+	}
+	ok(c, gin.H{
+		"result_id":        row.ID,
+		"version":          row.Version,
+		"operation_type":   row.OperationType,
+		"operation_note":   row.OperationNote,
+		"parent_result_id": row.ParentResultID,
+		"created_by":       row.CreatedBy,
+		"generated_at":     row.GeneratedAt.Format(time.RFC3339),
+		"edited_at":        editedAt,
+		"content":          row.Content,
+		"citations":        row.GetCitations(),
+		"team_citations":   row.GetTeamCitations(),
+	})
+}
+
+func (h *EditHandler) RestoreSummaryVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	resultID, err := strconv.ParseInt(c.Param("result_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid result id"})
+		return
+	}
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "仅创建者可恢复版本"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可恢复版本"})
+		return
+	}
+	var source model.SummaryResult
+	if err := h.db.Where("id = ? AND task_id = ?", resultID, taskID).First(&source).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		return tx.Model(&model.SummaryTask{}).
+			Where("id = ? AND status = ?", taskID, model.StatusCompleted).
+			Update("current_result_id", source.ID).Error
+	})
+	if err != nil {
+		log.Printf("[restore] transaction error task=%d result=%d: %v", taskID, resultID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	ok(c, gin.H{"task_id": taskID, "result_id": source.ID, "version": source.Version})
+}
+
+func buildRefineSystemPrompt() string {
+	return `你是专业的工作总结编辑助手。请根据用户的修改意见，对“当前总结”做局部调整。
+
+要求：
+- 尽量保留用户没有要求修改的内容、结构和引用编号。
+- 不要重新发散总结，不要补充当前总结里没有依据的新事实。
+- 如果只是语气、长短、结构调整，应保持事实含义不变。
+- 保留 Markdown 格式。
+- 只输出修改后的完整总结正文，不要输出解释、前后缀或代码块。`
+}
+
+func stripMarkdownFence(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) >= 2 && strings.HasPrefix(strings.TrimSpace(lines[0]), "```") && strings.HasPrefix(strings.TrimSpace(lines[len(lines)-1]), "```") {
+		return strings.Join(lines[1:len(lines)-1], "\n")
+	}
+	return trimmed
 }

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -1,11 +1,14 @@
 package handler
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
@@ -13,16 +16,23 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const maxContentBytes = 500 * 1024
+const maxFeedbackRunes = 2000
 
 type EditHandler struct {
-	db *gorm.DB
+	db  *gorm.DB
+	llm *service.LLMClient
 }
 
-func NewEditHandler(db *gorm.DB) *EditHandler {
-	return &EditHandler{db: db}
+func NewEditHandler(db *gorm.DB, llm ...*service.LLMClient) *EditHandler {
+	h := &EditHandler{db: db}
+	if len(llm) > 0 {
+		h.llm = llm[0]
+	}
+	return h
 }
 
 type editSummaryReq struct {
@@ -193,4 +203,393 @@ func (h *EditHandler) EditSummary(c *gin.Context) {
 	}
 
 	ok(c, gin.H{"edited_at": now.Format(time.RFC3339)})
+}
+
+type refineSummaryReq struct {
+	Feedback     string `json:"feedback"`
+	BaseResultID int64  `json:"base_result_id"`
+}
+
+type summaryVersionItem struct {
+	ResultID       int64  `json:"result_id"`
+	Version        int    `json:"version"`
+	OperationType  string `json:"operation_type"`
+	OperationNote  string `json:"operation_note"`
+	ParentResultID *int64 `json:"parent_result_id,omitempty"`
+	CreatedBy      string `json:"created_by"`
+	GeneratedAt    string `json:"generated_at"`
+	EditedAt       any    `json:"edited_at"`
+}
+
+func (h *EditHandler) RefineSummary(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	var req refineSummaryReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "仅创建者可调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	baseResult, err := queryDisplayResult(h.db, taskID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "总结结果不存在"})
+		return
+	}
+	if baseResult.ID != req.BaseResultID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.Call(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", baseResult.Content, feedback)},
+	}, 0.1)
+	if err != nil {
+		log.Printf("[refine] llm error task=%d result=%d: %v", taskID, baseResult.ID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整失败，请稍后重试"})
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整结果为空"})
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "调整结果超过 500KB 限制"})
+		return
+	}
+
+	basePlainCitations := baseResult.GetCitations()
+	if !callerPlainCitationsVisible(h.db, &task, userID, &baseResult) {
+		basePlainCitations = []model.Citation{}
+	}
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, basePlainCitations)
+	cleanedTeamCitations := cleanUnreferencedTeamCitations(newContent, baseResult.GetTeamCitations())
+	newResult := model.SummaryResult{
+		TaskID:         taskID,
+		Content:        newContent,
+		TotalMsgCount:  baseResult.TotalMsgCount,
+		TotalTokenUsed: baseResult.TotalTokenUsed + tokens,
+		ModelVersion:   h.llm.ModelVersion(),
+		OperationType:  "refine",
+		OperationNote:  feedback,
+		ParentResultID: &baseResult.ID,
+		CreatedBy:      userID,
+		GeneratedAt:    timezone.Now(),
+	}
+	newResult.SetCitations(cleanedCitations)
+	newResult.SetTeamCitations(cleanedTeamCitations)
+
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var taskCheck model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
+		latest, err := queryDisplayResult(tx, taskID)
+		if err != nil {
+			return err
+		}
+		if latest.ID != baseResult.ID {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		if taskCheck.Status != model.StatusCompleted {
+			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
+		}
+		nextVer, err := service.GetNextVersion(tx, taskID)
+		if err != nil {
+			return err
+		}
+		newResult.Version = nextVer
+		if err := tx.Create(&newResult).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", newResult.ID).Error; err != nil {
+			return err
+		}
+		if err := service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit); err != nil {
+			return err
+		}
+		return appendBoundScheduleGenerationInstruction(tx, taskCheck, feedback)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		log.Printf("[refine] transaction error task=%d: %v", taskID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+
+	ok(c, gin.H{
+		"task_id":          taskID,
+		"result_id":        newResult.ID,
+		"version":          newResult.Version,
+		"content":          newResult.Content,
+		"citations":        newResult.GetCitations(),
+		"team_citations":   newResult.GetTeamCitations(),
+		"total_msg_count":  newResult.TotalMsgCount,
+		"total_token_used": newResult.TotalTokenUsed,
+		"model_version":    newResult.ModelVersion,
+		"operation_type":   newResult.OperationType,
+		"operation_note":   newResult.OperationNote,
+		"parent_result_id": newResult.ParentResultID,
+		"generated_at":     newResult.GeneratedAt.Format(time.RFC3339),
+	})
+}
+
+func (h *EditHandler) ListSummaryVersions(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	limit := 3
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= service.SummaryResultVersionKeepLimit {
+			limit = n
+		}
+	}
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		var participantCount int64
+		if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, userID).Count(&participantCount).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+			return
+		}
+		if participantCount == 0 {
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权查看版本"})
+			return
+		}
+	}
+	var rows []model.SummaryResult
+	if err := h.db.Where("task_id = ?", taskID).Order("version DESC").Order("id DESC").Limit(limit).Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	items := make([]summaryVersionItem, 0, len(rows))
+	for _, row := range rows {
+		var editedAt any
+		if row.EditedAt != nil {
+			editedAt = row.EditedAt.Format(time.RFC3339)
+		}
+		items = append(items, summaryVersionItem{
+			ResultID:       row.ID,
+			Version:        row.Version,
+			OperationType:  row.OperationType,
+			OperationNote:  row.OperationNote,
+			ParentResultID: row.ParentResultID,
+			CreatedBy:      row.CreatedBy,
+			GeneratedAt:    row.GeneratedAt.Format(time.RFC3339),
+			EditedAt:       editedAt,
+		})
+	}
+	ok(c, gin.H{"versions": items, "keep_limit": service.SummaryResultVersionKeepLimit})
+}
+
+func (h *EditHandler) GetSummaryVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	resultID, err := strconv.ParseInt(c.Param("result_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid result id"})
+		return
+	}
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		var participantCount int64
+		if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, userID).Count(&participantCount).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+			return
+		}
+		if participantCount == 0 {
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权查看版本"})
+			return
+		}
+	}
+	var row model.SummaryResult
+	if err := h.db.Where("id = ? AND task_id = ?", resultID, taskID).First(&row).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	var editedAt any
+	if row.EditedAt != nil {
+		editedAt = row.EditedAt.Format(time.RFC3339)
+	}
+	plainCitations := row.GetCitations()
+	if !callerPlainCitationsVisible(h.db, &task, userID, &row) {
+		plainCitations = []model.Citation{}
+	}
+	ok(c, gin.H{
+		"result_id":        row.ID,
+		"version":          row.Version,
+		"operation_type":   row.OperationType,
+		"operation_note":   row.OperationNote,
+		"parent_result_id": row.ParentResultID,
+		"created_by":       row.CreatedBy,
+		"generated_at":     row.GeneratedAt.Format(time.RFC3339),
+		"edited_at":        editedAt,
+		"content":          row.Content,
+		"citations":        plainCitations,
+		"team_citations":   row.GetTeamCitations(),
+	})
+}
+
+func (h *EditHandler) RestoreSummaryVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	resultID, err := strconv.ParseInt(c.Param("result_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid result id"})
+		return
+	}
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "仅创建者可恢复版本"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可恢复版本"})
+		return
+	}
+	var source model.SummaryResult
+	if err := h.db.Where("id = ? AND task_id = ?", resultID, taskID).First(&source).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var taskCheck model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
+		if taskCheck.Status != model.StatusCompleted {
+			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
+		}
+		res := tx.Model(&model.SummaryTask{}).
+			Where("id = ? AND status = ?", taskID, model.StatusCompleted).
+			Update("current_result_id", source.ID)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+			return
+		}
+		log.Printf("[restore] transaction error task=%d result=%d: %v", taskID, resultID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	ok(c, gin.H{"task_id": taskID, "result_id": source.ID, "version": source.Version})
+}
+
+func cleanUnreferencedTeamCitations(content string, citations []model.TeamCitation) []model.TeamCitation {
+	if len(citations) == 0 {
+		return []model.TeamCitation{}
+	}
+	kept := make([]model.TeamCitation, 0, len(citations))
+	seen := make(map[int]bool, len(citations))
+	for _, citation := range citations {
+		if citation.Index <= 0 || seen[citation.Index] {
+			continue
+		}
+		if strings.Contains(content, fmt.Sprintf("[P%d]", citation.Index)) {
+			kept = append(kept, citation)
+			seen[citation.Index] = true
+		}
+	}
+	if kept == nil {
+		return []model.TeamCitation{}
+	}
+	return kept
+}
+
+func buildRefineSystemPrompt() string {
+	return `你是专业的工作总结编辑助手。请根据用户的修改意见，对“当前总结”做局部调整。
+
+要求：
+- 尽量保留用户没有要求修改的内容、结构和引用编号。
+- 不要重新发散总结，不要补充当前总结里没有依据的新事实。
+- 如果只是语气、长短、结构调整，应保持事实含义不变。
+- 保留 Markdown 格式。
+- 只输出修改后的完整总结正文，不要输出解释、前后缀或代码块。`
+}
+
+func stripMarkdownFence(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) >= 2 && strings.HasPrefix(strings.TrimSpace(lines[0]), "```") && strings.HasPrefix(strings.TrimSpace(lines[len(lines)-1]), "```") {
+		return strings.Join(lines[1:len(lines)-1], "\n")
+	}
+	return trimmed
 }

--- a/internal/api/handler/edit_test.go
+++ b/internal/api/handler/edit_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -40,6 +41,8 @@ func setupEditRouter(h *EditHandler) *gin.Engine {
 	r := gin.New()
 	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
 	r.PUT("/api/v1/summaries/:id/edit", h.EditSummary)
+	r.POST("/api/v1/summaries/:id/refine", h.RefineSummary)
+	r.GET("/api/v1/summaries/:id/versions/:result_id", h.GetSummaryVersion)
 	return r
 }
 
@@ -589,5 +592,165 @@ func TestEditSummary_ContentTooLarge(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for oversized content, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func newTestRefineLLM(t *testing.T, content string) (*service.LLMClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("unexpected LLM path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"choices":[{"message":{"content":%q},"finish_reason":"stop"}],"usage":{"total_tokens":7,"completion_tokens":3}}`, content)
+	}))
+	return service.NewLLMClient(srv.URL, "test-key", "test-model", 5, 256, false, 5), srv.Close
+}
+
+func seedVersionCitationPrivacyTask(t *testing.T, db *gorm.DB) (taskID int64, resultID int64) {
+	t.Helper()
+	now := time.Now().UTC()
+	task := model.SummaryTask{
+		TaskNo:      "TST-VERSION-PRIVACY",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	participant := model.SummaryParticipant{TaskID: task.ID, UserID: "member_a", UserName: "Member A", Status: model.ParticipantCompleted}
+	if err := db.Create(&participant).Error; err != nil {
+		t.Fatalf("seed participant: %v", err)
+	}
+	citations := []model.Citation{{
+		Index:       1,
+		Sender:      "Member A",
+		Content:     "private raw message from member A",
+		SentAt:      "2026-01-01T00:00:00Z",
+		Source:      "grp",
+		ChannelID:   "ch1",
+		ChannelType: 2,
+		MessageSeq:  100,
+	}}
+	pr := model.PersonalResult{
+		TaskID:           task.ID,
+		ParticipantRefID: participant.ID,
+		UserID:           "member_a",
+		WorkerStatus:     model.PersonalStatusCompleted,
+		Content:          "member A personal content with [1]",
+		GeneratedAt:      &now,
+	}
+	pr.SetCitations(citations)
+	if err := db.Create(&pr).Error; err != nil {
+		t.Fatalf("seed personal result: %v", err)
+	}
+	result := model.SummaryResult{
+		TaskID:         task.ID,
+		Content:        "team content copied from member A with [1]",
+		TotalMsgCount:  1,
+		TotalTokenUsed: 10,
+		ModelVersion:   "test-v1",
+		Version:        1,
+		CreatedBy:      "member_a",
+		GeneratedAt:    now,
+	}
+	result.SetCitations(citations)
+	if err := db.Create(&result).Error; err != nil {
+		t.Fatalf("seed summary result: %v", err)
+	}
+	return task.ID, result.ID
+}
+
+func doGetSummaryVersionRequest(r *gin.Engine, taskID, resultID int64, userID string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/summaries/%d/versions/%d", taskID, resultID), nil)
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func doRefineSummaryRequest(r *gin.Engine, taskID int64, userID string, body interface{}) *httptest.ResponseRecorder {
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, _ = json.Marshal(body)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/summaries/%d/refine", taskID), bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func responseCitationsLen(t *testing.T, w *httptest.ResponseRecorder) int {
+	t.Helper()
+	var resp struct {
+		Data struct {
+			Citations []json.RawMessage `json:"citations"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, w.Body.String())
+	}
+	return len(resp.Data.Citations)
+}
+
+func TestGetSummaryVersion_RedactsPlainCitationsForNonProducer(t *testing.T) {
+	db := setupEditDB(t)
+	taskID, resultID := seedVersionCitationPrivacyTask(t, db)
+
+	h := NewEditHandler(db)
+	r := setupEditRouter(h)
+
+	w := doGetSummaryVersionRequest(r, taskID, resultID, "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := responseCitationsLen(t, w); got != 0 {
+		t.Fatalf("non-producer creator must not see member plain citations, got %d: %s", got, w.Body.String())
+	}
+
+	producer := doGetSummaryVersionRequest(r, taskID, resultID, "member_a")
+	if producer.Code != http.StatusOK {
+		t.Fatalf("expected producer 200, got %d: %s", producer.Code, producer.Body.String())
+	}
+	if got := responseCitationsLen(t, producer); got == 0 {
+		t.Fatalf("producer should keep own plain citations, body=%s", producer.Body.String())
+	}
+}
+
+func TestRefineSummary_DoesNotCopyInvisiblePlainCitations(t *testing.T) {
+	db := setupEditDB(t)
+	taskID, resultID := seedVersionCitationPrivacyTask(t, db)
+	llm, closeLLM := newTestRefineLLM(t, "refined team content still referencing [1]")
+	defer closeLLM()
+
+	h := NewEditHandler(db, llm)
+	r := setupEditRouter(h)
+	w := doRefineSummaryRequest(r, taskID, "creator1", map[string]interface{}{
+		"feedback":       "make it clearer",
+		"base_result_id": resultID,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := responseCitationsLen(t, w); got != 0 {
+		t.Fatalf("refine response must not return invisible member citations, got %d: %s", got, w.Body.String())
+	}
+
+	var refined model.SummaryResult
+	if err := db.Where("task_id = ? AND operation_type = ?", taskID, "refine").First(&refined).Error; err != nil {
+		t.Fatalf("load refined result: %v", err)
+	}
+	if got := len(refined.GetCitations()); got != 0 {
+		t.Fatalf("refined result must not persist invisible member citations, got %d", got)
 	}
 }

--- a/internal/api/handler/personal.go
+++ b/internal/api/handler/personal.go
@@ -117,11 +117,16 @@ type PersonalHandler struct {
 	db               *gorm.DB
 	workerTriggerURL string
 	hub              *ws.Hub
+	llm              *service.LLMClient
 }
 
 // NewPersonalHandler creates a new PersonalHandler.
 func NewPersonalHandler(db *gorm.DB, workerTriggerURL string, hub *ws.Hub) *PersonalHandler {
 	return &PersonalHandler{db: db, workerTriggerURL: workerTriggerURL, hub: hub}
+}
+
+func (h *PersonalHandler) SetLLM(llm *service.LLMClient) {
+	h.llm = llm
 }
 
 func (h *PersonalHandler) parseTaskID(c *gin.Context) (int64, bool) {
@@ -420,6 +425,8 @@ func (h *PersonalHandler) GetPersonal(c *gin.Context) {
 	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
 		// Not found → return default
 		ok(c, gin.H{
+			"id":             0,
+			"version":        0,
 			"worker_status":  0,
 			"workflow_stage": "",
 			"content":        "",
@@ -430,7 +437,23 @@ func (h *PersonalHandler) GetPersonal(c *gin.Context) {
 		return
 	}
 
+	version := 0
+	if pr.CurrentVersionID != nil {
+		var currentVersion model.PersonalResultVersion
+		if err := h.db.Where("id = ? AND task_id = ? AND user_id = ?", *pr.CurrentVersionID, taskID, userID).First(&currentVersion).Error; err == nil {
+			version = currentVersion.Version
+		}
+	}
+	if version == 0 {
+		_ = h.db.Model(&model.PersonalResultVersion{}).Where("task_id = ? AND user_id = ?", taskID, userID).Select("COALESCE(MAX(version), 0)").Scan(&version).Error
+	}
+	if version == 0 && strings.TrimSpace(pr.Content) != "" {
+		version = 1
+	}
+
 	result := gin.H{
+		"id":             pr.ID,
+		"version":        version,
 		"worker_status":  pr.WorkerStatus,
 		"workflow_stage": pr.WorkflowStage,
 		"content":        pr.Content,
@@ -489,28 +512,48 @@ func (h *PersonalHandler) Submit(c *gin.Context) {
 	// Use a conditional UPDATE ... WHERE submitted_at IS NULL so exactly one writer
 	// (manual OR system) ever sets submitted_at; the loser sees RowsAffected==0 and
 	// returns the idempotent "already submitted" response WITHOUT rewriting source.
-	res := h.db.Model(&model.PersonalResult{}).
-		Where("id = ? AND submitted_at IS NULL", pr.ID).
-		Updates(map[string]interface{}{
-			"submitted_at":  now,
-			"submit_source": model.SubmitSourceManual,
-		})
-	if res.Error != nil {
-		log.Printf("[personal] submit conditional update error: %v", res.Error)
-		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: res.Error.Error()})
+	var alreadySubmitted bool
+	err := h.db.Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND submitted_at IS NULL", pr.ID).
+			Updates(map[string]interface{}{
+				"submitted_at":  now,
+				"submit_source": model.SubmitSourceManual,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			alreadySubmitted = true
+			return nil
+		}
+
+		if err := tx.Model(&model.SummaryParticipant{}).
+			Where("task_id = ? AND user_id = ?", taskID, userID).
+			Update("status", model.ParticipantSubmitted).Error; err != nil {
+			return err
+		}
+
+		var participantCount int64
+		if err := tx.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Count(&participantCount).Error; err != nil {
+			return err
+		}
+		if participantCount > 1 {
+			return h.reviveCompletedForRecompute(tx, taskID)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("[personal] submit transaction error: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
 		return
 	}
-	if res.RowsAffected == 0 {
+	if alreadySubmitted {
 		// Already submitted by a concurrent manual /submit or the system back-fill.
 		// Do NOT rewrite submit_source; return the same idempotent "submitted" semantics.
 		ok(c, gin.H{"status": "submitted"})
 		return
 	}
-
-	// Update participant status to submitted
-	h.db.Model(&model.SummaryParticipant{}).
-		Where("task_id = ? AND user_id = ?", taskID, userID).
-		Update("status", model.ParticipantSubmitted)
 
 	// Broadcast MEMBER_SUBMITTED event to all subscribers
 	if h.hub != nil {

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -1,0 +1,664 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type refinePersonalReq struct {
+	Feedback     string `json:"feedback"`
+	BaseResultID int64  `json:"base_result_id"`
+	BaseVersion  int    `json:"base_version"`
+}
+
+type personalVersionItem struct {
+	VersionID       int64  `json:"result_id"`
+	Version         int    `json:"version"`
+	OperationType   string `json:"operation_type"`
+	OperationNote   string `json:"operation_note"`
+	ParentVersionID *int64 `json:"parent_result_id,omitempty"`
+	CreatedBy       string `json:"created_by"`
+	GeneratedAt     string `json:"generated_at"`
+	EditedAt        any    `json:"edited_at"`
+}
+
+func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	var req refinePersonalReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+	if req.BaseVersion <= 0 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "base_version is required"})
+		return
+	}
+
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+	if req.BaseResultID > 0 && req.BaseResultID != pr.ID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+	if pr.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(pr.Content) == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "个人总结未完成，无法调整"})
+		return
+	}
+
+	currentVersion, err := currentPersonalVersion(h.db, taskID, userID, pr)
+	if err != nil {
+		log.Printf("[personal-refine] query current version task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if req.BaseVersion != currentVersion {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.Call(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", pr.Content, feedback)},
+	}, 0.1)
+	if err != nil {
+		log.Printf("[personal-refine] llm error task=%d personal_result=%d: %v", taskID, pr.ID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整失败，请稍后重试"})
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整结果为空"})
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "调整结果超过 500KB 限制"})
+		return
+	}
+
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, pr.GetCitations())
+	tmp := &model.PersonalResult{}
+	tmp.SetCitations(cleanedCitations)
+	citationsJSON := tmp.CitationsJSON
+
+	now := timezone.Now()
+	var newVersion model.PersonalResultVersion
+	shouldTriggerMeta := false
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if latestPR.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(latestPR.Content) == "" {
+			return service.NewBizError(40005, "个人总结状态已变更", http.StatusBadRequest)
+		}
+		versionBeforeBaseline, err := currentPersonalVersion(tx, taskID, userID, latestPR)
+		if err != nil {
+			return err
+		}
+		if req.BaseVersion != versionBeforeBaseline {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		latestVersion, err := ensurePersonalVersionBaseline(tx, latestPR)
+		if err != nil {
+			return err
+		}
+
+		nextVer, err := service.GetNextPersonalVersion(tx, taskID, userID)
+		if err != nil {
+			return err
+		}
+		newVersion = model.PersonalResultVersion{
+			TaskID:           taskID,
+			ParticipantRefID: latestPR.ParticipantRefID,
+			UserID:           userID,
+			Content:          newContent,
+			CitationsJSON:    citationsJSON,
+			MsgCount:         latestPR.MsgCount,
+			TotalTokenUsed:   latestPR.TotalTokenUsed + tokens,
+			ModelVersion:     h.llm.ModelVersion(),
+			Version:          nextVer,
+			OperationType:    "refine",
+			OperationNote:    feedback,
+			ParentVersionID:  &latestVersion.ID,
+			CreatedBy:        userID,
+			GeneratedAt:      now,
+		}
+		if err := tx.Create(&newVersion).Error; err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ? AND worker_status = ?", latestPR.ID, taskID, userID, model.PersonalStatusCompleted).
+			Updates(map[string]interface{}{
+				"content":            newContent,
+				"citations_json":     citationsJSON,
+				"total_token_used":   latestPR.TotalTokenUsed + tokens,
+				"model_version":      h.llm.ModelVersion(),
+				"current_version_id": newVersion.ID,
+				"generated_at":       now,
+				"edited_at":          now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		if err := service.PrunePersonalResultVersions(tx, taskID, userID, service.PersonalResultVersionKeepLimit); err != nil {
+			return err
+		}
+		var participantCount int64
+		if err := tx.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Count(&participantCount).Error; err != nil {
+			return err
+		}
+		if participantCount > 1 {
+			if err := h.reviveCompletedForRecompute(tx, taskID); err != nil {
+				return err
+			}
+			shouldTriggerMeta = true
+		}
+		return nil
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		if err == gorm.ErrRecordNotFound || err == errPersonalResultGone {
+			c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+			return
+		}
+		log.Printf("[personal-refine] transaction error task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if shouldTriggerMeta {
+		go h.triggerWorker(model.WorkerTriggerRequest{
+			Type:   "meta_summary",
+			TaskID: taskID,
+		})
+	}
+
+	ok(c, gin.H{
+		"task_id":          taskID,
+		"result_id":        pr.ID,
+		"version_id":       newVersion.ID,
+		"version":          newVersion.Version,
+		"content":          newContent,
+		"citations":        newVersion.GetCitations(),
+		"msg_count":        newVersion.MsgCount,
+		"total_token_used": newVersion.TotalTokenUsed,
+		"model_version":    newVersion.ModelVersion,
+		"operation_type":   newVersion.OperationType,
+		"operation_note":   newVersion.OperationNote,
+		"parent_result_id": newVersion.ParentVersionID,
+		"generated_at":     newVersion.GeneratedAt.Format(time.RFC3339),
+	})
+}
+
+func (h *PersonalHandler) ListPersonalVersions(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	limit := 3
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= service.PersonalResultVersionKeepLimit {
+			limit = n
+		}
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人版本"})
+		return
+	}
+	var participantCount int64
+	if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, userID).Count(&participantCount).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if participantCount == 0 {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "你不是该任务的参与者"})
+		return
+	}
+
+	var rows []model.PersonalResultVersion
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).Order("version DESC").Order("id DESC").Limit(limit).Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	items := make([]personalVersionItem, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, personalVersionItem{
+			VersionID:       row.ID,
+			Version:         row.Version,
+			OperationType:   row.OperationType,
+			OperationNote:   row.OperationNote,
+			ParentVersionID: row.ParentVersionID,
+			CreatedBy:       row.CreatedBy,
+			GeneratedAt:     row.GeneratedAt.Format(time.RFC3339),
+			EditedAt:        nil,
+		})
+	}
+	ok(c, gin.H{"versions": items, "keep_limit": service.PersonalResultVersionKeepLimit})
+}
+
+func (h *PersonalHandler) GetPersonalVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	versionID, err := strconv.ParseInt(c.Param("version_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid version id"})
+		return
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人版本"})
+		return
+	}
+	var row model.PersonalResultVersion
+	if err := h.db.Where("id = ? AND task_id = ? AND user_id = ?", versionID, taskID, userID).First(&row).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	ok(c, gin.H{
+		"result_id":        row.ID,
+		"version_id":       row.ID,
+		"version":          row.Version,
+		"operation_type":   row.OperationType,
+		"operation_note":   row.OperationNote,
+		"parent_result_id": row.ParentVersionID,
+		"created_by":       row.CreatedBy,
+		"generated_at":     row.GeneratedAt.Format(time.RFC3339),
+		"edited_at":        nil,
+		"content":          row.Content,
+		"citations":        row.GetCitations(),
+	})
+}
+
+func (h *PersonalHandler) RestorePersonalVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	versionID, err := strconv.ParseInt(c.Param("version_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid version id"})
+		return
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人版本"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可恢复版本"})
+		return
+	}
+	var source model.PersonalResultVersion
+	if err := h.db.Where("id = ? AND task_id = ? AND user_id = ?", versionID, taskID, userID).First(&source).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+
+	now := timezone.Now()
+	shouldTriggerMeta := false
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if _, err := ensurePersonalVersionBaseline(tx, latestPR); err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
+			Updates(map[string]interface{}{
+				"content":            source.Content,
+				"citations_json":     source.CitationsJSON,
+				"msg_count":          source.MsgCount,
+				"total_token_used":   source.TotalTokenUsed,
+				"model_version":      source.ModelVersion,
+				"current_version_id": source.ID,
+				"worker_status":      model.PersonalStatusCompleted,
+				"workflow_stage":     model.WorkflowStageGenerateSummary,
+				"retry_count":        0,
+				"error_message":      nil,
+				"generated_at":       now,
+				"edited_at":          now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return errPersonalResultGone
+		}
+		var participantCount int64
+		if err := tx.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Count(&participantCount).Error; err != nil {
+			return err
+		}
+		if participantCount > 1 {
+			if err := h.reviveCompletedForRecompute(tx, taskID); err != nil {
+				return err
+			}
+			shouldTriggerMeta = true
+		}
+		return nil
+	})
+	if err != nil {
+		if err == gorm.ErrRecordNotFound || err == errPersonalResultGone {
+			c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+			return
+		}
+		log.Printf("[personal-restore] transaction error task=%d user=%s version=%d: %v", taskID, userID, versionID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if shouldTriggerMeta {
+		go h.triggerWorker(model.WorkerTriggerRequest{
+			Type:   "meta_summary",
+			TaskID: taskID,
+		})
+	}
+	ok(c, gin.H{"task_id": taskID, "result_id": pr.ID, "version_id": source.ID, "version": source.Version})
+}
+
+type regeneratePersonalReq struct {
+	Topic string `json:"topic"`
+}
+
+func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人重新生成"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可重新生成个人总结"})
+		return
+	}
+
+	var participant model.SummaryParticipant
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&participant).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "你不是该任务的参与者"})
+		return
+	}
+	var participantCount int64
+	if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Count(&participantCount).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if participantCount <= 1 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "单人任务请使用全部重新生成"})
+		return
+	}
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+	if pr.WorkerStatus == model.PersonalStatusPending || pr.WorkerStatus == model.PersonalStatusProcessing {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40005, Message: "个人总结正在生成中"})
+		return
+	}
+
+	var req regeneratePersonalReq
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	topic := strings.TrimSpace(req.Topic)
+	if utf8.RuneCountInString(topic) > 1000 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 1000 字符"})
+		return
+	}
+	err := h.db.Transaction(func(tx *gorm.DB) error {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if _, err := ensurePersonalVersionBaseline(tx, latestPR); err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ? AND worker_status IN ?", latestPR.ID, taskID, userID, []int{model.PersonalStatusCompleted, model.PersonalStatusFailed}).
+			Updates(map[string]interface{}{
+				"worker_status":      model.PersonalStatusPending,
+				"workflow_stage":     "",
+				"retry_count":        0,
+				"content":            "",
+				"citations_json":     "",
+				"msg_count":          0,
+				"total_token_used":   0,
+				"model_version":      "",
+				"current_version_id": nil,
+				"error_message":      nil,
+				"submitted_at":       nil,
+				"submit_source":      model.SubmitSourceNone,
+				"generated_at":       nil,
+				"edited_at":          nil,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return service.NewBizError(40005, "个人总结正在生成中", http.StatusConflict)
+		}
+		if err := tx.Model(&model.SummaryParticipant{}).
+			Where("id = ? AND task_id = ?", participant.ID, taskID).
+			Updates(map[string]interface{}{
+				"status":            model.ParticipantAccepted,
+				"worker_started_at": nil,
+			}).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		log.Printf("[personal-regenerate] transaction error task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+
+	go h.triggerWorker(model.WorkerTriggerRequest{
+		Type:             "personal_regenerate",
+		TaskID:           taskID,
+		ParticipantRefID: participant.ID,
+	})
+
+	ok(c, gin.H{"task_id": taskID, "result_id": pr.ID, "status": model.PersonalStatusPending})
+}
+
+func currentPersonalVersion(db *gorm.DB, taskID int64, userID string, pr model.PersonalResult) (int, error) {
+	if pr.CurrentVersionID != nil {
+		var current model.PersonalResultVersion
+		if err := db.Where("id = ? AND task_id = ? AND user_id = ?", *pr.CurrentVersionID, taskID, userID).First(&current).Error; err == nil {
+			return current.Version, nil
+		} else if err != gorm.ErrRecordNotFound {
+			return 0, err
+		}
+	}
+	var version int
+	if err := db.Model(&model.PersonalResultVersion{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Select("COALESCE(MAX(version), 0)").Scan(&version).Error; err != nil {
+		return 0, err
+	}
+	if version == 0 && strings.TrimSpace(pr.Content) != "" {
+		return 1, nil
+	}
+	return version, nil
+}
+
+func ensurePersonalVersionBaseline(tx *gorm.DB, pr model.PersonalResult) (model.PersonalResultVersion, error) {
+	var latest model.PersonalResultVersion
+	if pr.CurrentVersionID != nil {
+		if err := tx.Where("id = ? AND task_id = ? AND user_id = ?", *pr.CurrentVersionID, pr.TaskID, pr.UserID).First(&latest).Error; err == nil {
+			if personalCanonicalDiffersFromVersion(pr, latest) {
+				return createPersonalVersionSnapshot(tx, pr, &latest, "edit")
+			}
+			return latest, nil
+		} else if err != gorm.ErrRecordNotFound {
+			return latest, err
+		}
+	}
+
+	err := tx.Where("task_id = ? AND user_id = ?", pr.TaskID, pr.UserID).
+		Order("version DESC").Order("id DESC").First(&latest).Error
+	if err == nil {
+		if personalCanonicalDiffersFromVersion(pr, latest) {
+			return createPersonalVersionSnapshot(tx, pr, &latest, "edit")
+		}
+		if pr.CurrentVersionID == nil {
+			if err := tx.Model(&model.PersonalResult{}).Where("id = ? AND current_version_id IS NULL", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
+				return latest, err
+			}
+		}
+		return latest, nil
+	}
+	if err != gorm.ErrRecordNotFound {
+		return latest, err
+	}
+	return createPersonalVersionSnapshot(tx, pr, nil, "generate")
+}
+
+func personalCanonicalDiffersFromVersion(pr model.PersonalResult, version model.PersonalResultVersion) bool {
+	if pr.EditedAt == nil {
+		return false
+	}
+	return pr.Content != version.Content ||
+		pr.CitationsJSON != version.CitationsJSON ||
+		pr.MsgCount != version.MsgCount ||
+		pr.TotalTokenUsed != version.TotalTokenUsed ||
+		pr.ModelVersion != version.ModelVersion
+}
+
+func createPersonalVersionSnapshot(tx *gorm.DB, pr model.PersonalResult, parent *model.PersonalResultVersion, operationType string) (model.PersonalResultVersion, error) {
+	generatedAt := timezone.Now()
+	if pr.EditedAt != nil {
+		generatedAt = *pr.EditedAt
+	} else if pr.GeneratedAt != nil {
+		generatedAt = *pr.GeneratedAt
+	} else if !pr.CreatedAt.IsZero() {
+		generatedAt = pr.CreatedAt
+	}
+	version := 1
+	var parentID *int64
+	if parent != nil {
+		parentID = &parent.ID
+		nextVer, err := service.GetNextPersonalVersion(tx, pr.TaskID, pr.UserID)
+		if err != nil {
+			return model.PersonalResultVersion{}, err
+		}
+		version = nextVer
+	}
+	latest := model.PersonalResultVersion{
+		TaskID:           pr.TaskID,
+		ParticipantRefID: pr.ParticipantRefID,
+		UserID:           pr.UserID,
+		Content:          pr.Content,
+		CitationsJSON:    pr.CitationsJSON,
+		MsgCount:         pr.MsgCount,
+		TotalTokenUsed:   pr.TotalTokenUsed,
+		ModelVersion:     pr.ModelVersion,
+		Version:          version,
+		OperationType:    operationType,
+		ParentVersionID:  parentID,
+		CreatedBy:        pr.UserID,
+		GeneratedAt:      generatedAt,
+	}
+	if err := tx.Create(&latest).Error; err != nil {
+		return latest, err
+	}
+	if err := tx.Model(&model.PersonalResult{}).Where("id = ?", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
+		return latest, err
+	}
+	return latest, nil
+}

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -191,7 +191,10 @@ func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
 		if res.RowsAffected == 0 {
 			return errPersonalResultGone
 		}
-		return service.PrunePersonalResultVersions(tx, taskID, userID, service.PersonalResultVersionKeepLimit)
+		if err := service.PrunePersonalResultVersions(tx, taskID, userID, service.PersonalResultVersionKeepLimit); err != nil {
+			return err
+		}
+		return appendBoundScheduleGenerationInstruction(tx, *task, feedback)
 	})
 	if err != nil {
 		if bizError, isBiz := err.(*service.BizError); isBiz {
@@ -493,6 +496,11 @@ func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
 		}
 		if newTitle != task.Title {
 			if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("title", newTitle).Error; err != nil {
+				return err
+			}
+		}
+		if topic != "" {
+			if err := resetBoundScheduleGenerationInstruction(tx, *task, topic); err != nil {
 				return err
 			}
 		}

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type refinePersonalReq struct {
@@ -130,18 +131,24 @@ func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
 	var newVersion model.PersonalResultVersion
 	err = h.db.Transaction(func(tx *gorm.DB) error {
 		var latestPR model.PersonalResult
-		if err := tx.Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).First(&latestPR).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
 			return err
 		}
 		if latestPR.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(latestPR.Content) == "" {
 			return service.NewBizError(40005, "个人总结状态已变更", http.StatusBadRequest)
 		}
-		latestVersion, err := ensurePersonalVersionBaseline(tx, latestPR)
+		versionBeforeBaseline, err := currentPersonalVersion(tx, taskID, userID, latestPR)
 		if err != nil {
 			return err
 		}
-		if req.BaseVersion > 0 && req.BaseVersion != latestVersion.Version {
+		if req.BaseVersion > 0 && req.BaseVersion != versionBeforeBaseline {
 			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		latestVersion, err := ensurePersonalVersionBaseline(tx, latestPR)
+		if err != nil {
+			return err
 		}
 
 		nextVer, err := service.GetNextPersonalVersion(tx, taskID, userID)
@@ -343,11 +350,17 @@ func (h *PersonalHandler) RestorePersonalVersion(c *gin.Context) {
 
 	now := timezone.Now()
 	err = h.db.Transaction(func(tx *gorm.DB) error {
-		if _, err := ensurePersonalVersionBaseline(tx, pr); err != nil {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if _, err := ensurePersonalVersionBaseline(tx, latestPR); err != nil {
 			return err
 		}
 		res := tx.Model(&model.PersonalResult{}).
-			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
 			Updates(map[string]interface{}{
 				"content":            source.Content,
 				"citations_json":     source.CitationsJSON,
@@ -445,11 +458,17 @@ func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
 	}
 
 	err := h.db.Transaction(func(tx *gorm.DB) error {
-		if _, err := ensurePersonalVersionBaseline(tx, pr); err != nil && strings.TrimSpace(pr.Content) != "" {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if _, err := ensurePersonalVersionBaseline(tx, latestPR); err != nil {
 			return err
 		}
 		res := tx.Model(&model.PersonalResult{}).
-			Where("id = ? AND task_id = ? AND user_id = ? AND worker_status IN ?", pr.ID, taskID, userID, []int{model.PersonalStatusCompleted, model.PersonalStatusFailed}).
+			Where("id = ? AND task_id = ? AND user_id = ? AND worker_status IN ?", latestPR.ID, taskID, userID, []int{model.PersonalStatusCompleted, model.PersonalStatusFailed}).
 			Updates(map[string]interface{}{
 				"worker_status":      model.PersonalStatusPending,
 				"workflow_stage":     "",
@@ -507,6 +526,14 @@ func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
 }
 
 func currentPersonalVersion(db *gorm.DB, taskID int64, userID string, pr model.PersonalResult) (int, error) {
+	if pr.CurrentVersionID != nil {
+		var current model.PersonalResultVersion
+		if err := db.Where("id = ? AND task_id = ? AND user_id = ?", *pr.CurrentVersionID, taskID, userID).First(&current).Error; err == nil {
+			return current.Version, nil
+		} else if err != gorm.ErrRecordNotFound {
+			return 0, err
+		}
+	}
 	var version int
 	if err := db.Model(&model.PersonalResultVersion{}).
 		Where("task_id = ? AND user_id = ?", taskID, userID).
@@ -523,6 +550,9 @@ func ensurePersonalVersionBaseline(tx *gorm.DB, pr model.PersonalResult) (model.
 	var latest model.PersonalResultVersion
 	if pr.CurrentVersionID != nil {
 		if err := tx.Where("id = ? AND task_id = ? AND user_id = ?", *pr.CurrentVersionID, pr.TaskID, pr.UserID).First(&latest).Error; err == nil {
+			if personalCanonicalDiffersFromVersion(pr, latest) {
+				return createPersonalVersionSnapshot(tx, pr, &latest, "edit")
+			}
 			return latest, nil
 		} else if err != gorm.ErrRecordNotFound {
 			return latest, err
@@ -532,6 +562,9 @@ func ensurePersonalVersionBaseline(tx *gorm.DB, pr model.PersonalResult) (model.
 	err := tx.Where("task_id = ? AND user_id = ?", pr.TaskID, pr.UserID).
 		Order("version DESC").Order("id DESC").First(&latest).Error
 	if err == nil {
+		if personalCanonicalDiffersFromVersion(pr, latest) {
+			return createPersonalVersionSnapshot(tx, pr, &latest, "edit")
+		}
 		if pr.CurrentVersionID == nil {
 			if err := tx.Model(&model.PersonalResult{}).Where("id = ? AND current_version_id IS NULL", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
 				return latest, err
@@ -542,13 +575,40 @@ func ensurePersonalVersionBaseline(tx *gorm.DB, pr model.PersonalResult) (model.
 	if err != gorm.ErrRecordNotFound {
 		return latest, err
 	}
+	return createPersonalVersionSnapshot(tx, pr, nil, "generate")
+}
+
+func personalCanonicalDiffersFromVersion(pr model.PersonalResult, version model.PersonalResultVersion) bool {
+	if pr.EditedAt == nil {
+		return false
+	}
+	return pr.Content != version.Content ||
+		pr.CitationsJSON != version.CitationsJSON ||
+		pr.MsgCount != version.MsgCount ||
+		pr.TotalTokenUsed != version.TotalTokenUsed ||
+		pr.ModelVersion != version.ModelVersion
+}
+
+func createPersonalVersionSnapshot(tx *gorm.DB, pr model.PersonalResult, parent *model.PersonalResultVersion, operationType string) (model.PersonalResultVersion, error) {
 	generatedAt := timezone.Now()
-	if pr.GeneratedAt != nil {
+	if pr.EditedAt != nil {
+		generatedAt = *pr.EditedAt
+	} else if pr.GeneratedAt != nil {
 		generatedAt = *pr.GeneratedAt
 	} else if !pr.CreatedAt.IsZero() {
 		generatedAt = pr.CreatedAt
 	}
-	latest = model.PersonalResultVersion{
+	version := 1
+	var parentID *int64
+	if parent != nil {
+		parentID = &parent.ID
+		nextVer, err := service.GetNextPersonalVersion(tx, pr.TaskID, pr.UserID)
+		if err != nil {
+			return model.PersonalResultVersion{}, err
+		}
+		version = nextVer
+	}
+	latest := model.PersonalResultVersion{
 		TaskID:           pr.TaskID,
 		ParticipantRefID: pr.ParticipantRefID,
 		UserID:           pr.UserID,
@@ -557,15 +617,16 @@ func ensurePersonalVersionBaseline(tx *gorm.DB, pr model.PersonalResult) (model.
 		MsgCount:         pr.MsgCount,
 		TotalTokenUsed:   pr.TotalTokenUsed,
 		ModelVersion:     pr.ModelVersion,
-		Version:          1,
-		OperationType:    "generate",
+		Version:          version,
+		OperationType:    operationType,
+		ParentVersionID:  parentID,
 		CreatedBy:        pr.UserID,
 		GeneratedAt:      generatedAt,
 	}
 	if err := tx.Create(&latest).Error; err != nil {
 		return latest, err
 	}
-	if err := tx.Model(&model.PersonalResult{}).Where("id = ? AND current_version_id IS NULL", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
+	if err := tx.Model(&model.PersonalResult{}).Where("id = ?", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
 		return latest, err
 	}
 	return latest, nil

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -248,6 +248,222 @@ func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
 	})
 }
 
+func (h *PersonalHandler) RefinePersonalSummaryStream(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	var req refinePersonalReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+	if req.BaseResultID > 0 && req.BaseResultID != pr.ID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+	if pr.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(pr.Content) == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "个人总结未完成，无法调整"})
+		return
+	}
+
+	currentVersion, err := currentPersonalVersion(h.db, taskID, userID, pr)
+	if err != nil {
+		log.Printf("[personal-refine-stream] query current version task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if req.BaseVersion > 0 && req.BaseVersion != currentVersion {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	w := c.Writer
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	_ = writeSSE(w, "start", gin.H{"type": "start", "task_id": taskID, "scope": "personal"})
+	w.Flush()
+
+	writeStreamError := func(message string) {
+		_ = writeSSE(w, "error", gin.H{"type": "error", "task_id": taskID, "scope": "personal", "message": message})
+		w.Flush()
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.CallStream(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", pr.Content, feedback)},
+	}, 0.1, func(delta string) error {
+		if delta == "" {
+			return nil
+		}
+		if err := writeSSE(w, "delta", gin.H{"type": "delta", "task_id": taskID, "scope": "personal", "delta": delta}); err != nil {
+			return err
+		}
+		w.Flush()
+		return nil
+	})
+	if err != nil {
+		log.Printf("[personal-refine-stream] llm error task=%d personal_result=%d: %v", taskID, pr.ID, err)
+		writeStreamError("调整失败，请稍后重试")
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		writeStreamError("调整结果为空")
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		writeStreamError("调整结果超过 500KB 限制")
+		return
+	}
+
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, pr.GetCitations())
+	tmp := &model.PersonalResult{}
+	tmp.SetCitations(cleanedCitations)
+	citationsJSON := tmp.CitationsJSON
+
+	now := timezone.Now()
+	var newVersion model.PersonalResultVersion
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if latestPR.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(latestPR.Content) == "" {
+			return service.NewBizError(40005, "个人总结状态已变更", http.StatusBadRequest)
+		}
+		versionBeforeBaseline, err := currentPersonalVersion(tx, taskID, userID, latestPR)
+		if err != nil {
+			return err
+		}
+		if req.BaseVersion > 0 && req.BaseVersion != versionBeforeBaseline {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		latestVersion, err := ensurePersonalVersionBaseline(tx, latestPR)
+		if err != nil {
+			return err
+		}
+
+		nextVer, err := service.GetNextPersonalVersion(tx, taskID, userID)
+		if err != nil {
+			return err
+		}
+		newVersion = model.PersonalResultVersion{
+			TaskID:           taskID,
+			ParticipantRefID: latestPR.ParticipantRefID,
+			UserID:           userID,
+			Content:          newContent,
+			CitationsJSON:    citationsJSON,
+			MsgCount:         latestPR.MsgCount,
+			TotalTokenUsed:   latestPR.TotalTokenUsed + tokens,
+			ModelVersion:     h.llm.ModelVersion(),
+			Version:          nextVer,
+			OperationType:    "refine",
+			OperationNote:    feedback,
+			ParentVersionID:  &latestVersion.ID,
+			CreatedBy:        userID,
+			GeneratedAt:      now,
+		}
+		if err := tx.Create(&newVersion).Error; err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
+			Updates(map[string]interface{}{
+				"content":            newContent,
+				"citations_json":     citationsJSON,
+				"total_token_used":   latestPR.TotalTokenUsed + tokens,
+				"model_version":      h.llm.ModelVersion(),
+				"current_version_id": newVersion.ID,
+				"generated_at":       now,
+				"edited_at":          now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return errPersonalResultGone
+		}
+		if err := service.PrunePersonalResultVersions(tx, taskID, userID, service.PersonalResultVersionKeepLimit); err != nil {
+			return err
+		}
+		return appendBoundScheduleGenerationInstruction(tx, *task, feedback)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			writeStreamError(bizError.Message)
+			return
+		}
+		if err == gorm.ErrRecordNotFound || err == errPersonalResultGone {
+			writeStreamError("个人总结不存在")
+			return
+		}
+		log.Printf("[personal-refine-stream] transaction error task=%d user=%s: %v", taskID, userID, err)
+		writeStreamError("internal error")
+		return
+	}
+
+	_ = writeSSE(w, "done", gin.H{
+		"type":             "done",
+		"task_id":          taskID,
+		"scope":            "personal",
+		"result_id":        pr.ID,
+		"version_id":       newVersion.ID,
+		"version":          newVersion.Version,
+		"content":          newContent,
+		"citations":        newVersion.GetCitations(),
+		"msg_count":        newVersion.MsgCount,
+		"total_token_used": newVersion.TotalTokenUsed,
+		"model_version":    newVersion.ModelVersion,
+		"operation_type":   newVersion.OperationType,
+		"operation_note":   newVersion.OperationNote,
+		"parent_result_id": newVersion.ParentVersionID,
+		"generated_at":     newVersion.GeneratedAt.Format(time.RFC3339),
+	})
+	w.Flush()
+}
+
 func (h *PersonalHandler) ListPersonalVersions(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	taskID, valid := h.parseTaskID(c)

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -1,0 +1,572 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type refinePersonalReq struct {
+	Feedback     string `json:"feedback"`
+	BaseResultID int64  `json:"base_result_id"`
+	BaseVersion  int    `json:"base_version"`
+}
+
+type personalVersionItem struct {
+	VersionID       int64  `json:"result_id"`
+	Version         int    `json:"version"`
+	OperationType   string `json:"operation_type"`
+	OperationNote   string `json:"operation_note"`
+	ParentVersionID *int64 `json:"parent_result_id,omitempty"`
+	CreatedBy       string `json:"created_by"`
+	GeneratedAt     string `json:"generated_at"`
+	EditedAt        any    `json:"edited_at"`
+}
+
+func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	var req refinePersonalReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+	if req.BaseResultID > 0 && req.BaseResultID != pr.ID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+	if pr.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(pr.Content) == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "个人总结未完成，无法调整"})
+		return
+	}
+
+	currentVersion, err := currentPersonalVersion(h.db, taskID, userID, pr)
+	if err != nil {
+		log.Printf("[personal-refine] query current version task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if req.BaseVersion > 0 && req.BaseVersion != currentVersion {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.Call(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", pr.Content, feedback)},
+	}, 0.1)
+	if err != nil {
+		log.Printf("[personal-refine] llm error task=%d personal_result=%d: %v", taskID, pr.ID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整失败，请稍后重试"})
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "调整结果为空"})
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "调整结果超过 500KB 限制"})
+		return
+	}
+
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, pr.GetCitations())
+	tmp := &model.PersonalResult{}
+	tmp.SetCitations(cleanedCitations)
+	citationsJSON := tmp.CitationsJSON
+
+	now := timezone.Now()
+	var newVersion model.PersonalResultVersion
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var latestPR model.PersonalResult
+		if err := tx.Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).First(&latestPR).Error; err != nil {
+			return err
+		}
+		if latestPR.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(latestPR.Content) == "" {
+			return service.NewBizError(40005, "个人总结状态已变更", http.StatusBadRequest)
+		}
+		latestVersion, err := ensurePersonalVersionBaseline(tx, latestPR)
+		if err != nil {
+			return err
+		}
+		if req.BaseVersion > 0 && req.BaseVersion != latestVersion.Version {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+
+		nextVer, err := service.GetNextPersonalVersion(tx, taskID, userID)
+		if err != nil {
+			return err
+		}
+		newVersion = model.PersonalResultVersion{
+			TaskID:           taskID,
+			ParticipantRefID: latestPR.ParticipantRefID,
+			UserID:           userID,
+			Content:          newContent,
+			CitationsJSON:    citationsJSON,
+			MsgCount:         latestPR.MsgCount,
+			TotalTokenUsed:   latestPR.TotalTokenUsed + tokens,
+			ModelVersion:     h.llm.ModelVersion(),
+			Version:          nextVer,
+			OperationType:    "refine",
+			OperationNote:    feedback,
+			ParentVersionID:  &latestVersion.ID,
+			CreatedBy:        userID,
+			GeneratedAt:      now,
+		}
+		if err := tx.Create(&newVersion).Error; err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
+			Updates(map[string]interface{}{
+				"content":            newContent,
+				"citations_json":     citationsJSON,
+				"total_token_used":   latestPR.TotalTokenUsed + tokens,
+				"model_version":      h.llm.ModelVersion(),
+				"current_version_id": newVersion.ID,
+				"generated_at":       now,
+				"edited_at":          now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return errPersonalResultGone
+		}
+		return service.PrunePersonalResultVersions(tx, taskID, userID, service.PersonalResultVersionKeepLimit)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		if err == gorm.ErrRecordNotFound || err == errPersonalResultGone {
+			c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+			return
+		}
+		log.Printf("[personal-refine] transaction error task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+
+	ok(c, gin.H{
+		"task_id":          taskID,
+		"result_id":        pr.ID,
+		"version_id":       newVersion.ID,
+		"version":          newVersion.Version,
+		"content":          newContent,
+		"citations":        newVersion.GetCitations(),
+		"msg_count":        newVersion.MsgCount,
+		"total_token_used": newVersion.TotalTokenUsed,
+		"model_version":    newVersion.ModelVersion,
+		"operation_type":   newVersion.OperationType,
+		"operation_note":   newVersion.OperationNote,
+		"parent_result_id": newVersion.ParentVersionID,
+		"generated_at":     newVersion.GeneratedAt.Format(time.RFC3339),
+	})
+}
+
+func (h *PersonalHandler) ListPersonalVersions(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	limit := 3
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= service.PersonalResultVersionKeepLimit {
+			limit = n
+		}
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人版本"})
+		return
+	}
+	var participantCount int64
+	if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, userID).Count(&participantCount).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if participantCount == 0 {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "你不是该任务的参与者"})
+		return
+	}
+
+	var rows []model.PersonalResultVersion
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).Order("version DESC").Order("id DESC").Limit(limit).Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	items := make([]personalVersionItem, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, personalVersionItem{
+			VersionID:       row.ID,
+			Version:         row.Version,
+			OperationType:   row.OperationType,
+			OperationNote:   row.OperationNote,
+			ParentVersionID: row.ParentVersionID,
+			CreatedBy:       row.CreatedBy,
+			GeneratedAt:     row.GeneratedAt.Format(time.RFC3339),
+			EditedAt:        nil,
+		})
+	}
+	ok(c, gin.H{"versions": items, "keep_limit": service.PersonalResultVersionKeepLimit})
+}
+
+func (h *PersonalHandler) GetPersonalVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	versionID, err := strconv.ParseInt(c.Param("version_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid version id"})
+		return
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人版本"})
+		return
+	}
+	var row model.PersonalResultVersion
+	if err := h.db.Where("id = ? AND task_id = ? AND user_id = ?", versionID, taskID, userID).First(&row).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	ok(c, gin.H{
+		"result_id":        row.ID,
+		"version_id":       row.ID,
+		"version":          row.Version,
+		"operation_type":   row.OperationType,
+		"operation_note":   row.OperationNote,
+		"parent_result_id": row.ParentVersionID,
+		"created_by":       row.CreatedBy,
+		"generated_at":     row.GeneratedAt.Format(time.RFC3339),
+		"edited_at":        nil,
+		"content":          row.Content,
+		"citations":        row.GetCitations(),
+	})
+}
+
+func (h *PersonalHandler) RestorePersonalVersion(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	versionID, err := strconv.ParseInt(c.Param("version_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid version id"})
+		return
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人版本"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可恢复版本"})
+		return
+	}
+	var source model.PersonalResultVersion
+	if err := h.db.Where("id = ? AND task_id = ? AND user_id = ?", versionID, taskID, userID).First(&source).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "版本不存在"})
+		return
+	}
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+
+	now := timezone.Now()
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		if _, err := ensurePersonalVersionBaseline(tx, pr); err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			Updates(map[string]interface{}{
+				"content":            source.Content,
+				"citations_json":     source.CitationsJSON,
+				"msg_count":          source.MsgCount,
+				"total_token_used":   source.TotalTokenUsed,
+				"model_version":      source.ModelVersion,
+				"current_version_id": source.ID,
+				"worker_status":      model.PersonalStatusCompleted,
+				"workflow_stage":     model.WorkflowStageGenerateSummary,
+				"retry_count":        0,
+				"error_message":      nil,
+				"generated_at":       now,
+				"edited_at":          now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return errPersonalResultGone
+		}
+		return nil
+	})
+	if err != nil {
+		if err == gorm.ErrRecordNotFound || err == errPersonalResultGone {
+			c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+			return
+		}
+		log.Printf("[personal-restore] transaction error task=%d user=%s version=%d: %v", taskID, userID, versionID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	ok(c, gin.H{"task_id": taskID, "result_id": pr.ID, "version_id": source.ID, "version": source.Version})
+}
+
+type regeneratePersonalReq struct {
+	Topic string `json:"topic"`
+}
+
+func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人重新生成"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可重新生成个人总结"})
+		return
+	}
+
+	var participant model.SummaryParticipant
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&participant).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "你不是该任务的参与者"})
+		return
+	}
+	var participantCount int64
+	if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Count(&participantCount).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if participantCount <= 1 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "单人任务请使用全部重新生成"})
+		return
+	}
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+	if pr.WorkerStatus == model.PersonalStatusPending || pr.WorkerStatus == model.PersonalStatusProcessing {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40005, Message: "个人总结正在生成中"})
+		return
+	}
+
+	var req regeneratePersonalReq
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	topic := strings.TrimSpace(req.Topic)
+	if utf8.RuneCountInString(topic) > 1000 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 1000 字符"})
+		return
+	}
+	newTitle := task.Title
+	if topic != "" && topic != task.Title {
+		newTitle = topic
+	}
+
+	err := h.db.Transaction(func(tx *gorm.DB) error {
+		if _, err := ensurePersonalVersionBaseline(tx, pr); err != nil && strings.TrimSpace(pr.Content) != "" {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ? AND worker_status IN ?", pr.ID, taskID, userID, []int{model.PersonalStatusCompleted, model.PersonalStatusFailed}).
+			Updates(map[string]interface{}{
+				"worker_status":      model.PersonalStatusPending,
+				"workflow_stage":     "",
+				"retry_count":        0,
+				"content":            "",
+				"citations_json":     "",
+				"msg_count":          0,
+				"total_token_used":   0,
+				"model_version":      "",
+				"current_version_id": nil,
+				"error_message":      nil,
+				"submitted_at":       nil,
+				"submit_source":      model.SubmitSourceNone,
+				"generated_at":       nil,
+				"edited_at":          nil,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return service.NewBizError(40005, "个人总结正在生成中", http.StatusConflict)
+		}
+		if newTitle != task.Title {
+			if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("title", newTitle).Error; err != nil {
+				return err
+			}
+		}
+		if err := tx.Model(&model.SummaryParticipant{}).
+			Where("id = ? AND task_id = ?", participant.ID, taskID).
+			Updates(map[string]interface{}{
+				"status":            model.ParticipantAccepted,
+				"worker_started_at": nil,
+			}).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			bizErr(c, bizError)
+			return
+		}
+		log.Printf("[personal-regenerate] transaction error task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+
+	go h.triggerWorker(model.WorkerTriggerRequest{
+		Type:             "personal_regenerate",
+		TaskID:           taskID,
+		ParticipantRefID: participant.ID,
+	})
+
+	ok(c, gin.H{"task_id": taskID, "result_id": pr.ID, "status": model.PersonalStatusPending})
+}
+
+func currentPersonalVersion(db *gorm.DB, taskID int64, userID string, pr model.PersonalResult) (int, error) {
+	var version int
+	if err := db.Model(&model.PersonalResultVersion{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Select("COALESCE(MAX(version), 0)").Scan(&version).Error; err != nil {
+		return 0, err
+	}
+	if version == 0 && strings.TrimSpace(pr.Content) != "" {
+		return 1, nil
+	}
+	return version, nil
+}
+
+func ensurePersonalVersionBaseline(tx *gorm.DB, pr model.PersonalResult) (model.PersonalResultVersion, error) {
+	var latest model.PersonalResultVersion
+	if pr.CurrentVersionID != nil {
+		if err := tx.Where("id = ? AND task_id = ? AND user_id = ?", *pr.CurrentVersionID, pr.TaskID, pr.UserID).First(&latest).Error; err == nil {
+			return latest, nil
+		} else if err != gorm.ErrRecordNotFound {
+			return latest, err
+		}
+	}
+
+	err := tx.Where("task_id = ? AND user_id = ?", pr.TaskID, pr.UserID).
+		Order("version DESC").Order("id DESC").First(&latest).Error
+	if err == nil {
+		if pr.CurrentVersionID == nil {
+			if err := tx.Model(&model.PersonalResult{}).Where("id = ? AND current_version_id IS NULL", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
+				return latest, err
+			}
+		}
+		return latest, nil
+	}
+	if err != gorm.ErrRecordNotFound {
+		return latest, err
+	}
+	generatedAt := timezone.Now()
+	if pr.GeneratedAt != nil {
+		generatedAt = *pr.GeneratedAt
+	} else if !pr.CreatedAt.IsZero() {
+		generatedAt = pr.CreatedAt
+	}
+	latest = model.PersonalResultVersion{
+		TaskID:           pr.TaskID,
+		ParticipantRefID: pr.ParticipantRefID,
+		UserID:           pr.UserID,
+		Content:          pr.Content,
+		CitationsJSON:    pr.CitationsJSON,
+		MsgCount:         pr.MsgCount,
+		TotalTokenUsed:   pr.TotalTokenUsed,
+		ModelVersion:     pr.ModelVersion,
+		Version:          1,
+		OperationType:    "generate",
+		CreatedBy:        pr.UserID,
+		GeneratedAt:      generatedAt,
+	}
+	if err := tx.Create(&latest).Error; err != nil {
+		return latest, err
+	}
+	if err := tx.Model(&model.PersonalResult{}).Where("id = ? AND current_version_id IS NULL", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
+		return latest, err
+	}
+	return latest, nil
+}

--- a/internal/api/handler/personal_refine_test.go
+++ b/internal/api/handler/personal_refine_test.go
@@ -1,0 +1,223 @@
+//go:build cgo
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupPersonalRefineDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&model.SummarySchedule{},
+		&model.SummaryTask{},
+		&model.SummaryParticipant{},
+		&model.PersonalResult{},
+		&model.PersonalResultVersion{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func setupPersonalRefineRouter(h *PersonalHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.POST("/api/v1/summaries/:id/personal-refine", h.RefinePersonalSummary)
+	r.POST("/api/v1/summaries/:id/personal-regenerate", h.RegeneratePersonalSummary)
+	return r
+}
+
+func seedScheduledMultiPersonPersonalTask(t *testing.T, db *gorm.DB) (task model.SummaryTask, sched model.SummarySchedule, pr model.PersonalResult) {
+	t.Helper()
+	now := time.Now().UTC()
+	sched = model.SummarySchedule{
+		SpaceID:               "space1",
+		CreatorID:             "creator1",
+		Title:                 "shared schedule title",
+		GenerationInstruction: "existing shared instruction",
+		IsActive:              1,
+	}
+	if err := db.Create(&sched).Error; err != nil {
+		t.Fatalf("seed schedule: %v", err)
+	}
+	task = model.SummaryTask{
+		TaskNo:      "TST-PERSONAL-REFINE",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		Title:       "shared task title",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+		ScheduleID:  &sched.ID,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	creator := model.SummaryParticipant{TaskID: task.ID, UserID: "creator1", UserName: "Creator", Status: model.ParticipantCompleted}
+	member := model.SummaryParticipant{TaskID: task.ID, UserID: "member_a", UserName: "Member A", Status: model.ParticipantCompleted}
+	if err := db.Create(&creator).Error; err != nil {
+		t.Fatalf("seed creator participant: %v", err)
+	}
+	if err := db.Create(&member).Error; err != nil {
+		t.Fatalf("seed member participant: %v", err)
+	}
+	pr = model.PersonalResult{
+		TaskID:           task.ID,
+		ParticipantRefID: member.ID,
+		UserID:           "member_a",
+		WorkerStatus:     model.PersonalStatusCompleted,
+		Content:          "old personal summary with [1]",
+		GeneratedAt:      &now,
+	}
+	pr.SetCitations([]model.Citation{{Index: 1, Sender: "Member A", Content: "raw", SentAt: "2026-01-01T00:00:00Z", Source: "grp", ChannelID: "ch1", ChannelType: 2, MessageSeq: 1}})
+	if err := db.Create(&pr).Error; err != nil {
+		t.Fatalf("seed personal result: %v", err)
+	}
+	return task, sched, pr
+}
+
+func doPersonalRefineRequest(r *gin.Engine, taskID int64, userID string, body interface{}) *httptest.ResponseRecorder {
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, _ = json.Marshal(body)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/summaries/%d/personal-refine", taskID), bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func doPersonalRegenerateRequest(r *gin.Engine, taskID int64, userID string, body interface{}) *httptest.ResponseRecorder {
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, _ = json.Marshal(body)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/summaries/%d/personal-regenerate", taskID), bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestRefinePersonalSummary_RequiresBaseVersion(t *testing.T) {
+	db := setupPersonalRefineDB(t)
+	task, _, pr := seedScheduledMultiPersonPersonalTask(t, db)
+	llm, closeLLM := newTestRefineLLM(t, "new personal summary")
+	defer closeLLM()
+
+	h := NewPersonalHandler(db, "", nil)
+	h.SetLLM(llm)
+	r := setupPersonalRefineRouter(h)
+
+	w := doPersonalRefineRequest(r, task.ID, "member_a", map[string]interface{}{
+		"feedback":       "make mine shorter",
+		"base_result_id": pr.ID,
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when base_version is missing, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRefinePersonalSummary_StaleBaseVersionConflicts(t *testing.T) {
+	db := setupPersonalRefineDB(t)
+	task, _, pr := seedScheduledMultiPersonPersonalTask(t, db)
+	llm, closeLLM := newTestRefineLLM(t, "new personal summary")
+	defer closeLLM()
+
+	h := NewPersonalHandler(db, "", nil)
+	h.SetLLM(llm)
+	r := setupPersonalRefineRouter(h)
+
+	w := doPersonalRefineRequest(r, task.ID, "member_a", map[string]interface{}{
+		"feedback":       "make mine shorter",
+		"base_result_id": pr.ID,
+		"base_version":   2,
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for stale base_version, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRefinePersonalSummary_DoesNotMutateSharedScheduleInstruction(t *testing.T) {
+	db := setupPersonalRefineDB(t)
+	task, sched, pr := seedScheduledMultiPersonPersonalTask(t, db)
+	llm, closeLLM := newTestRefineLLM(t, "new personal summary")
+	defer closeLLM()
+
+	h := NewPersonalHandler(db, "", nil)
+	h.SetLLM(llm)
+	r := setupPersonalRefineRouter(h)
+
+	w := doPersonalRefineRequest(r, task.ID, "member_a", map[string]interface{}{
+		"feedback":       "make my section terser",
+		"base_result_id": pr.ID,
+		"base_version":   1,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got model.SummarySchedule
+	if err := db.First(&got, sched.ID).Error; err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+	if got.GenerationInstruction != sched.GenerationInstruction {
+		t.Fatalf("personal refine must not mutate shared schedule instruction, got %q want %q", got.GenerationInstruction, sched.GenerationInstruction)
+	}
+}
+
+func TestRegeneratePersonalSummary_DoesNotMutateSharedTaskOrSchedule(t *testing.T) {
+	db := setupPersonalRefineDB(t)
+	task, sched, _ := seedScheduledMultiPersonPersonalTask(t, db)
+
+	h := NewPersonalHandler(db, "", nil)
+	r := setupPersonalRefineRouter(h)
+
+	w := doPersonalRegenerateRequest(r, task.ID, "member_a", map[string]interface{}{
+		"topic": "private one-off personal topic",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var gotTask model.SummaryTask
+	if err := db.First(&gotTask, task.ID).Error; err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if gotTask.Title != task.Title {
+		t.Fatalf("personal regenerate must not mutate shared task title, got %q want %q", gotTask.Title, task.Title)
+	}
+	var gotSched model.SummarySchedule
+	if err := db.First(&gotSched, sched.ID).Error; err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+	if gotSched.GenerationInstruction != sched.GenerationInstruction {
+		t.Fatalf("personal regenerate must not mutate shared schedule instruction, got %q want %q", gotSched.GenerationInstruction, sched.GenerationInstruction)
+	}
+}

--- a/internal/api/handler/regenerate_test.go
+++ b/internal/api/handler/regenerate_test.go
@@ -157,17 +157,17 @@ func TestRegenerate_ResetsAllAssociatedData(t *testing.T) {
 	// Verify participant reset
 	var participant model.SummaryParticipant
 	db.First(&participant, participantID)
-	if participant.Status != model.ParticipantPending {
-		t.Errorf("participant status: want %d, got %d", model.ParticipantPending, participant.Status)
+	if participant.Status != model.ParticipantAccepted {
+		t.Errorf("participant status: want %d, got %d", model.ParticipantAccepted, participant.Status)
 	}
 	if participant.WorkerStartedAt != nil {
 		t.Error("participant worker_started_at should be nil")
 	}
-	if participant.ConfirmedAt != nil {
-		t.Error("participant confirmed_at should be nil")
+	if participant.ConfirmedAt == nil {
+		t.Error("participant confirmed_at should be kept for regenerate")
 	}
-	if participant.PersonalResultID != nil {
-		t.Error("participant personal_result_id should be nil")
+	if participant.PersonalResultID == nil || *participant.PersonalResultID != prID {
+		t.Errorf("participant personal_result_id should keep %d, got %v", prID, participant.PersonalResultID)
 	}
 
 	// Verify PersonalResult reset
@@ -178,6 +178,9 @@ func TestRegenerate_ResetsAllAssociatedData(t *testing.T) {
 	}
 	if pr.Content != "" {
 		t.Errorf("personal_result content: want empty, got %q", pr.Content)
+	}
+	if pr.SubmitSource != model.SubmitSourceSystem {
+		t.Errorf("personal_result submit_source: want system, got %d", pr.SubmitSource)
 	}
 	if pr.CitationsJSON != "" {
 		t.Errorf("personal_result citations_json: want empty, got %q", pr.CitationsJSON)
@@ -192,11 +195,11 @@ func TestRegenerate_ResetsAllAssociatedData(t *testing.T) {
 		t.Error("personal_result submitted_at should be nil")
 	}
 
-	// Verify SummaryResult deleted
+	// Verify SummaryResult retained as version history.
 	var resultCount int64
 	db.Model(&model.SummaryResult{}).Where("task_id = ?", taskID).Count(&resultCount)
-	if resultCount != 0 {
-		t.Errorf("summary_result count: want 0, got %d", resultCount)
+	if resultCount != 1 {
+		t.Errorf("summary_result count: want 1, got %d", resultCount)
 	}
 
 	// Verify SummaryChunk deleted
@@ -385,6 +388,84 @@ func TestRegenerate_TriggersWorker(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Error("triggerWorker was not called within 2s")
+	}
+}
+
+func TestRegenerate_MultiPersonDoesNotReinviteAndTriggersAllAccepted(t *testing.T) {
+	db := setupRegenerateDB(t)
+	imDB, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	imDB.Exec("CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0)")
+	imDB.Exec("INSERT INTO group_member (group_no, uid, is_deleted) VALUES ('grp_abc', 'creator1', 0), ('grp_abc', 'member2', 0)")
+
+	taskID, participantID, _ := seedCompletedTask(t, db)
+	now := time.Now().UTC()
+	member := model.SummaryParticipant{
+		TaskID:      taskID,
+		UserID:      "member2",
+		UserName:    "Member2",
+		Status:      model.ParticipantSubmitted,
+		ConfirmedAt: &now,
+	}
+	db.Create(&member)
+	memberPR := model.PersonalResult{
+		TaskID:           taskID,
+		ParticipantRefID: member.ID,
+		UserID:           "member2",
+		WorkerStatus:     model.PersonalStatusCompleted,
+		Content:          "old member content",
+		SubmittedAt:      &now,
+		GeneratedAt:      &now,
+	}
+	db.Create(&memberPR)
+	db.Model(&member).Update("personal_result_id", memberPR.ID)
+
+	triggered := make(chan model.WorkerTriggerRequest, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req model.WorkerTriggerRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		triggered <- req
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := NewTaskHandler(db, imDB, ts.URL)
+	r := setupRegenerateRouter(h)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/summaries/%d/regenerate", taskID), nil)
+	req.Header.Set("Token", "creator1")
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	gotIDs := map[int64]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-triggered:
+			if got.Type != "personal_summary" {
+				t.Errorf("trigger type: want personal_summary, got %s", got.Type)
+			}
+			gotIDs[got.ParticipantRefID] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected trigger %d", i+1)
+		}
+	}
+	if !gotIDs[participantID] || !gotIDs[member.ID] {
+		t.Fatalf("expected triggers for creator %d and member %d, got %v", participantID, member.ID, gotIDs)
+	}
+
+	var participants []model.SummaryParticipant
+	db.Where("task_id = ?", taskID).Order("id ASC").Find(&participants)
+	for _, p := range participants {
+		if p.Status != model.ParticipantAccepted {
+			t.Errorf("participant %s should stay accepted for regenerate, got %d", p.UserID, p.Status)
+		}
+		if p.ConfirmedAt == nil {
+			t.Errorf("participant %s confirmed_at should not be cleared", p.UserID)
+		}
 	}
 }
 

--- a/internal/api/handler/result_select.go
+++ b/internal/api/handler/result_select.go
@@ -5,17 +5,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// queryDisplayResult returns the result shown by the read paths (list/detail/
-// get). The display contract is "latest result wins": the highest version is
-// returned regardless of whether older rows were hand-edited. A scheduled run
-// (or a regenerate) inserts a strictly higher version, so its fresh output is
-// shown immediately; hand-edited rows are retained in the table as queryable
-// history but no longer mask a newer scheduled result.
-//
-// Rationale: an earlier ordering placed edited rows ahead of newer unedited
-// rows, which permanently hid every future scheduled result once the user had
-// edited any single result. version DESC is the single, unambiguous order.
+// queryDisplayResult returns the result shown by read paths. If a task has an
+// explicit current_result_id (for restoring an older version without creating a
+// new history row), that row wins. Older rows without the pointer fall back to
+// the newest version for backward compatibility and test fixtures.
 func queryDisplayResult(db *gorm.DB, taskID int64) (model.SummaryResult, error) {
+	var task model.SummaryTask
+	if err := db.Select("current_result_id").Where("id = ?", taskID).First(&task).Error; err == nil && task.CurrentResultID != nil {
+		var current model.SummaryResult
+		if err := db.Where("id = ? AND task_id = ?", *task.CurrentResultID, taskID).First(&current).Error; err == nil {
+			return current, nil
+		}
+	}
+
 	var result model.SummaryResult
 	err := db.
 		Where("task_id = ?", taskID).

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -40,16 +40,17 @@ func NewScheduleHandlerWithFlag(db *gorm.DB, featureTeamSchedule bool) *Schedule
 }
 
 type createScheduleReq struct {
-	Title          string           `json:"title"`
-	CronExpr       string           `json:"cron_expr"`
-	IntervalDays   int              `json:"interval_days"`
-	IntervalMonths int              `json:"interval_months"`
-	RunTime        string           `json:"run_time"`
-	DayOfWeek      int              `json:"day_of_week"`
-	DayOfMonth     int              `json:"day_of_month"`
-	TimeRangeType  int              `json:"time_range_type"`
-	Sources        []sourceReq      `json:"sources"`
-	Participants   []participantReq `json:"participants"`
+	Title                 string           `json:"title"`
+	GenerationInstruction string           `json:"generation_instruction"`
+	CronExpr              string           `json:"cron_expr"`
+	IntervalDays          int              `json:"interval_days"`
+	IntervalMonths        int              `json:"interval_months"`
+	RunTime               string           `json:"run_time"`
+	DayOfWeek             int              `json:"day_of_week"`
+	DayOfMonth            int              `json:"day_of_month"`
+	TimeRangeType         int              `json:"time_range_type"`
+	Sources               []sourceReq      `json:"sources"`
+	Participants          []participantReq `json:"participants"`
 	// ConfirmPolicy: 0=AUTO (no confirm), 1=CONFIRM (V5 one-time schedule-level
 	// confirm). Pointer so "not sent" is distinguishable from an explicit 0; the
 	// handler defaults multi-person schedules to CONFIRM. confirm_lead_minutes is
@@ -60,19 +61,20 @@ type createScheduleReq struct {
 }
 
 type updateScheduleReq struct {
-	Title          *string          `json:"title"`
-	CronExpr       *string          `json:"cron_expr"`
-	IntervalDays   *int             `json:"interval_days"`
-	IntervalMonths *int             `json:"interval_months"`
-	RunTime        *string          `json:"run_time"`
-	DayOfWeek      *int             `json:"day_of_week"`
-	DayOfMonth     *int             `json:"day_of_month"`
-	TimeRangeType  *int             `json:"time_range_type"`
-	Sources        []sourceReq      `json:"sources,omitempty"`
-	Participants   []participantReq `json:"participants,omitempty"`
-	ConfirmPolicy  *int             `json:"confirm_policy"`
-	Scope          string           `json:"scope,omitempty"`
-	TaskID         *int64           `json:"task_id,omitempty"`
+	Title                 *string          `json:"title"`
+	GenerationInstruction *string          `json:"generation_instruction"`
+	CronExpr              *string          `json:"cron_expr"`
+	IntervalDays          *int             `json:"interval_days"`
+	IntervalMonths        *int             `json:"interval_months"`
+	RunTime               *string          `json:"run_time"`
+	DayOfWeek             *int             `json:"day_of_week"`
+	DayOfMonth            *int             `json:"day_of_month"`
+	TimeRangeType         *int             `json:"time_range_type"`
+	Sources               []sourceReq      `json:"sources,omitempty"`
+	Participants          []participantReq `json:"participants,omitempty"`
+	ConfirmPolicy         *int             `json:"confirm_policy"`
+	Scope                 string           `json:"scope,omitempty"`
+	TaskID                *int64           `json:"task_id,omitempty"`
 }
 
 type toggleScheduleReq struct {
@@ -497,6 +499,15 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 1000 字符"})
 		return
 	}
+	generationInstruction, err := normalizeScheduleGenerationInstruction(req.GenerationInstruction)
+	if err != nil {
+		if biz, ok := err.(*service.BizError); ok {
+			bizErr(c, biz)
+			return
+		}
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: err.Error()})
+		return
+	}
 
 	// Multi-person guard needs task.CreatorID, so the participant check runs in the
 	// transaction after loadTaskForTaskScope locks the task.
@@ -560,20 +571,21 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 	}
 
 	sched := model.SummarySchedule{
-		SpaceID:           spaceID,
-		CreatorID:         userID,
-		Title:             req.Title,
-		SummaryMode:       summaryMode,
-		CronExpr:          req.CronExpr,
-		IntervalDays:      req.IntervalDays,
-		IntervalMonths:    req.IntervalMonths,
-		RunTime:           req.RunTime,
-		DayOfWeek:         req.DayOfWeek,
-		DayOfMonth:        req.DayOfMonth,
-		TimeRangeType:     req.TimeRangeType,
-		SourceConfig:      sourceConfig,
-		ParticipantConfig: participantConfig,
-		ConfirmPolicy:     confirmPolicy,
+		SpaceID:               spaceID,
+		CreatorID:             userID,
+		Title:                 req.Title,
+		GenerationInstruction: generationInstruction,
+		SummaryMode:           summaryMode,
+		CronExpr:              req.CronExpr,
+		IntervalDays:          req.IntervalDays,
+		IntervalMonths:        req.IntervalMonths,
+		RunTime:               req.RunTime,
+		DayOfWeek:             req.DayOfWeek,
+		DayOfMonth:            req.DayOfMonth,
+		TimeRangeType:         req.TimeRangeType,
+		SourceConfig:          sourceConfig,
+		ParticipantConfig:     participantConfig,
+		ConfirmPolicy:         confirmPolicy,
 	}
 
 	if req.Scope != "task" {
@@ -687,19 +699,20 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 			// Reuse the (possibly inactive) schedule and re-activate it so the
 			// scheduler picks it up; first-run semantics via nextRun.
 			updates := map[string]interface{}{
-				"title":              sched.Title,
-				"cron_expr":          sched.CronExpr,
-				"interval_days":      sched.IntervalDays,
-				"interval_months":    sched.IntervalMonths,
-				"run_time":           sched.RunTime,
-				"day_of_week":        sched.DayOfWeek,
-				"day_of_month":       sched.DayOfMonth,
-				"time_range_type":    sched.TimeRangeType,
-				"source_config":      sched.SourceConfig,
-				"participant_config": sched.ParticipantConfig,
-				"confirm_policy":     sched.ConfirmPolicy,
-				"next_run_at":        nextRun,
-				"is_active":          1,
+				"title":                  sched.Title,
+				"generation_instruction": sched.GenerationInstruction,
+				"cron_expr":              sched.CronExpr,
+				"interval_days":          sched.IntervalDays,
+				"interval_months":        sched.IntervalMonths,
+				"run_time":               sched.RunTime,
+				"day_of_week":            sched.DayOfWeek,
+				"day_of_month":           sched.DayOfMonth,
+				"time_range_type":        sched.TimeRangeType,
+				"source_config":          sched.SourceConfig,
+				"participant_config":     sched.ParticipantConfig,
+				"confirm_policy":         sched.ConfirmPolicy,
+				"next_run_at":            nextRun,
+				"is_active":              1,
 			}
 			if sched.IntervalMonths > 0 {
 				updates["anchor_dom"] = finalAnchorDOM
@@ -803,21 +816,22 @@ func (h *ScheduleHandler) ListSchedules(c *gin.Context) {
 	items := make([]gin.H, 0, len(schedules))
 	for _, s := range schedules {
 		item := gin.H{
-			"schedule_id":        s.ID,
-			"title":              s.Title,
-			"summary_mode":       s.SummaryMode,
-			"cron_expr":          s.CronExpr,
-			"interval_days":      s.IntervalDays,
-			"interval_months":    s.IntervalMonths,
-			"run_time":           s.RunTime,
-			"day_of_week":        s.DayOfWeek,
-			"day_of_month":       s.DayOfMonth,
-			"time_range_type":    s.TimeRangeType,
-			"source_config":      s.SourceConfig,
-			"participant_config": s.ParticipantConfig,
-			"confirm_policy":     s.ConfirmPolicy,
-			"is_active":          s.IsActive,
-			"created_at":         s.CreatedAt.Format(time.RFC3339),
+			"schedule_id":            s.ID,
+			"title":                  s.Title,
+			"generation_instruction": s.GenerationInstruction,
+			"summary_mode":           s.SummaryMode,
+			"cron_expr":              s.CronExpr,
+			"interval_days":          s.IntervalDays,
+			"interval_months":        s.IntervalMonths,
+			"run_time":               s.RunTime,
+			"day_of_week":            s.DayOfWeek,
+			"day_of_month":           s.DayOfMonth,
+			"time_range_type":        s.TimeRangeType,
+			"source_config":          s.SourceConfig,
+			"participant_config":     s.ParticipantConfig,
+			"confirm_policy":         s.ConfirmPolicy,
+			"is_active":              s.IsActive,
+			"created_at":             s.CreatedAt.Format(time.RFC3339),
 		}
 		if s.LastRunAt != nil {
 			item["last_run_at"] = s.LastRunAt.Format(time.RFC3339)
@@ -855,21 +869,22 @@ func (h *ScheduleHandler) GetSchedule(c *gin.Context) {
 	}
 
 	item := gin.H{
-		"schedule_id":        sched.ID,
-		"title":              sched.Title,
-		"summary_mode":       sched.SummaryMode,
-		"cron_expr":          sched.CronExpr,
-		"interval_days":      sched.IntervalDays,
-		"interval_months":    sched.IntervalMonths,
-		"run_time":           sched.RunTime,
-		"day_of_week":        sched.DayOfWeek,
-		"day_of_month":       sched.DayOfMonth,
-		"time_range_type":    sched.TimeRangeType,
-		"source_config":      sched.SourceConfig,
-		"participant_config": sched.ParticipantConfig,
-		"confirm_policy":     sched.ConfirmPolicy,
-		"is_active":          sched.IsActive,
-		"created_at":         sched.CreatedAt.Format(time.RFC3339),
+		"schedule_id":            sched.ID,
+		"title":                  sched.Title,
+		"generation_instruction": sched.GenerationInstruction,
+		"summary_mode":           sched.SummaryMode,
+		"cron_expr":              sched.CronExpr,
+		"interval_days":          sched.IntervalDays,
+		"interval_months":        sched.IntervalMonths,
+		"run_time":               sched.RunTime,
+		"day_of_week":            sched.DayOfWeek,
+		"day_of_month":           sched.DayOfMonth,
+		"time_range_type":        sched.TimeRangeType,
+		"source_config":          sched.SourceConfig,
+		"participant_config":     sched.ParticipantConfig,
+		"confirm_policy":         sched.ConfirmPolicy,
+		"is_active":              sched.IsActive,
+		"created_at":             sched.CreatedAt.Format(time.RFC3339),
 	}
 	if sched.LastRunAt != nil {
 		item["last_run_at"] = sched.LastRunAt.Format(time.RFC3339)
@@ -998,6 +1013,18 @@ func (h *ScheduleHandler) UpdateSchedule(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 1000 字符"})
 		return
 	}
+	if req.GenerationInstruction != nil {
+		generationInstruction, err := normalizeScheduleGenerationInstruction(*req.GenerationInstruction)
+		if err != nil {
+			if biz, ok := err.(*service.BizError); ok {
+				bizErr(c, biz)
+				return
+			}
+			c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: err.Error()})
+			return
+		}
+		req.GenerationInstruction = &generationInstruction
+	}
 	// Fail-closed multi-person guard on update; only when participants are sent
 	// (nil = leave untouched). Stored-config bind path is checked later in the tx.
 	// Bypassed when team schedules are enabled.
@@ -1013,6 +1040,9 @@ func (h *ScheduleHandler) UpdateSchedule(c *gin.Context) {
 	updates := make(map[string]interface{})
 	if req.Title != nil {
 		updates["title"] = *req.Title
+	}
+	if req.GenerationInstruction != nil {
+		updates["generation_instruction"] = *req.GenerationInstruction
 	}
 
 	// Determine effective cron/interval after this update to recompute next_run_at

--- a/internal/api/handler/schedule_instruction.go
+++ b/internal/api/handler/schedule_instruction.go
@@ -61,11 +61,7 @@ func resetBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTask
 	if err != nil {
 		return err
 	}
-	updates := map[string]interface{}{"generation_instruction": next}
-	if next != "" {
-		updates["title"] = next
-	}
 	return tx.Model(&model.SummarySchedule{}).
 		Where("id = ? AND space_id = ? AND deleted_at IS NULL", *task.ScheduleID, task.SpaceID).
-		Updates(updates).Error
+		Update("generation_instruction", next).Error
 }

--- a/internal/api/handler/schedule_instruction.go
+++ b/internal/api/handler/schedule_instruction.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const maxScheduleInstructionRunes = 8000
+
+func normalizeScheduleGenerationInstruction(v string) (string, error) {
+	out := strings.TrimSpace(v)
+	if utf8.RuneCountInString(out) > maxScheduleInstructionRunes {
+		return "", service.NewBizError(40010, "定时生成要求不能超过 8000 字符", http.StatusBadRequest)
+	}
+	return out, nil
+}
+
+func appendBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTask, feedback string) error {
+	if task.ScheduleID == nil {
+		return nil
+	}
+	addition := strings.TrimSpace(feedback)
+	if addition == "" {
+		return nil
+	}
+	var sched model.SummarySchedule
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ? AND space_id = ? AND deleted_at IS NULL", *task.ScheduleID, task.SpaceID).
+		First(&sched).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return err
+	}
+	current := strings.TrimSpace(sched.GenerationInstruction)
+	next := addition
+	if current != "" {
+		next = current + "\n" + addition
+	}
+	next = keepLatestRunes(next, maxScheduleInstructionRunes)
+	return tx.Model(&model.SummarySchedule{}).
+		Where("id = ?", sched.ID).
+		Update("generation_instruction", next).Error
+}
+
+func keepLatestRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return strings.TrimSpace(string(runes[len(runes)-maxRunes:]))
+}
+
+func resetBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTask, instruction string) error {
+	if task.ScheduleID == nil {
+		return nil
+	}
+	next, err := normalizeScheduleGenerationInstruction(instruction)
+	if err != nil {
+		return err
+	}
+	return tx.Model(&model.SummarySchedule{}).
+		Where("id = ? AND space_id = ? AND deleted_at IS NULL", *task.ScheduleID, task.SpaceID).
+		Update("generation_instruction", next).Error
+}

--- a/internal/api/handler/schedule_instruction.go
+++ b/internal/api/handler/schedule_instruction.go
@@ -45,12 +45,21 @@ func appendBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTas
 	if current != "" {
 		next = current + "\n" + addition
 	}
-	if utf8.RuneCountInString(next) > maxScheduleInstructionRunes {
-		return service.NewBizError(40010, "定时生成要求不能超过 8000 字符", http.StatusBadRequest)
-	}
+	next = keepLatestRunes(next, maxScheduleInstructionRunes)
 	return tx.Model(&model.SummarySchedule{}).
 		Where("id = ?", sched.ID).
 		Update("generation_instruction", next).Error
+}
+
+func keepLatestRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return strings.TrimSpace(string(runes[len(runes)-maxRunes:]))
 }
 
 func resetBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTask, instruction string) error {

--- a/internal/api/handler/schedule_instruction.go
+++ b/internal/api/handler/schedule_instruction.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const maxScheduleInstructionRunes = 8000
+
+func normalizeScheduleGenerationInstruction(v string) (string, error) {
+	out := strings.TrimSpace(v)
+	if utf8.RuneCountInString(out) > maxScheduleInstructionRunes {
+		return "", service.NewBizError(40010, "定时生成要求不能超过 8000 字符", http.StatusBadRequest)
+	}
+	return out, nil
+}
+
+func appendBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTask, feedback string) error {
+	if task.ScheduleID == nil {
+		return nil
+	}
+	addition := strings.TrimSpace(feedback)
+	if addition == "" {
+		return nil
+	}
+	var sched model.SummarySchedule
+	err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ? AND space_id = ? AND deleted_at IS NULL", *task.ScheduleID, task.SpaceID).
+		First(&sched).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return err
+	}
+	current := strings.TrimSpace(sched.GenerationInstruction)
+	next := addition
+	if current != "" {
+		next = current + "\n" + addition
+	}
+	if utf8.RuneCountInString(next) > maxScheduleInstructionRunes {
+		return service.NewBizError(40010, "定时生成要求不能超过 8000 字符", http.StatusBadRequest)
+	}
+	return tx.Model(&model.SummarySchedule{}).
+		Where("id = ?", sched.ID).
+		Update("generation_instruction", next).Error
+}
+
+func resetBoundScheduleGenerationInstruction(tx *gorm.DB, task model.SummaryTask, instruction string) error {
+	if task.ScheduleID == nil {
+		return nil
+	}
+	next, err := normalizeScheduleGenerationInstruction(instruction)
+	if err != nil {
+		return err
+	}
+	updates := map[string]interface{}{"generation_instruction": next}
+	if next != "" {
+		updates["title"] = next
+	}
+	return tx.Model(&model.SummarySchedule{}).
+		Where("id = ? AND space_id = ? AND deleted_at IS NULL", *task.ScheduleID, task.SpaceID).
+		Updates(updates).Error
+}

--- a/internal/api/handler/schedule_instruction_test.go
+++ b/internal/api/handler/schedule_instruction_test.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKeepLatestRunesKeepsRecentInstruction(t *testing.T) {
+	old := strings.Repeat("旧", maxScheduleInstructionRunes)
+	latest := "最新修改意见"
+	got := keepLatestRunes(old+"\n"+latest, maxScheduleInstructionRunes)
+	if len([]rune(got)) > maxScheduleInstructionRunes {
+		t.Fatalf("got %d runes, want <= %d", len([]rune(got)), maxScheduleInstructionRunes)
+	}
+	if !strings.Contains(got, latest) {
+		t.Fatalf("latest instruction should be retained, got suffix %q", got[len(got)-len(latest):])
+	}
+}

--- a/internal/api/handler/stream.go
+++ b/internal/api/handler/stream.go
@@ -1,0 +1,167 @@
+package handler
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+const sseHeartbeatInterval = 5 * time.Second
+
+type StreamHandler struct {
+	db  *gorm.DB
+	hub *streaming.Hub
+}
+
+func NewStreamHandler(db *gorm.DB, hub *streaming.Hub) *StreamHandler {
+	return &StreamHandler{db: db, hub: hub}
+}
+
+// Ingest handles POST /internal/summary-stream. It reads worker-produced NDJSON
+// over a single chunked request and publishes events to the in-memory SSE hub.
+func (h *StreamHandler) Ingest(c *gin.Context) {
+	if h == nil || h.hub == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "summary stream hub not configured"})
+		return
+	}
+	defer c.Request.Body.Close()
+
+	scanner := bufio.NewScanner(c.Request.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev streaming.Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			log.Printf("[summary-stream] invalid event: %v", err)
+			continue
+		}
+		h.hub.Publish(ev)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("[summary-stream] ingest read error: %v", err)
+	}
+	c.JSON(http.StatusOK, gin.H{"code": 0, "message": "ok"})
+}
+
+// StreamSummary handles GET /api/v1/summaries/:id/stream.
+func (h *StreamHandler) StreamSummary(c *gin.Context) {
+	if h == nil || h.hub == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "summary stream hub not configured"})
+		return
+	}
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || taskID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid task id"})
+		return
+	}
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "missing auth context"})
+		return
+	}
+	if !h.canAccessTask(taskID, spaceID, userID) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "task not found"})
+		return
+	}
+
+	scope := streaming.NormalizeScope(c.DefaultQuery("scope", streaming.ScopePersonal))
+	targetUserID := userID
+	if scope == streaming.ScopeTeam {
+		// Team summary is task-level rather than user-level: all authorized
+		// participants subscribe to the same stream key.
+		targetUserID = ""
+	}
+
+	w := c.Writer
+	// Keep SSE alive even if a future http.Server WriteTimeout is configured.
+	// Streaming endpoints must not inherit finite write deadlines.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	w.Flush()
+
+	ch, snapshot, done, cancel := h.hub.Subscribe(taskID, scope, targetUserID)
+	defer cancel()
+
+	if snapshot != "" {
+		_ = writeSSE(w, streaming.EventSnapshot, streaming.Event{Type: streaming.EventSnapshot, TaskID: taskID, Scope: scope, Content: snapshot})
+		w.Flush()
+	}
+	if done {
+		_ = writeSSE(w, streaming.EventDone, streaming.Event{Type: streaming.EventDone, TaskID: taskID, Scope: scope, Content: snapshot})
+		w.Flush()
+		return
+	}
+
+	ticker := time.NewTicker(sseHeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case <-ticker.C:
+			_, _ = fmt.Fprint(w, ": ping\n\n")
+			w.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := writeSSE(w, ev.Type, ev); err != nil {
+				return
+			}
+			w.Flush()
+			if ev.Type == streaming.EventDone || ev.Type == streaming.EventError {
+				return
+			}
+		}
+	}
+}
+
+func (h *StreamHandler) canAccessTask(taskID int64, spaceID, userID string) bool {
+	if h == nil || h.db == nil {
+		return false
+	}
+	var count int64
+	err := h.db.Raw(`
+SELECT COUNT(1)
+FROM summary_task t
+WHERE t.id = ?
+  AND t.space_id = ?
+  AND t.deleted_at IS NULL
+  AND (
+    t.creator_id = ?
+    OR EXISTS (
+      SELECT 1 FROM summary_participant p
+      WHERE p.task_id = t.id AND p.user_id = ?
+    )
+  )
+`, taskID, spaceID, userID, userID).Scan(&count).Error
+	return err == nil && count > 0
+}
+
+func writeSSE(w http.ResponseWriter, event string, data interface{}) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, b)
+	return err
+}

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -691,6 +691,9 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 			"total_token_used": latestResult.TotalTokenUsed,
 			"model_version":    latestResult.ModelVersion,
 			"version":          latestResult.Version,
+			"operation_type":   latestResult.OperationType,
+			"operation_note":   latestResult.OperationNote,
+			"parent_result_id": latestResult.ParentResultID,
 			"generated_at":     latestResult.GeneratedAt.Format(time.RFC3339),
 		}
 	}
@@ -884,6 +887,9 @@ func (h *TaskHandler) GetResult(c *gin.Context) {
 		"total_token_used": result.TotalTokenUsed,
 		"model_version":    result.ModelVersion,
 		"version":          result.Version,
+		"operation_type":   result.OperationType,
+		"operation_note":   result.OperationNote,
+		"parent_result_id": result.ParentResultID,
 		"generated_at":     result.GeneratedAt.Format(time.RFC3339),
 		"result_is_edited": result.EditedAt != nil,
 		"result_edited_at": func() interface{} {
@@ -944,6 +950,7 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 	}
 
 	nextVer, _ := service.GetNextVersion(h.db, taskID)
+	now := timezone.Now()
 
 	err = h.db.Transaction(func(tx *gorm.DB) error {
 		// Atomic status transition: only proceed if the task is still in a
@@ -967,30 +974,43 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 			return service.NewBizError(40005, "任务已在处理中，请稍后再试", http.StatusConflict)
 		}
 
-		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryResult{}).Error; err != nil {
-			return err
-		}
+		// Keep previous summary_result rows as lightweight version history.
+		// Chunks are intermediate pipeline data and are still cleared before rerun.
 		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryChunk{}).Error; err != nil {
 			return err
 		}
-		if err := tx.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Updates(map[string]interface{}{
-			"status":             model.ParticipantPending,
-			"worker_started_at":  nil,
-			"confirmed_at":       nil,
-			"personal_result_id": nil,
-		}).Error; err != nil {
+		// Regenerate is not a new invitation round. Participants who were already
+		// in the accepted roster keep that consent and are re-armed directly;
+		// pending/declined invitees stay out of this round.
+		acceptedParticipantIDs := tx.Model(&model.SummaryParticipant{}).
+			Select("id").
+			Where("task_id = ? AND status NOT IN ?", taskID, []int{model.ParticipantPending, model.ParticipantDeclined})
+		if err := tx.Model(&model.SummaryParticipant{}).
+			Where("task_id = ? AND status NOT IN ?", taskID, []int{model.ParticipantPending, model.ParticipantDeclined}).
+			Updates(map[string]interface{}{
+				"status":            model.ParticipantAccepted,
+				"worker_started_at": nil,
+				"confirmed_at":      now,
+			}).Error; err != nil {
 			return err
 		}
-		if err := tx.Model(&model.PersonalResult{}).Where("task_id = ?", taskID).Updates(map[string]interface{}{
-			"worker_status":  model.PersonalStatusPending,
-			"workflow_stage": "",
-			"content":        "",
-			"citations_json": "",
-			"error_message":  nil,
-			"submitted_at":   nil,
-			"generated_at":   nil,
-			"edited_at":      nil,
-		}).Error; err != nil {
+		if err := tx.Model(&model.PersonalResult{}).
+			Where("task_id = ? AND participant_ref_id IN (?)", taskID, acceptedParticipantIDs).
+			Updates(map[string]interface{}{
+				"worker_status":      model.PersonalStatusPending,
+				"workflow_stage":     "",
+				"content":            "",
+				"citations_json":     "",
+				"msg_count":          0,
+				"total_token_used":   0,
+				"model_version":      "",
+				"current_version_id": nil,
+				"error_message":      nil,
+				"submitted_at":       nil,
+				"submit_source":      model.SubmitSourceSystem,
+				"generated_at":       nil,
+				"edited_at":          nil,
+			}).Error; err != nil {
 			return err
 		}
 		// Regenerate must re-arm notification delivery: clear all prior rows so
@@ -1011,13 +1031,20 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		return
 	}
 
-	var creatorParticipant model.SummaryParticipant
-	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, task.CreatorID).First(&creatorParticipant).Error; err == nil {
-		go h.triggerWorker(model.WorkerTriggerRequest{
-			Type:             "personal_summary",
-			TaskID:           taskID,
-			ParticipantRefID: creatorParticipant.ID,
-		})
+	var triggerParticipants []model.SummaryParticipant
+	triggerQuery := h.db.Where("task_id = ? AND status NOT IN (?, ?)", taskID, model.ParticipantPending, model.ParticipantDeclined)
+	if task.SummaryMode != model.ModeByPerson {
+		triggerQuery = triggerQuery.Where("user_id = ?", task.CreatorID)
+	}
+	if err := triggerQuery.Find(&triggerParticipants).Error; err == nil {
+		for _, participant := range triggerParticipants {
+			ptID := participant.ID
+			go h.triggerWorker(model.WorkerTriggerRequest{
+				Type:             "personal_summary",
+				TaskID:           taskID,
+				ParticipantRefID: ptID,
+			})
+		}
 	}
 
 	ok(c, gin.H{

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -691,6 +691,9 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 			"total_token_used": latestResult.TotalTokenUsed,
 			"model_version":    latestResult.ModelVersion,
 			"version":          latestResult.Version,
+			"operation_type":   latestResult.OperationType,
+			"operation_note":   latestResult.OperationNote,
+			"parent_result_id": latestResult.ParentResultID,
 			"generated_at":     latestResult.GeneratedAt.Format(time.RFC3339),
 		}
 	}
@@ -884,6 +887,9 @@ func (h *TaskHandler) GetResult(c *gin.Context) {
 		"total_token_used": result.TotalTokenUsed,
 		"model_version":    result.ModelVersion,
 		"version":          result.Version,
+		"operation_type":   result.OperationType,
+		"operation_note":   result.OperationNote,
+		"parent_result_id": result.ParentResultID,
 		"generated_at":     result.GeneratedAt.Format(time.RFC3339),
 		"result_is_edited": result.EditedAt != nil,
 		"result_edited_at": func() interface{} {
@@ -944,6 +950,7 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 	}
 
 	nextVer, _ := service.GetNextVersion(h.db, taskID)
+	now := timezone.Now()
 
 	err = h.db.Transaction(func(tx *gorm.DB) error {
 		// Atomic status transition: only proceed if the task is still in a
@@ -967,36 +974,54 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 			return service.NewBizError(40005, "任务已在处理中，请稍后再试", http.StatusConflict)
 		}
 
-		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryResult{}).Error; err != nil {
-			return err
-		}
+		// Keep previous summary_result rows as lightweight version history.
+		// Chunks are intermediate pipeline data and are still cleared before rerun.
 		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryChunk{}).Error; err != nil {
 			return err
 		}
-		if err := tx.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Updates(map[string]interface{}{
-			"status":             model.ParticipantPending,
-			"worker_started_at":  nil,
-			"confirmed_at":       nil,
-			"personal_result_id": nil,
-		}).Error; err != nil {
+		// Regenerate is not a new invitation round. Participants who were already
+		// in the accepted roster keep that consent and are re-armed directly;
+		// pending/declined invitees stay out of this round.
+		acceptedParticipantIDs := tx.Model(&model.SummaryParticipant{}).
+			Select("id").
+			Where("task_id = ? AND status NOT IN ?", taskID, []int{model.ParticipantPending, model.ParticipantDeclined})
+		if err := tx.Model(&model.SummaryParticipant{}).
+			Where("task_id = ? AND status NOT IN ?", taskID, []int{model.ParticipantPending, model.ParticipantDeclined}).
+			Updates(map[string]interface{}{
+				"status":            model.ParticipantAccepted,
+				"worker_started_at": nil,
+				"confirmed_at":      now,
+			}).Error; err != nil {
 			return err
 		}
-		if err := tx.Model(&model.PersonalResult{}).Where("task_id = ?", taskID).Updates(map[string]interface{}{
-			"worker_status":  model.PersonalStatusPending,
-			"workflow_stage": "",
-			"content":        "",
-			"citations_json": "",
-			"error_message":  nil,
-			"submitted_at":   nil,
-			"generated_at":   nil,
-			"edited_at":      nil,
-		}).Error; err != nil {
+		if err := tx.Model(&model.PersonalResult{}).
+			Where("task_id = ? AND participant_ref_id IN (?)", taskID, acceptedParticipantIDs).
+			Updates(map[string]interface{}{
+				"worker_status":      model.PersonalStatusPending,
+				"workflow_stage":     "",
+				"content":            "",
+				"citations_json":     "",
+				"msg_count":          0,
+				"total_token_used":   0,
+				"model_version":      "",
+				"current_version_id": nil,
+				"error_message":      nil,
+				"submitted_at":       nil,
+				"submit_source":      model.SubmitSourceSystem,
+				"generated_at":       nil,
+				"edited_at":          nil,
+			}).Error; err != nil {
 			return err
 		}
 		// Regenerate must re-arm notification delivery: clear all prior rows so
 		// OnTaskTerminal re-claims fresh instead of hitting sent/failed dedup rows.
 		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryNotification{}).Error; err != nil {
 			return err
+		}
+		if topic != "" {
+			if err := resetBoundScheduleGenerationInstruction(tx, task, topic); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -1011,13 +1036,20 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		return
 	}
 
-	var creatorParticipant model.SummaryParticipant
-	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, task.CreatorID).First(&creatorParticipant).Error; err == nil {
-		go h.triggerWorker(model.WorkerTriggerRequest{
-			Type:             "personal_summary",
-			TaskID:           taskID,
-			ParticipantRefID: creatorParticipant.ID,
-		})
+	var triggerParticipants []model.SummaryParticipant
+	triggerQuery := h.db.Where("task_id = ? AND status NOT IN (?, ?)", taskID, model.ParticipantPending, model.ParticipantDeclined)
+	if task.SummaryMode != model.ModeByPerson {
+		triggerQuery = triggerQuery.Where("user_id = ?", task.CreatorID)
+	}
+	if err := triggerQuery.Find(&triggerParticipants).Error; err == nil {
+		for _, participant := range triggerParticipants {
+			ptID := participant.ID
+			go h.triggerWorker(model.WorkerTriggerRequest{
+				Type:             "personal_summary",
+				TaskID:           taskID,
+				ParticipantRefID: ptID,
+			})
+		}
 	}
 
 	ok(c, gin.H{

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -1018,6 +1018,11 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryNotification{}).Error; err != nil {
 			return err
 		}
+		if topic != "" {
+			if err := resetBoundScheduleGenerationInstruction(tx, task, topic); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -6,12 +6,13 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/handler"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
 // SetupPublic configures the public API router on :8080.
-func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int) *gin.Engine {
+func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int, llm ...*service.LLMClient) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -40,7 +41,12 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	taskH.SetCustomTemplateLimit(customTemplateLimit)
 	schedH := handler.NewScheduleHandlerWithFlag(db, featureTeamSchedule)
 	personalH := handler.NewPersonalHandler(db, workerTriggerURL, hub)
-	editH := handler.NewEditHandler(db)
+	var refineLLM *service.LLMClient
+	if len(llm) > 0 {
+		refineLLM = llm[0]
+	}
+	editH := handler.NewEditHandler(db, refineLLM)
+	personalH.SetLLM(refineLLM)
 
 	v1 := r.Group("/api/v1")
 	v1.Use(middleware.StrictAuthMiddleware(authResolver), middleware.StrictSpaceMiddleware())
@@ -51,6 +57,15 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.GET("/summaries/:id", taskH.GetSummary)
 		v1.GET("/summaries/:id/result", taskH.GetResult)
 		v1.POST("/summaries/:id/regenerate", taskH.Regenerate)
+		v1.POST("/summaries/:id/refine", editH.RefineSummary)
+		v1.GET("/summaries/:id/versions", editH.ListSummaryVersions)
+		v1.GET("/summaries/:id/versions/:result_id", editH.GetSummaryVersion)
+		v1.POST("/summaries/:id/versions/:result_id/restore", editH.RestoreSummaryVersion)
+		v1.POST("/summaries/:id/personal-refine", personalH.RefinePersonalSummary)
+		v1.POST("/summaries/:id/personal-regenerate", personalH.RegeneratePersonalSummary)
+		v1.GET("/summaries/:id/personal-versions", personalH.ListPersonalVersions)
+		v1.GET("/summaries/:id/personal-versions/:version_id", personalH.GetPersonalVersion)
+		v1.POST("/summaries/:id/personal-versions/:version_id/restore", personalH.RestorePersonalVersion)
 		v1.PUT("/summaries/:id/edit", editH.EditSummary)
 		// need3/need6: a participant edits their OWN personal report -> triggers team recompute.
 		v1.PUT("/summaries/:id/personal-edit", personalH.PersonalEdit)

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
 // SetupPublic configures the public API router on :8080.
-func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int, llm ...*service.LLMClient) *gin.Engine {
+func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int, streamHub *streaming.Hub, llm ...*service.LLMClient) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -20,7 +21,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	r.Use(func(c *gin.Context) {
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id")
+		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id,Accept,Accept-Language")
 		if c.Request.Method == http.MethodOptions {
 			c.AbortWithStatus(http.StatusNoContent)
 			return
@@ -47,6 +48,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	}
 	editH := handler.NewEditHandler(db, refineLLM)
 	personalH.SetLLM(refineLLM)
+	streamH := handler.NewStreamHandler(db, streamHub)
 
 	v1 := r.Group("/api/v1")
 	v1.Use(middleware.StrictAuthMiddleware(authResolver), middleware.StrictSpaceMiddleware())
@@ -55,13 +57,16 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.POST("/summaries/batch-status", taskH.BatchStatus)
 		v1.GET("/summaries", taskH.ListSummaries)
 		v1.GET("/summaries/:id", taskH.GetSummary)
+		v1.GET("/summaries/:id/stream", streamH.StreamSummary)
 		v1.GET("/summaries/:id/result", taskH.GetResult)
 		v1.POST("/summaries/:id/regenerate", taskH.Regenerate)
 		v1.POST("/summaries/:id/refine", editH.RefineSummary)
+		v1.POST("/summaries/:id/refine/stream", editH.RefineSummaryStream)
 		v1.GET("/summaries/:id/versions", editH.ListSummaryVersions)
 		v1.GET("/summaries/:id/versions/:result_id", editH.GetSummaryVersion)
 		v1.POST("/summaries/:id/versions/:result_id/restore", editH.RestoreSummaryVersion)
 		v1.POST("/summaries/:id/personal-refine", personalH.RefinePersonalSummary)
+		v1.POST("/summaries/:id/personal-refine/stream", personalH.RefinePersonalSummaryStream)
 		v1.POST("/summaries/:id/personal-regenerate", personalH.RegeneratePersonalSummary)
 		v1.GET("/summaries/:id/personal-versions", personalH.ListPersonalVersions)
 		v1.GET("/summaries/:id/personal-versions/:version_id", personalH.GetPersonalVersion)
@@ -124,7 +129,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 
 // SetupInternal configures the internal API router on :8081.
 // Returns the engine and the InternalHandler so the caller can wire the worker trigger channel.
-func SetupInternal(hub *ws.Hub) (*gin.Engine, *handler.InternalHandler) {
+func SetupInternal(hub *ws.Hub, streamHub ...*streaming.Hub) (*gin.Engine, *handler.InternalHandler) {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -134,6 +139,10 @@ func SetupInternal(hub *ws.Hub) (*gin.Engine, *handler.InternalHandler) {
 	})
 	r.POST("/internal/task-event", intH.TaskEvent)
 	r.POST("/internal/worker-trigger", intH.WorkerTrigger)
+	if len(streamHub) > 0 && streamHub[0] != nil {
+		streamH := handler.NewStreamHandler(nil, streamHub[0])
+		r.POST("/internal/summary-stream", streamH.Ingest)
+	}
 
 	return r, intH
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -125,6 +125,7 @@ type SummaryTask struct {
 	RetryCount         int        `gorm:"column:retry_count;type:tinyint;not null;default:0" json:"retry_count"`
 	ErrorMessage       *string    `gorm:"column:error_message;type:varchar(500)" json:"error_message"`
 	ScheduleID         *int64     `gorm:"column:schedule_id" json:"schedule_id"`
+	CurrentResultID    *int64     `gorm:"column:current_result_id" json:"current_result_id"`
 	OriginChannelID    string     `gorm:"column:origin_channel_id;type:varchar(64);not null;default:'';index:idx_origin_channel" json:"origin_channel_id"`
 	OriginChannelType  int        `gorm:"column:origin_channel_type;type:tinyint;not null;default:0" json:"origin_channel_type"`
 	ProcessingDeadline *time.Time `gorm:"column:processing_deadline" json:"processing_deadline"`
@@ -234,6 +235,10 @@ type SummaryResult struct {
 	TotalTokenUsed    int        `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
 	ModelVersion      string     `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
 	Version           int        `gorm:"column:version;not null;default:1" json:"version"`
+	OperationType     string     `gorm:"column:operation_type;type:varchar(32);not null;default:'generate'" json:"operation_type"`
+	OperationNote     string     `gorm:"column:operation_note;type:text" json:"operation_note"`
+	ParentResultID    *int64     `gorm:"column:parent_result_id" json:"parent_result_id,omitempty"`
+	CreatedBy         string     `gorm:"column:created_by;type:varchar(64);not null;default:''" json:"created_by"`
 	EditedAt          *time.Time `gorm:"column:edited_at" json:"edited_at"`
 	GeneratedAt       time.Time  `gorm:"column:generated_at;not null" json:"generated_at"`
 	CreatedAt         time.Time  `gorm:"column:created_at;not null" json:"created_at"`

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -125,6 +125,7 @@ type SummaryTask struct {
 	RetryCount         int        `gorm:"column:retry_count;type:tinyint;not null;default:0" json:"retry_count"`
 	ErrorMessage       *string    `gorm:"column:error_message;type:varchar(500)" json:"error_message"`
 	ScheduleID         *int64     `gorm:"column:schedule_id" json:"schedule_id"`
+	CurrentResultID    *int64     `gorm:"column:current_result_id" json:"current_result_id"`
 	OriginChannelID    string     `gorm:"column:origin_channel_id;type:varchar(64);not null;default:'';index:idx_origin_channel" json:"origin_channel_id"`
 	OriginChannelType  int        `gorm:"column:origin_channel_type;type:tinyint;not null;default:0" json:"origin_channel_type"`
 	ProcessingDeadline *time.Time `gorm:"column:processing_deadline" json:"processing_deadline"`
@@ -234,6 +235,10 @@ type SummaryResult struct {
 	TotalTokenUsed    int        `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
 	ModelVersion      string     `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
 	Version           int        `gorm:"column:version;not null;default:1" json:"version"`
+	OperationType     string     `gorm:"column:operation_type;type:varchar(32);not null;default:'generate'" json:"operation_type"`
+	OperationNote     string     `gorm:"column:operation_note;type:text" json:"operation_note"`
+	ParentResultID    *int64     `gorm:"column:parent_result_id" json:"parent_result_id,omitempty"`
+	CreatedBy         string     `gorm:"column:created_by;type:varchar(64);not null;default:''" json:"created_by"`
 	EditedAt          *time.Time `gorm:"column:edited_at" json:"edited_at"`
 	GeneratedAt       time.Time  `gorm:"column:generated_at;not null" json:"generated_at"`
 	CreatedAt         time.Time  `gorm:"column:created_at;not null" json:"created_at"`
@@ -296,15 +301,16 @@ func (SummaryResult) TableName() string { return "summary_result" }
 
 // SummarySchedule represents a recurring schedule configuration.
 type SummarySchedule struct {
-	ID             int64  `gorm:"primaryKey;autoIncrement" json:"id"`
-	SpaceID        string `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
-	CreatorID      string `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
-	Title          string `gorm:"column:title;type:varchar(1000);not null;default:''" json:"title"`
-	SummaryMode    int    `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
-	CronExpr       string `gorm:"column:cron_expr;type:varchar(50);not null" json:"cron_expr"`
-	IntervalDays   int    `gorm:"column:interval_days;type:int;not null;default:0" json:"interval_days"`
-	IntervalMonths int    `gorm:"column:interval_months;type:int;not null;default:0" json:"interval_months"`
-	RunTime        string `gorm:"column:run_time;type:varchar(5);not null;default:''" json:"run_time"`
+	ID                    int64  `gorm:"primaryKey;autoIncrement" json:"id"`
+	SpaceID               string `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
+	CreatorID             string `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
+	Title                 string `gorm:"column:title;type:varchar(1000);not null;default:''" json:"title"`
+	GenerationInstruction string `gorm:"column:generation_instruction;type:text" json:"generation_instruction"`
+	SummaryMode           int    `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
+	CronExpr              string `gorm:"column:cron_expr;type:varchar(50);not null" json:"cron_expr"`
+	IntervalDays          int    `gorm:"column:interval_days;type:int;not null;default:0" json:"interval_days"`
+	IntervalMonths        int    `gorm:"column:interval_months;type:int;not null;default:0" json:"interval_months"`
+	RunTime               string `gorm:"column:run_time;type:varchar(5);not null;default:''" json:"run_time"`
 	// DayOfWeek aligns WEEK mode (interval_days multiple of 7) to a specific
 	// weekday: 1=Mon..7=Sun, 0=unconstrained. Ignored for non-week modes.
 	DayOfWeek int `gorm:"column:day_of_week;type:tinyint;not null;default:0" json:"day_of_week"`

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -301,15 +301,16 @@ func (SummaryResult) TableName() string { return "summary_result" }
 
 // SummarySchedule represents a recurring schedule configuration.
 type SummarySchedule struct {
-	ID             int64  `gorm:"primaryKey;autoIncrement" json:"id"`
-	SpaceID        string `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
-	CreatorID      string `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
-	Title          string `gorm:"column:title;type:varchar(1000);not null;default:''" json:"title"`
-	SummaryMode    int    `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
-	CronExpr       string `gorm:"column:cron_expr;type:varchar(50);not null" json:"cron_expr"`
-	IntervalDays   int    `gorm:"column:interval_days;type:int;not null;default:0" json:"interval_days"`
-	IntervalMonths int    `gorm:"column:interval_months;type:int;not null;default:0" json:"interval_months"`
-	RunTime        string `gorm:"column:run_time;type:varchar(5);not null;default:''" json:"run_time"`
+	ID                    int64  `gorm:"primaryKey;autoIncrement" json:"id"`
+	SpaceID               string `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
+	CreatorID             string `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
+	Title                 string `gorm:"column:title;type:varchar(1000);not null;default:''" json:"title"`
+	GenerationInstruction string `gorm:"column:generation_instruction;type:text" json:"generation_instruction"`
+	SummaryMode           int    `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
+	CronExpr              string `gorm:"column:cron_expr;type:varchar(50);not null" json:"cron_expr"`
+	IntervalDays          int    `gorm:"column:interval_days;type:int;not null;default:0" json:"interval_days"`
+	IntervalMonths        int    `gorm:"column:interval_months;type:int;not null;default:0" json:"interval_months"`
+	RunTime               string `gorm:"column:run_time;type:varchar(5);not null;default:''" json:"run_time"`
 	// DayOfWeek aligns WEEK mode (interval_days multiple of 7) to a specific
 	// weekday: 1=Mon..7=Sun, 0=unconstrained. Ignored for non-week modes.
 	DayOfWeek int `gorm:"column:day_of_week;type:tinyint;not null;default:0" json:"day_of_week"`

--- a/internal/model/personal_result.go
+++ b/internal/model/personal_result.go
@@ -42,6 +42,7 @@ type PersonalResult struct {
 	MsgCount         int        `gorm:"column:msg_count;not null;default:0" json:"msg_count"`
 	TotalTokenUsed   int        `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
 	ModelVersion     string     `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
+	CurrentVersionID *int64     `gorm:"column:current_version_id" json:"current_version_id"`
 	WorkerStatus     int        `gorm:"column:worker_status;type:tinyint;not null;default:0" json:"worker_status"`
 	WorkflowStage    string     `gorm:"column:workflow_stage;type:varchar(32);not null;default:''" json:"workflow_stage"`
 	RetryCount       int        `gorm:"column:retry_count;type:tinyint;not null;default:0" json:"retry_count"`
@@ -55,6 +56,55 @@ type PersonalResult struct {
 }
 
 func (PersonalResult) TableName() string { return "summary_personal_result" }
+
+// PersonalResultVersion stores lightweight history for the caller-owned
+// PersonalResult. summary_personal_result remains the current materialized row
+// used by read paths; this table is only version history.
+type PersonalResultVersion struct {
+	ID               int64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID           int64     `gorm:"column:task_id;not null" json:"task_id"`
+	ParticipantRefID int64     `gorm:"column:participant_ref_id;not null" json:"participant_ref_id"`
+	UserID           string    `gorm:"column:user_id;type:varchar(64);not null" json:"user_id"`
+	Content          string    `gorm:"column:content;type:mediumtext;not null" json:"content"`
+	CitationsJSON    string    `gorm:"column:citations_json;type:mediumtext" json:"-"`
+	MsgCount         int       `gorm:"column:msg_count;not null;default:0" json:"msg_count"`
+	TotalTokenUsed   int       `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
+	ModelVersion     string    `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
+	Version          int       `gorm:"column:version;not null;default:1" json:"version"`
+	OperationType    string    `gorm:"column:operation_type;type:varchar(32);not null;default:'generate'" json:"operation_type"`
+	OperationNote    string    `gorm:"column:operation_note;type:text" json:"operation_note"`
+	ParentVersionID  *int64    `gorm:"column:parent_version_id" json:"parent_version_id,omitempty"`
+	CreatedBy        string    `gorm:"column:created_by;type:varchar(64);not null;default:''" json:"created_by"`
+	GeneratedAt      time.Time `gorm:"column:generated_at;not null" json:"generated_at"`
+	CreatedAt        time.Time `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"column:updated_at;not null" json:"updated_at"`
+}
+
+func (PersonalResultVersion) TableName() string { return "summary_personal_result_version" }
+
+func (r *PersonalResultVersion) GetCitations() []Citation {
+	if r.CitationsJSON == "" {
+		return []Citation{}
+	}
+	var citations []Citation
+	if err := json.Unmarshal([]byte(r.CitationsJSON), &citations); err != nil {
+		return []Citation{}
+	}
+	return citations
+}
+
+func (r *PersonalResultVersion) SetCitations(citations []Citation) {
+	if len(citations) == 0 {
+		r.CitationsJSON = "[]"
+		return
+	}
+	data, err := json.Marshal(citations)
+	if err != nil {
+		r.CitationsJSON = "[]"
+		return
+	}
+	r.CitationsJSON = string(data)
+}
 
 // GetCitations deserializes CitationsJSON into a slice of Citation.
 func (r *PersonalResult) GetCitations() []Citation {

--- a/internal/model/personal_result.go
+++ b/internal/model/personal_result.go
@@ -62,15 +62,15 @@ func (PersonalResult) TableName() string { return "summary_personal_result" }
 // used by read paths; this table is only version history.
 type PersonalResultVersion struct {
 	ID               int64     `gorm:"primaryKey;autoIncrement" json:"id"`
-	TaskID           int64     `gorm:"column:task_id;not null" json:"task_id"`
+	TaskID           int64     `gorm:"column:task_id;not null;uniqueIndex:uk_personal_result_version_task_user_version" json:"task_id"`
 	ParticipantRefID int64     `gorm:"column:participant_ref_id;not null" json:"participant_ref_id"`
-	UserID           string    `gorm:"column:user_id;type:varchar(64);not null" json:"user_id"`
+	UserID           string    `gorm:"column:user_id;type:varchar(64);not null;uniqueIndex:uk_personal_result_version_task_user_version" json:"user_id"`
 	Content          string    `gorm:"column:content;type:mediumtext;not null" json:"content"`
 	CitationsJSON    string    `gorm:"column:citations_json;type:mediumtext" json:"-"`
 	MsgCount         int       `gorm:"column:msg_count;not null;default:0" json:"msg_count"`
 	TotalTokenUsed   int       `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
 	ModelVersion     string    `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
-	Version          int       `gorm:"column:version;not null;default:1" json:"version"`
+	Version          int       `gorm:"column:version;not null;default:1;uniqueIndex:uk_personal_result_version_task_user_version" json:"version"`
 	OperationType    string    `gorm:"column:operation_type;type:varchar(32);not null;default:'generate'" json:"operation_type"`
 	OperationNote    string    `gorm:"column:operation_note;type:text" json:"operation_note"`
 	ParentVersionID  *int64    `gorm:"column:parent_version_id" json:"parent_version_id,omitempty"`

--- a/internal/model/personal_result.go
+++ b/internal/model/personal_result.go
@@ -42,6 +42,7 @@ type PersonalResult struct {
 	MsgCount         int        `gorm:"column:msg_count;not null;default:0" json:"msg_count"`
 	TotalTokenUsed   int        `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
 	ModelVersion     string     `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
+	CurrentVersionID *int64     `gorm:"column:current_version_id" json:"current_version_id"`
 	WorkerStatus     int        `gorm:"column:worker_status;type:tinyint;not null;default:0" json:"worker_status"`
 	WorkflowStage    string     `gorm:"column:workflow_stage;type:varchar(32);not null;default:''" json:"workflow_stage"`
 	RetryCount       int        `gorm:"column:retry_count;type:tinyint;not null;default:0" json:"retry_count"`
@@ -55,6 +56,55 @@ type PersonalResult struct {
 }
 
 func (PersonalResult) TableName() string { return "summary_personal_result" }
+
+// PersonalResultVersion stores lightweight history for the caller-owned
+// PersonalResult. summary_personal_result remains the current materialized row
+// used by read paths; this table is only version history.
+type PersonalResultVersion struct {
+	ID               int64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID           int64     `gorm:"column:task_id;not null;uniqueIndex:uk_personal_result_version_task_user_version" json:"task_id"`
+	ParticipantRefID int64     `gorm:"column:participant_ref_id;not null" json:"participant_ref_id"`
+	UserID           string    `gorm:"column:user_id;type:varchar(64);not null;uniqueIndex:uk_personal_result_version_task_user_version" json:"user_id"`
+	Content          string    `gorm:"column:content;type:mediumtext;not null" json:"content"`
+	CitationsJSON    string    `gorm:"column:citations_json;type:mediumtext" json:"-"`
+	MsgCount         int       `gorm:"column:msg_count;not null;default:0" json:"msg_count"`
+	TotalTokenUsed   int       `gorm:"column:total_token_used;not null;default:0" json:"total_token_used"`
+	ModelVersion     string    `gorm:"column:model_version;type:varchar(50);not null;default:''" json:"model_version"`
+	Version          int       `gorm:"column:version;not null;default:1;uniqueIndex:uk_personal_result_version_task_user_version" json:"version"`
+	OperationType    string    `gorm:"column:operation_type;type:varchar(32);not null;default:'generate'" json:"operation_type"`
+	OperationNote    string    `gorm:"column:operation_note;type:text" json:"operation_note"`
+	ParentVersionID  *int64    `gorm:"column:parent_version_id" json:"parent_version_id,omitempty"`
+	CreatedBy        string    `gorm:"column:created_by;type:varchar(64);not null;default:''" json:"created_by"`
+	GeneratedAt      time.Time `gorm:"column:generated_at;not null" json:"generated_at"`
+	CreatedAt        time.Time `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"column:updated_at;not null" json:"updated_at"`
+}
+
+func (PersonalResultVersion) TableName() string { return "summary_personal_result_version" }
+
+func (r *PersonalResultVersion) GetCitations() []Citation {
+	if r.CitationsJSON == "" {
+		return []Citation{}
+	}
+	var citations []Citation
+	if err := json.Unmarshal([]byte(r.CitationsJSON), &citations); err != nil {
+		return []Citation{}
+	}
+	return citations
+}
+
+func (r *PersonalResultVersion) SetCitations(citations []Citation) {
+	if len(citations) == 0 {
+		r.CitationsJSON = "[]"
+		return
+	}
+	data, err := json.Marshal(citations)
+	if err != nil {
+		r.CitationsJSON = "[]"
+		return
+	}
+	r.CitationsJSON = string(data)
+}
 
 // GetCitations deserializes CitationsJSON into a slice of Citation.
 func (r *PersonalResult) GetCitations() []Citation {

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -92,6 +93,7 @@ type chatRequestWithTools struct {
 	ToolChoice         interface{}            `json:"tool_choice"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
+	Stream             bool                   `json:"stream,omitempty"`
 }
 
 type chatResponseWithTools struct {
@@ -112,6 +114,10 @@ type chatResponseWithTools struct {
 	} `json:"usage"`
 }
 
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
 type chatRequest struct {
 	Model              string                 `json:"model"`
 	Messages           []ChatMessage          `json:"messages"`
@@ -119,6 +125,8 @@ type chatRequest struct {
 	MaxTokens          int                    `json:"max_tokens"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
+	Stream             bool                   `json:"stream,omitempty"`
+	StreamOptions      *streamOptions         `json:"stream_options,omitempty"`
 }
 
 type chatResponse struct {
@@ -222,6 +230,120 @@ func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperatur
 	}
 
 	return content, chatResp.Usage.TotalTokens, nil
+}
+
+type chatStreamResponse struct {
+	Choices []struct {
+		Delta struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			Reasoning        string `json:"reasoning"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		TotalTokens      int `json:"total_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// CallStream makes a chat completion streaming request. onDelta is called for
+// each user-visible content delta. It returns the accumulated full content so
+// downstream citation building and DB persistence remain source-of-truth.
+func (c *LLMClient) CallStream(ctx context.Context, messages []ChatMessage, temperature float64, onDelta func(string) error) (string, int, error) {
+	if config.IsKimiModel(c.model) && temperature != kimiRequiredTemperature {
+		log.Printf("[llm] overriding stream temperature from %.2f to %.2f (model constraint)",
+			temperature, kimiRequiredTemperature)
+		temperature = kimiRequiredTemperature
+	} else if config.IsKimiModel(c.model) {
+		temperature = kimiRequiredTemperature
+	}
+	log.Printf("[llm] streaming model=%s temperature=%.2f max_tokens=%d", c.model, temperature, c.maxTokens)
+
+	reqBody := chatRequest{
+		Model:         c.model,
+		Messages:      messages,
+		Temperature:   temperature,
+		MaxTokens:     c.maxTokens,
+		Stream:        true,
+		StreamOptions: &streamOptions{IncludeUsage: true},
+	}
+	thinking, kwargs := c.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", 0, fmt.Errorf("LLM stream API error: status=%d body=%s", resp.StatusCode, string(respBody))
+	}
+
+	var sb strings.Builder
+	var totalTokens int
+	var reasoningLen int
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			break
+		}
+		var chunk chatStreamResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return sb.String(), totalTokens, fmt.Errorf("unmarshal LLM stream chunk: %w", err)
+		}
+		if chunk.Usage.TotalTokens > 0 {
+			totalTokens = chunk.Usage.TotalTokens
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		delta := chunk.Choices[0].Delta.Content
+		if delta == "" {
+			reasoningLen += len(chunk.Choices[0].Delta.ReasoningContent) + len(chunk.Choices[0].Delta.Reasoning)
+			continue
+		}
+		sb.WriteString(delta)
+		if onDelta != nil {
+			if err := onDelta(delta); err != nil {
+				return sb.String(), totalTokens, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return sb.String(), totalTokens, fmt.Errorf("read LLM stream: %w", err)
+	}
+	content := sb.String()
+	if content == "" && reasoningLen > 0 {
+		return "", totalTokens, fmt.Errorf("LLM returned empty streamed content: reasoning consumed output budget")
+	}
+	if content == "" {
+		return "", totalTokens, fmt.Errorf("LLM returned empty streamed content")
+	}
+	return content, totalTokens, nil
 }
 
 // CallRaw is a simple single-turn call returning text only. Used for topic narrowing.
@@ -524,9 +646,73 @@ func (c *LLMClient) CallReduce(ctx context.Context, chunkSummaries []string, sou
 	}, 0.1)
 }
 
-// CallReduceByPerson merges participant-level summaries.
-// Each participant is assigned a [Pn] tag that the LLM should reference in the output.
-func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
+// CallMapStream runs the Map phase for a user-visible single chunk and streams
+// the generated summary deltas.
+func (c *LLMClient) CallMapStream(ctx context.Context, formattedMessages string, sourceName string, chunkIndex int, msgCount int, timeStart, timeEnd string, topic string, userName string, onDelta func(string) error) (string, int, error) {
+	if strings.TrimSpace(formattedMessages) == "" {
+		return "(该时段无文本消息)", 0, nil
+	}
+	systemPrompt := buildMapSystemPrompt(userName, topic)
+	userPrompt := fmt.Sprintf("来源：%s\n时间范围：%s ~ %s\n消息数：%d 条\n\n聊天记录：\n%s",
+		sourceName, timeStart, timeEnd, msgCount, formattedMessages)
+
+	var emitted bool
+	wrappedDelta := func(delta string) error {
+		emitted = true
+		if onDelta == nil {
+			return nil
+		}
+		return onDelta(delta)
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		content, tokens, err := c.CallStream(ctx, []ChatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userPrompt},
+		}, 0.1, wrappedDelta)
+		if err == nil {
+			return content, tokens, nil
+		}
+		log.Printf("[llm] Stream Map chunk %d attempt %d failed: %v", chunkIndex, attempt+1, err)
+		if emitted {
+			return content, tokens, err
+		}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "reasoning consumed") || strings.Contains(errMsg, "empty content") {
+			return "", tokens, fmt.Errorf("reasoning budget exhausted on chunk %d", chunkIndex)
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(1<<uint(attempt)) * time.Second)
+		}
+	}
+	return fmt.Sprintf("(分片 %d %s)", chunkIndex, MapFailedMarker), 0, nil
+}
+
+// CallReduceStream merges chunk summaries and streams the final user-visible
+// reduced summary.
+func (c *LLMClient) CallReduceStream(ctx context.Context, chunkSummaries []string, sourceNames string, startTime, endTime string, totalMsgCount int, topic string, onDelta func(string) error) (string, int, error) {
+	if len(chunkSummaries) == 1 {
+		if onDelta != nil && chunkSummaries[0] != "" {
+			_ = onDelta(chunkSummaries[0])
+		}
+		return chunkSummaries[0], 0, nil
+	}
+
+	var parts []string
+	for i, s := range chunkSummaries {
+		parts = append(parts, fmt.Sprintf("【分片 %d】\n%s", i+1, s))
+	}
+	summariesText := strings.Join(parts, "\n\n---\n\n")
+	system := buildReduceSystemPrompt(topic)
+	userPrompt := fmt.Sprintf("信息来源：%s\n时间范围：%s ~ %s\n消息总量：%d 条\n\n以下是各分片的总结，请合并：\n\n%s",
+		sourceNames, startTime, endTime, totalMsgCount, summariesText)
+
+	return c.CallStream(ctx, []ChatMessage{
+		{Role: "system", Content: system},
+		{Role: "user", Content: userPrompt},
+	}, 0.1, onDelta)
+}
+
+func buildReduceByPersonMessages(participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) []ChatMessage {
 	var parts []string
 	for i, ps := range participantSummaries {
 		parts = append(parts, fmt.Sprintf("[P%d]【%s 的工作总结】\n%s", i+1, ps.Name, ps.Summary))
@@ -544,8 +730,21 @@ func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries
 - 如果总结主题中包含输出结构、详细程度、分点方式、待办格式等要求，必须优先遵循；如果主题没有指定结构，再根据实际内容自行组织结构
 - 用显示名称指代人，绝对不要输出 UID 或用户 ID`
 
-	return c.Call(ctx, []ChatMessage{
+	return []ChatMessage{
 		{Role: "system", Content: system},
 		{Role: "user", Content: fmt.Sprintf("总结主题：%s\n时间范围：%s ~ %s\n\n%s", topic, startTime, endTime, text)},
-	}, 0.1)
+	}
+}
+
+// CallReduceByPerson merges participant-level summaries.
+// Each participant is assigned a [Pn] tag that the LLM should reference in the output.
+func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
+	return c.Call(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1)
+}
+
+// CallReduceByPersonStream merges participant-level summaries and streams the
+// final team summary. Each participant is assigned a [Pn] tag that the LLM should
+// reference in the output.
+func (c *LLMClient) CallReduceByPersonStream(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string, onDelta func(string) error) (string, int, error) {
+	return c.CallStream(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta)
 }

--- a/internal/service/summary.go
+++ b/internal/service/summary.go
@@ -195,6 +195,30 @@ func GetNextVersion(db *gorm.DB, taskID int64) (int, error) {
 }
 
 // SplitIntoChunks splits messages into chunks of roughly chunkSize.
+
+const SummaryResultVersionKeepLimit = 5
+const PersonalResultVersionKeepLimit = 5
+
+// PruneSummaryResultVersions keeps the newest summary result versions and deletes older rows.
+func PruneSummaryResultVersions(db *gorm.DB, taskID int64, keep int) error {
+	if keep <= 0 {
+		keep = SummaryResultVersionKeepLimit
+	}
+	var keepIDs []int64
+	if err := db.Model(&model.SummaryResult{}).
+		Where("task_id = ?", taskID).
+		Order("version DESC").
+		Order("id DESC").
+		Limit(keep).
+		Pluck("id", &keepIDs).Error; err != nil {
+		return err
+	}
+	if len(keepIDs) < keep {
+		return nil
+	}
+	return db.Where("task_id = ? AND id NOT IN ?", taskID, keepIDs).Delete(&model.SummaryResult{}).Error
+}
+
 func SplitIntoChunks(messages []map[string]interface{}, chunkSize int) [][]map[string]interface{} {
 	if chunkSize <= 0 {
 		chunkSize = 500
@@ -263,4 +287,39 @@ func containsAny(s string, keywords []string) bool {
 		}
 	}
 	return false
+}
+
+func GetNextPersonalVersion(db *gorm.DB, taskID int64, userID string) (int, error) {
+	var maxVer *int
+	err := db.Model(&model.PersonalResultVersion{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Select("MAX(version)").
+		Scan(&maxVer).Error
+	if err != nil {
+		return 0, err
+	}
+	if maxVer == nil {
+		return 1, nil
+	}
+	return *maxVer + 1, nil
+}
+
+// PrunePersonalResultVersions keeps the newest personal result versions for a user.
+func PrunePersonalResultVersions(db *gorm.DB, taskID int64, userID string, keep int) error {
+	if keep <= 0 {
+		keep = PersonalResultVersionKeepLimit
+	}
+	var keepIDs []int64
+	if err := db.Model(&model.PersonalResultVersion{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Order("version DESC").
+		Order("id DESC").
+		Limit(keep).
+		Pluck("id", &keepIDs).Error; err != nil {
+		return err
+	}
+	if len(keepIDs) < keep {
+		return nil
+	}
+	return db.Where("task_id = ? AND user_id = ? AND id NOT IN ?", taskID, userID, keepIDs).Delete(&model.PersonalResultVersion{}).Error
 }

--- a/internal/service/summary.go
+++ b/internal/service/summary.go
@@ -199,7 +199,9 @@ func GetNextVersion(db *gorm.DB, taskID int64) (int, error) {
 const SummaryResultVersionKeepLimit = 5
 const PersonalResultVersionKeepLimit = 5
 
-// PruneSummaryResultVersions keeps the newest summary result versions and deletes older rows.
+// PruneSummaryResultVersions keeps the newest auto-generated summary result versions.
+// Hand-edited rows are retained as user data, and the current display pointer is
+// never pruned even when it points to an older restored version.
 func PruneSummaryResultVersions(db *gorm.DB, taskID int64, keep int) error {
 	if keep <= 0 {
 		keep = SummaryResultVersionKeepLimit
@@ -216,7 +218,20 @@ func PruneSummaryResultVersions(db *gorm.DB, taskID int64, keep int) error {
 	if len(keepIDs) < keep {
 		return nil
 	}
-	return db.Where("task_id = ? AND id NOT IN ?", taskID, keepIDs).Delete(&model.SummaryResult{}).Error
+	var current struct {
+		CurrentResultID *int64
+	}
+	if err := db.Model(&model.SummaryTask{}).
+		Where("id = ?", taskID).
+		Select("current_result_id").
+		Scan(&current).Error; err != nil {
+		return err
+	}
+	deleteQuery := db.Where("task_id = ? AND id NOT IN ? AND edited_at IS NULL", taskID, keepIDs)
+	if current.CurrentResultID != nil {
+		deleteQuery = deleteQuery.Where("id <> ?", *current.CurrentResultID)
+	}
+	return deleteQuery.Delete(&model.SummaryResult{}).Error
 }
 
 func SplitIntoChunks(messages []map[string]interface{}, chunkSize int) [][]map[string]interface{} {
@@ -305,6 +320,8 @@ func GetNextPersonalVersion(db *gorm.DB, taskID int64, userID string) (int, erro
 }
 
 // PrunePersonalResultVersions keeps the newest personal result versions for a user.
+// The current_version_id pointer is always retained, including after restoring
+// an older version.
 func PrunePersonalResultVersions(db *gorm.DB, taskID int64, userID string, keep int) error {
 	if keep <= 0 {
 		keep = PersonalResultVersionKeepLimit
@@ -321,5 +338,18 @@ func PrunePersonalResultVersions(db *gorm.DB, taskID int64, userID string, keep 
 	if len(keepIDs) < keep {
 		return nil
 	}
-	return db.Where("task_id = ? AND user_id = ? AND id NOT IN ?", taskID, userID, keepIDs).Delete(&model.PersonalResultVersion{}).Error
+	var current struct {
+		CurrentVersionID *int64
+	}
+	if err := db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Select("current_version_id").
+		Scan(&current).Error; err != nil {
+		return err
+	}
+	deleteQuery := db.Where("task_id = ? AND user_id = ? AND id NOT IN ?", taskID, userID, keepIDs)
+	if current.CurrentVersionID != nil {
+		deleteQuery = deleteQuery.Where("id <> ?", *current.CurrentVersionID)
+	}
+	return deleteQuery.Delete(&model.PersonalResultVersion{}).Error
 }

--- a/internal/service/summary.go
+++ b/internal/service/summary.go
@@ -195,6 +195,45 @@ func GetNextVersion(db *gorm.DB, taskID int64) (int, error) {
 }
 
 // SplitIntoChunks splits messages into chunks of roughly chunkSize.
+
+const SummaryResultVersionKeepLimit = 5
+const PersonalResultVersionKeepLimit = 5
+
+// PruneSummaryResultVersions keeps the newest auto-generated summary result versions.
+// Hand-edited rows are retained as user data, and the current display pointer is
+// never pruned even when it points to an older restored version.
+func PruneSummaryResultVersions(db *gorm.DB, taskID int64, keep int) error {
+	if keep <= 0 {
+		keep = SummaryResultVersionKeepLimit
+	}
+	var keepIDs []int64
+	if err := db.Model(&model.SummaryResult{}).
+		Where("task_id = ?", taskID).
+		Order("version DESC").
+		Order("id DESC").
+		Limit(keep).
+		Pluck("id", &keepIDs).Error; err != nil {
+		return err
+	}
+	if len(keepIDs) < keep {
+		return nil
+	}
+	var current struct {
+		CurrentResultID *int64
+	}
+	if err := db.Model(&model.SummaryTask{}).
+		Where("id = ?", taskID).
+		Select("current_result_id").
+		Scan(&current).Error; err != nil {
+		return err
+	}
+	deleteQuery := db.Where("task_id = ? AND id NOT IN ? AND edited_at IS NULL", taskID, keepIDs)
+	if current.CurrentResultID != nil {
+		deleteQuery = deleteQuery.Where("id <> ?", *current.CurrentResultID)
+	}
+	return deleteQuery.Delete(&model.SummaryResult{}).Error
+}
+
 func SplitIntoChunks(messages []map[string]interface{}, chunkSize int) [][]map[string]interface{} {
 	if chunkSize <= 0 {
 		chunkSize = 500
@@ -263,4 +302,54 @@ func containsAny(s string, keywords []string) bool {
 		}
 	}
 	return false
+}
+
+func GetNextPersonalVersion(db *gorm.DB, taskID int64, userID string) (int, error) {
+	var maxVer *int
+	err := db.Model(&model.PersonalResultVersion{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Select("MAX(version)").
+		Scan(&maxVer).Error
+	if err != nil {
+		return 0, err
+	}
+	if maxVer == nil {
+		return 1, nil
+	}
+	return *maxVer + 1, nil
+}
+
+// PrunePersonalResultVersions keeps the newest personal result versions for a user.
+// The current_version_id pointer is always retained, including after restoring
+// an older version.
+func PrunePersonalResultVersions(db *gorm.DB, taskID int64, userID string, keep int) error {
+	if keep <= 0 {
+		keep = PersonalResultVersionKeepLimit
+	}
+	var keepIDs []int64
+	if err := db.Model(&model.PersonalResultVersion{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Order("version DESC").
+		Order("id DESC").
+		Limit(keep).
+		Pluck("id", &keepIDs).Error; err != nil {
+		return err
+	}
+	if len(keepIDs) < keep {
+		return nil
+	}
+	var current struct {
+		CurrentVersionID *int64
+	}
+	if err := db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", taskID, userID).
+		Select("current_version_id").
+		Scan(&current).Error; err != nil {
+		return err
+	}
+	deleteQuery := db.Where("task_id = ? AND user_id = ? AND id NOT IN ?", taskID, userID, keepIDs)
+	if current.CurrentVersionID != nil {
+		deleteQuery = deleteQuery.Where("id <> ?", *current.CurrentVersionID)
+	}
+	return deleteQuery.Delete(&model.PersonalResultVersion{}).Error
 }

--- a/internal/streaming/event.go
+++ b/internal/streaming/event.go
@@ -1,0 +1,39 @@
+package streaming
+
+const (
+	EventStart    = "start"
+	EventStage    = "stage"
+	EventDelta    = "delta"
+	EventSnapshot = "snapshot"
+	EventDone     = "done"
+	EventError    = "error"
+)
+
+const (
+	ScopePersonal = "personal"
+	ScopeTeam     = "team"
+)
+
+// Event is the internal worker→api stream payload and the api→web SSE payload.
+// Phase 1 treats api as the source of truth for Snapshot: api appends Delta into
+// an in-memory snapshot; worker-sent Snapshot is accepted only as a best-effort
+// reconciliation hint for degraded paths.
+type Event struct {
+	Type         string `json:"type"`
+	TaskID       int64  `json:"task_id"`
+	RunID        string `json:"run_id,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	TargetUserID string `json:"target_user_id,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	Delta        string `json:"delta,omitempty"`
+	Content      string `json:"content,omitempty"`
+	Message      string `json:"message,omitempty"`
+	Status       int    `json:"status,omitempty"`
+}
+
+func NormalizeScope(scope string) string {
+	if scope == ScopeTeam {
+		return ScopeTeam
+	}
+	return ScopePersonal
+}

--- a/internal/streaming/hub.go
+++ b/internal/streaming/hub.go
@@ -1,0 +1,176 @@
+package streaming
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const defaultClientBuffer = 128
+
+const defaultIdleTTLMul = 10
+
+type streamState struct {
+	activeRunID string
+	snapshot    string
+	done        bool
+	lastEventAt time.Time
+	clients     map[chan Event]struct{}
+	cleanup     *time.Timer
+}
+
+// Hub is an in-memory, single-api-instance bridge from worker NDJSON streams to
+// browser SSE streams. Phase 1 deployment contract: summary-api runs as a single
+// replica (or traffic is sticky). Multi-replica requires Redis Pub/Sub.
+type Hub struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	idleTTL time.Duration
+	m       map[string]*streamState
+}
+
+func NewHub(ttl time.Duration) *Hub {
+	if ttl <= 0 {
+		ttl = 60 * time.Second
+	}
+	return &Hub{ttl: ttl, idleTTL: ttl * defaultIdleTTLMul, m: make(map[string]*streamState)}
+}
+
+func Key(taskID int64, scope, targetUserID string) string {
+	return fmt.Sprintf("%d:%s:%s", taskID, NormalizeScope(scope), targetUserID)
+}
+
+func (h *Hub) Subscribe(taskID int64, scope, targetUserID string) (<-chan Event, string, bool, func()) {
+	key := Key(taskID, scope, targetUserID)
+	ch := make(chan Event, defaultClientBuffer)
+
+	h.mu.Lock()
+	st := h.ensureLocked(key)
+	if st.cleanup != nil && !st.done {
+		st.cleanup.Stop()
+		st.cleanup = nil
+	}
+	st.clients[ch] = struct{}{}
+	snapshot := st.snapshot
+	done := st.done
+	h.mu.Unlock()
+
+	cancel := func() {
+		h.mu.Lock()
+		if cur := h.m[key]; cur != nil {
+			delete(cur.clients, ch)
+			if len(cur.clients) == 0 && !cur.done {
+				h.scheduleIdleCleanupLocked(key, cur)
+			}
+		}
+		h.mu.Unlock()
+		close(ch)
+	}
+	return ch, snapshot, done, cancel
+}
+
+func (h *Hub) Publish(ev Event) {
+	if ev.TaskID == 0 || ev.Type == "" {
+		return
+	}
+	ev.Scope = NormalizeScope(ev.Scope)
+	key := Key(ev.TaskID, ev.Scope, ev.TargetUserID)
+
+	h.mu.Lock()
+	st := h.ensureLocked(key)
+
+	if ev.Type == EventStart {
+		if st.cleanup != nil {
+			st.cleanup.Stop()
+			st.cleanup = nil
+		}
+		st.activeRunID = ev.RunID
+		st.snapshot = ""
+		st.done = false
+	} else if st.activeRunID != "" && ev.RunID != "" && ev.RunID != st.activeRunID {
+		// Old worker run arrived late after a newer run started; discard to avoid
+		// mixing regenerated content with a previous run.
+		h.mu.Unlock()
+		return
+	}
+
+	st.lastEventAt = time.Now()
+
+	switch ev.Type {
+	case EventDelta:
+		st.snapshot += ev.Delta
+		ev.Content = st.snapshot
+	case EventSnapshot:
+		if ev.Content != "" {
+			st.snapshot = ev.Content
+		}
+	case EventDone, EventError:
+		st.done = true
+		ev.Content = st.snapshot
+		if st.cleanup != nil {
+			st.cleanup.Stop()
+		}
+		st.cleanup = time.AfterFunc(h.ttl, func() { h.deleteKey(key) })
+	}
+	if !st.done {
+		h.scheduleIdleCleanupLocked(key, st)
+	}
+
+	clients := make([]chan Event, 0, len(st.clients))
+	for ch := range st.clients {
+		clients = append(clients, ch)
+	}
+	h.mu.Unlock()
+
+	for _, ch := range clients {
+		select {
+		case ch <- ev:
+		default:
+			// Slow SSE clients should not block worker token ingestion.
+		}
+	}
+}
+
+func (h *Hub) ensureLocked(key string) *streamState {
+	st := h.m[key]
+	if st == nil {
+		st = &streamState{clients: make(map[chan Event]struct{})}
+		h.m[key] = st
+	}
+	return st
+}
+
+func (h *Hub) scheduleIdleCleanupLocked(key string, st *streamState) {
+	if h.idleTTL <= 0 || st.done {
+		return
+	}
+	if st.cleanup != nil {
+		st.cleanup.Stop()
+	}
+	lastEventAt := st.lastEventAt
+	st.cleanup = time.AfterFunc(h.idleTTL, func() { h.deleteKeyIfIdle(key, lastEventAt) })
+}
+
+func (h *Hub) deleteKeyIfIdle(key string, lastEventAt time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	st := h.m[key]
+	if st == nil {
+		return
+	}
+	if st.done {
+		delete(h.m, key)
+		return
+	}
+	if len(st.clients) > 0 || !st.lastEventAt.Equal(lastEventAt) {
+		h.scheduleIdleCleanupLocked(key, st)
+		return
+	}
+	delete(h.m, key)
+}
+
+func (h *Hub) deleteKey(key string) {
+	h.mu.Lock()
+	delete(h.m, key)
+	h.mu.Unlock()
+}

--- a/internal/streaming/hub_test.go
+++ b/internal/streaming/hub_test.go
@@ -1,0 +1,92 @@
+package streaming
+
+import (
+	"testing"
+	"time"
+)
+
+func readEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for stream event")
+	}
+	return Event{}
+}
+
+func TestHubDeltaCarriesSnapshotAndLateSubscribe(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run-1", Scope: ScopePersonal, TargetUserID: "u1"})
+
+	ch, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "" || done {
+		t.Fatalf("initial snapshot=%q done=%v, want empty/false", snapshot, done)
+	}
+
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run-1", Scope: ScopePersonal, TargetUserID: "u1", Delta: "你"})
+	if ev := readEvent(t, ch); ev.Content != "你" || ev.Delta != "你" {
+		t.Fatalf("first delta content=%q delta=%q, want snapshot delta", ev.Content, ev.Delta)
+	}
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run-1", Scope: ScopePersonal, TargetUserID: "u1", Delta: "好"})
+	if ev := readEvent(t, ch); ev.Content != "你好" || ev.Delta != "好" {
+		t.Fatalf("second delta content=%q delta=%q, want accumulated snapshot", ev.Content, ev.Delta)
+	}
+
+	_, lateSnapshot, lateDone, lateCancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer lateCancel()
+	if lateSnapshot != "你好" || lateDone {
+		t.Fatalf("late snapshot=%q done=%v, want accumulated/false", lateSnapshot, lateDone)
+	}
+}
+
+func TestHubDropsOldRunEvents(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1", Delta: "old"})
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "new", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1", Delta: "-stale"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "new", Scope: ScopePersonal, TargetUserID: "u1", Delta: "new"})
+
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "new" || done {
+		t.Fatalf("snapshot=%q done=%v, want new/false", snapshot, done)
+	}
+}
+
+func TestHubDoneKeepsShortSnapshotThenExpires(t *testing.T) {
+	h := NewHub(20 * time.Millisecond)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: "done"})
+	h.Publish(Event{Type: EventDone, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	cancel()
+	if snapshot != "done" || !done {
+		t.Fatalf("snapshot=%q done=%v, want done snapshot/true", snapshot, done)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	_, snapshot, done, cancel = h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "" || done {
+		t.Fatalf("expired snapshot=%q done=%v, want empty/false", snapshot, done)
+	}
+}
+
+func TestHubUnfinishedIdleCleanup(t *testing.T) {
+	h := NewHub(time.Second)
+	h.idleTTL = 20 * time.Millisecond
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: "leak"})
+
+	time.Sleep(60 * time.Millisecond)
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "" || done {
+		t.Fatalf("idle-cleaned snapshot=%q done=%v, want empty/false", snapshot, done)
+	}
+}

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -200,8 +200,9 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 				})
 			}
 
+			generationTopic := m.proc.generationTopic(task)
 			reduceStart := time.Now()
-			content, tokens, err := m.proc.llm.CallReduceByPerson(ctx, participantSummaries, startTime, endTime, task.Title)
+			content, tokens, err := m.proc.llm.CallReduceByPerson(ctx, participantSummaries, startTime, endTime, generationTopic)
 			reportKey := "team#" + strconv.FormatInt(taskID, 10)
 			timing.RecordLLMSince(reportKey, "团队汇总: 合并各成员总结", reduceStart, tokens)
 			timing.FlushReport(reportKey, time.Since(reduceStart).Milliseconds(), nil)
@@ -262,10 +263,13 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 		// full version history. Determine isScheduled from the task's trigger type.
 		var metaTask model.SummaryTask
 		isScheduled := false
-		if err := m.proc.db.Select("trigger_type").First(&metaTask, taskID).Error; err != nil {
+		if err := m.proc.db.Select("trigger_type", "schedule_id", "title").First(&metaTask, taskID).Error; err != nil {
 			log.Printf("[meta-worker] task %d trigger_type lookup failed (defaulting isScheduled=false): %v", taskID, err)
 		} else {
 			isScheduled = metaTask.TriggerType == model.TriggerScheduled
+			if isScheduled {
+				result.OperationNote = m.proc.scheduledOperationNote(metaTask)
+			}
 		}
 		if err := saveLatestResultAndCompleteTask(m.proc.db, taskID, &result, isScheduled, snapshotContributorIDs); err != nil {
 			if errors.Is(err, errTaskNoLongerProcessing) {

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"gorm.io/gorm"
@@ -149,6 +150,28 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			return
 		}
 
+		runID := newSummaryRunID(taskID, "team")
+		teamStream := newSummaryStreamSender(ctx, m.proc.cfg, taskID, "", streaming.ScopeTeam, runID)
+		teamStreamFinalized := false
+		finishTeamDone := func() {
+			if teamStream != nil && !teamStreamFinalized {
+				teamStream.Done(model.StatusCompleted)
+				teamStreamFinalized = true
+			}
+		}
+		finishTeamError := func(message string) {
+			if teamStream != nil && !teamStreamFinalized {
+				teamStream.Error(message)
+				teamStreamFinalized = true
+			}
+		}
+		closeTeamStream := func() {
+			if teamStream != nil {
+				teamStream.Close()
+			}
+		}
+		teamStream.Stage(model.WorkflowStageGenerateSummary)
+
 		var finalContent string
 		var totalTokens int
 		var teamCitations []model.TeamCitation
@@ -157,6 +180,7 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			// Single submission: copy content directly, no LLM call
 			finalContent = submitted[0].Content
 			totalTokens = 0
+			_ = teamStream.Delta(finalContent)
 
 			var participant model.SummaryParticipant
 			m.proc.db.First(&participant, submitted[0].ParticipantRefID)
@@ -176,6 +200,8 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			var task model.SummaryTask
 			if err := m.proc.db.First(&task, taskID).Error; err != nil {
 				log.Printf("[meta-worker] task %d not found: %v", taskID, err)
+				finishTeamError("team summary task not found")
+				closeTeamStream()
 				return
 			}
 
@@ -202,12 +228,14 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 
 			generationTopic := m.proc.generationTopic(task)
 			reduceStart := time.Now()
-			content, tokens, err := m.proc.llm.CallReduceByPerson(ctx, participantSummaries, startTime, endTime, generationTopic)
+			content, tokens, err := m.proc.llm.CallReduceByPersonStream(ctx, participantSummaries, startTime, endTime, generationTopic, teamStream.Delta)
 			reportKey := "team#" + strconv.FormatInt(taskID, 10)
 			timing.RecordLLMSince(reportKey, "团队汇总: 合并各成员总结", reduceStart, tokens)
 			timing.FlushReport(reportKey, time.Since(reduceStart).Milliseconds(), nil)
 			if err != nil {
 				log.Printf("[meta-worker] reduce error task=%d: %v", taskID, err)
+				finishTeamError("team summary generation failed")
+				closeTeamStream()
 				return
 			}
 			finalContent = content
@@ -255,6 +283,8 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 		var taskCheck model.SummaryTask
 		if err := m.proc.db.Select("status").First(&taskCheck, taskID).Error; err != nil || taskCheck.Status != model.StatusProcessing {
 			log.Printf("[meta-worker] task %d no longer processing before result write, aborting", taskID)
+			finishTeamError("team summary task stopped before persistence")
+			closeTeamStream()
 			return
 		}
 
@@ -274,20 +304,29 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 		if err := saveLatestResultAndCompleteTask(m.proc.db, taskID, &result, isScheduled, snapshotContributorIDs); err != nil {
 			if errors.Is(err, errTaskNoLongerProcessing) {
 				log.Printf("[meta-worker] task %d status changed during processing (likely cancelled), skipping completion", taskID)
+				finishTeamError("team summary task stopped during persistence")
+				closeTeamStream()
 				return
 			}
 			if errors.Is(err, errRosterChangedDuringMerge) {
 				rosterRetries++
 				if rosterRetries > maxRosterRetries {
 					log.Printf("[meta-worker] task %d: exceeded roster-recompute retries (%d), aborting to avoid livelock", taskID, maxRosterRetries)
+					finishTeamError("team summary roster changed too often")
+					closeTeamStream()
 					return
 				}
 				log.Printf("[meta-worker] task %d: contributor roster changed during merge (member left/removed); recomputing with the updated roster (attempt %d)", taskID, rosterRetries)
+				closeTeamStream()
 				continue // re-read submitted snapshot at loop top and re-aggregate with the new roster
 			}
 			log.Printf("[meta-worker] save result error task=%d: %v", taskID, err)
+			finishTeamError("team summary persistence failed")
+			closeTeamStream()
 			return
 		}
+		finishTeamDone()
+		closeTeamStream()
 
 		// Send WS notification (META_SUMMARY_UPDATED, broadcast to all)
 		m.proc.sendCallback(model.TaskEvent{

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -81,8 +81,57 @@ func (p *Processor) updatePersonalWorkflowStage(personalResultID int64, stage st
 	}
 }
 
+func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr model.PersonalResult, content string, citations []model.Citation, msgCount, totalTokens int, modelVer string, genAt time.Time, skipContent bool) error {
+	updates := completedPersonalResultUpdates(pr, content, citations, msgCount, totalTokens, modelVer, genAt, skipContent)
+	if skipContent {
+		return p.db.Model(&pr).Updates(updates).Error
+	}
+
+	return p.db.Transaction(func(tx *gorm.DB) error {
+		nextVer, err := service.GetNextPersonalVersion(tx, pr.TaskID, pr.UserID)
+		if err != nil {
+			return err
+		}
+		operationType := "regenerate"
+		if nextVer <= 1 {
+			operationType = "generate"
+		} else if task.TriggerType == model.TriggerScheduled {
+			operationType = "scheduled_generate"
+		}
+
+		version := model.PersonalResultVersion{
+			TaskID:           pr.TaskID,
+			ParticipantRefID: pr.ParticipantRefID,
+			UserID:           pr.UserID,
+			Content:          content,
+			MsgCount:         msgCount,
+			TotalTokenUsed:   totalTokens,
+			ModelVersion:     modelVer,
+			Version:          nextVer,
+			OperationType:    operationType,
+			OperationNote:    task.Title,
+			CreatedBy:        pr.UserID,
+			GeneratedAt:      genAt,
+		}
+		version.SetCitations(citations)
+		if err := tx.Create(&version).Error; err != nil {
+			return err
+		}
+		updates["current_version_id"] = version.ID
+		return tx.Model(&pr).Updates(updates).Error
+	})
+}
+
 func (p *Processor) processPersonalSummary(ctx context.Context, taskID, participantRefID int64) {
-	log.Printf("[personal-worker] start task=%d participant=%d", taskID, participantRefID)
+	p.processPersonalSummaryWithOptions(ctx, taskID, participantRefID, false)
+}
+
+func (p *Processor) processPersonalSummaryAllowCompleted(ctx context.Context, taskID, participantRefID int64) {
+	p.processPersonalSummaryWithOptions(ctx, taskID, participantRefID, true)
+}
+
+func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskID, participantRefID int64, allowCompletedTask bool) {
+	log.Printf("[personal-worker] start task=%d participant=%d allow_completed=%t", taskID, participantRefID, allowCompletedTask)
 
 	// Load participant
 	var participant model.SummaryParticipant
@@ -112,7 +161,11 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		"worker_started_at": now,
 	})
 
-	// CAS update task status to PROCESSING (from any earlier state)
+	// CAS update task status to PROCESSING (from any earlier state).
+	// personal_regenerate is allowed to run against an already-Completed task
+	// without flipping the whole task back to Processing; the user will explicitly
+	// submit the regenerated personal result later, and Submit revives the task for
+	// meta recompute at that point.
 	deadline := timezone.Now().Add(time.Duration(p.cfg.WorkerLeaseMinutes) * time.Minute)
 	taskCAS := p.db.Model(&model.SummaryTask{}).
 		Where("id = ? AND status IN (?, ?)", taskID, model.StatusPending, model.StatusWaitingConfirm).
@@ -126,13 +179,16 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	}
 	if taskCAS.RowsAffected == 0 {
 		var currentTask model.SummaryTask
-		if err := p.db.Select("status").First(&currentTask, taskID).Error; err != nil || currentTask.Status != model.StatusProcessing {
-			log.Printf("[personal-worker] task=%d not in processing state, aborting", taskID)
+		if err := p.db.Select("status").First(&currentTask, taskID).Error; err != nil ||
+			(currentTask.Status != model.StatusProcessing && !(allowCompletedTask && currentTask.Status == model.StatusCompleted)) {
+			log.Printf("[personal-worker] task=%d not in runnable state, aborting", taskID)
 			return
 		}
-		// Refresh deadline for already-processing task (prevents scheduler false-positive)
-		p.db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
-			Update("processing_deadline", deadline)
+		if currentTask.Status == model.StatusProcessing {
+			// Refresh deadline for already-processing task (prevents scheduler false-positive)
+			p.db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
+				Update("processing_deadline", deadline)
+		}
 	}
 
 	// Load task
@@ -204,14 +260,18 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	// Best-effort check: abort early if task is no longer Processing.
 	// Final safety is guaranteed by the task-level CAS in the completion path below.
 	var taskCheck model.SummaryTask
-	if err := p.db.Select("status").First(&taskCheck, taskID).Error; err != nil || taskCheck.Status != model.StatusProcessing {
-		log.Printf("[personal-worker] task=%d no longer processing before result write, aborting", taskID)
+	if err := p.db.Select("status").First(&taskCheck, taskID).Error; err != nil ||
+		(taskCheck.Status != model.StatusProcessing && !(allowCompletedTask && taskCheck.Status == model.StatusCompleted)) {
+		log.Printf("[personal-worker] task=%d no longer runnable before result write, aborting", taskID)
 		return
 	}
 
 	genAt := timezone.Now()
 	persistStart := time.Now()
-	p.db.Model(&pr).Updates(completedPersonalResultUpdates(pr, content, citations, msgCount, totalTokens, modelVer, genAt, isScheduledEmptyWindow))
+	if err := p.persistCompletedPersonalResult(task, pr, content, citations, msgCount, totalTokens, modelVer, genAt, isScheduledEmptyWindow); err != nil {
+		log.Printf("[personal-worker] persist personal result task=%d pr=%d: %v", taskID, pr.ID, err)
+		return
+	}
 	p.db.Model(&participant).Updates(map[string]interface{}{
 		"status": model.ParticipantCompleted,
 	})
@@ -275,6 +335,11 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
 		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
+	} else if allowCompletedTask && taskCheck.Status == model.StatusCompleted {
+		// Personal-only regenerate: keep the team summary as-is until the user
+		// explicitly submits this regenerated personal result. Submit will revive
+		// the task and trigger meta recompute.
+		log.Printf("[personal-worker] task=%d user=%s personal regenerate completed; waiting for submit", taskID, participant.UserID)
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
 		//
@@ -287,8 +352,8 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		// submit_source=2 (system) when the participant has confirmed (status NOT IN
 		// Pending,Declined -- same gate as meta's totalAccepted), idempotently
 		// (WHERE submitted_at IS NULL, so a racing manual /submit is never overwritten).
-		if task.TriggerType == model.TriggerScheduled {
-			p.backfillScheduledSubmittedAt(taskID, &pr)
+		if task.TriggerType == model.TriggerScheduled || pr.SubmitSource == model.SubmitSourceSystem {
+			p.backfillSystemSubmittedAt(taskID, &pr)
 		}
 		p.meta.TriggerMetaSummary(taskID)
 	}
@@ -296,8 +361,8 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	log.Printf("[personal-worker] completed task=%d user=%s msgs=%d", taskID, participant.UserID, msgCount)
 }
 
-// backfillScheduledSubmittedAt system-back-fills submitted_at for a scheduled
-// multi-person personal result so the meta gate (submitted_at IS NOT NULL) can
+// backfillSystemSubmittedAt system-back-fills submitted_at for a scheduled
+// or task-level-regenerated multi-person personal result so the meta gate (submitted_at IS NOT NULL) can
 // progress without a manual /submit (§4.4-2). It runs in a single transaction:
 //   - re-reads the participant's current status under the same tx (the confirm
 //     gate must reflect committed state, not the in-memory pr loaded earlier);
@@ -309,7 +374,7 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 //
 // participantCount>1 is the caller's branch invariant (this is only reached from
 // the multi-person path), so it is not re-checked here.
-func (p *Processor) backfillScheduledSubmittedAt(taskID int64, pr *model.PersonalResult) {
+func (p *Processor) backfillSystemSubmittedAt(taskID int64, pr *model.PersonalResult) {
 	now := timezone.Now()
 	err := p.db.Transaction(func(tx *gorm.DB) error {
 		var status int

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -100,10 +100,12 @@ func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr mo
 			return err
 		}
 		operationType := "regenerate"
+		operationNote := task.Title
 		if nextVer <= 1 {
 			operationType = "generate"
 		} else if task.TriggerType == model.TriggerScheduled {
 			operationType = "scheduled_generate"
+			operationNote = p.scheduledOperationNote(task)
 		}
 
 		version := model.PersonalResultVersion{
@@ -116,7 +118,7 @@ func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr mo
 			ModelVersion:     modelVer,
 			Version:          nextVer,
 			OperationType:    operationType,
-			OperationNote:    task.Title,
+			OperationNote:    operationNote,
 			CreatedBy:        lockedPR.UserID,
 			GeneratedAt:      genAt,
 		}
@@ -886,6 +888,8 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		userName = userID
 	}
 
+	generationTopic := p.generationTopic(task)
+
 	var finalContent string
 	var totalTokens int
 
@@ -907,7 +911,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		var err error
 		finalContent, totalTokens, err = p.llm.CallMap(ctx,
 			joinStrings(formatted), sourceName, 0, len(userMessages),
-			startTime, endTime, task.Title, userName,
+			startTime, endTime, generationTopic, userName,
 		)
 		timing.RecordLLMSince(taskNo, "Map: 单次总结(跳过Map-Reduce)", mapCallStart, totalTokens)
 		timing.Observe(taskNo, "llm_map_summary", mapStart)
@@ -968,7 +972,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 				callStart := time.Now()
 				summary, tokens, err := p.llm.CallMap(ctx,
 					joinStrings(formatted), sourceName, idx, len(c),
-					startTime, endTime, task.Title, userName,
+					startTime, endTime, generationTopic, userName,
 				)
 				timing.RecordLLMSince(taskNo, fmt.Sprintf("Map: 分块总结 chunk#%d", idx), callStart, tokens)
 				if err != nil {
@@ -1029,7 +1033,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 			var err error
 			reduceCallStart := time.Now()
 			finalContent, reduceTokens, err = p.llm.CallReduce(ctx,
-				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, task.Title,
+				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, generationTopic,
 			)
 			timing.RecordLLMSince(taskNo, "Reduce: 合并分块总结", reduceCallStart, reduceTokens)
 			if err != nil {

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/tokenizer"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func escapeCitationMarkers(content string) string {
@@ -81,8 +82,89 @@ func (p *Processor) updatePersonalWorkflowStage(personalResultID int64, stage st
 	}
 }
 
+func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr model.PersonalResult, content string, citations []model.Citation, msgCount, totalTokens int, modelVer string, genAt time.Time, skipContent bool) error {
+	updates := completedPersonalResultUpdates(pr, content, citations, msgCount, totalTokens, modelVer, genAt, skipContent)
+	if skipContent {
+		return p.db.Transaction(func(tx *gorm.DB) error {
+			var lockedPR model.PersonalResult
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+				Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, pr.TaskID, pr.UserID).
+				First(&lockedPR).Error; err != nil {
+				return err
+			}
+			var latest model.PersonalResultVersion
+			if err := tx.Where("task_id = ? AND user_id = ?", lockedPR.TaskID, lockedPR.UserID).
+				Order("version DESC").Order("id DESC").First(&latest).Error; err == nil {
+				updates["content"] = latest.Content
+				updates["citations_json"] = latest.CitationsJSON
+				updates["msg_count"] = latest.MsgCount
+				updates["total_token_used"] = latest.TotalTokenUsed
+				updates["model_version"] = latest.ModelVersion
+				updates["current_version_id"] = latest.ID
+				updates["generated_at"] = latest.GeneratedAt
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return err
+			}
+			return tx.Model(&lockedPR).Updates(updates).Error
+		})
+	}
+
+	return p.db.Transaction(func(tx *gorm.DB) error {
+		var lockedPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, pr.TaskID, pr.UserID).
+			First(&lockedPR).Error; err != nil {
+			return err
+		}
+		nextVer, err := service.GetNextPersonalVersion(tx, lockedPR.TaskID, lockedPR.UserID)
+		if err != nil {
+			return err
+		}
+		operationType := "regenerate"
+		operationNote := task.Title
+		if nextVer <= 1 {
+			operationType = "generate"
+		} else if task.TriggerType == model.TriggerScheduled {
+			operationType = "scheduled_generate"
+			operationNote = p.scheduledOperationNote(task)
+		}
+
+		version := model.PersonalResultVersion{
+			TaskID:           lockedPR.TaskID,
+			ParticipantRefID: lockedPR.ParticipantRefID,
+			UserID:           lockedPR.UserID,
+			Content:          content,
+			MsgCount:         msgCount,
+			TotalTokenUsed:   totalTokens,
+			ModelVersion:     modelVer,
+			Version:          nextVer,
+			OperationType:    operationType,
+			OperationNote:    operationNote,
+			CreatedBy:        lockedPR.UserID,
+			GeneratedAt:      genAt,
+		}
+		version.SetCitations(citations)
+		if err := tx.Create(&version).Error; err != nil {
+			return err
+		}
+		updates["current_version_id"] = version.ID
+		if err := tx.Model(&lockedPR).Updates(updates).Error; err != nil {
+			return err
+		}
+		return service.PrunePersonalResultVersions(tx, lockedPR.TaskID, lockedPR.UserID, service.PersonalResultVersionKeepLimit)
+	})
+}
+
 func (p *Processor) processPersonalSummary(ctx context.Context, taskID, participantRefID int64) {
-	log.Printf("[personal-worker] start task=%d participant=%d", taskID, participantRefID)
+	p.processPersonalSummaryWithOptions(ctx, taskID, participantRefID, false)
+}
+
+func (p *Processor) processPersonalSummaryAllowCompleted(ctx context.Context, taskID, participantRefID int64) {
+	p.processPersonalSummaryWithOptions(ctx, taskID, participantRefID, true)
+}
+
+func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskID, participantRefID int64, allowCompletedTask bool) {
+	log.Printf("[personal-worker] start task=%d participant=%d allow_completed=%t", taskID, participantRefID, allowCompletedTask)
 
 	// Load participant
 	var participant model.SummaryParticipant
@@ -112,7 +194,11 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		"worker_started_at": now,
 	})
 
-	// CAS update task status to PROCESSING (from any earlier state)
+	// CAS update task status to PROCESSING (from any earlier state).
+	// personal_regenerate is allowed to run against an already-Completed task
+	// without flipping the whole task back to Processing; the user will explicitly
+	// submit the regenerated personal result later, and Submit revives the task for
+	// meta recompute at that point.
 	deadline := timezone.Now().Add(time.Duration(p.cfg.WorkerLeaseMinutes) * time.Minute)
 	taskCAS := p.db.Model(&model.SummaryTask{}).
 		Where("id = ? AND status IN (?, ?)", taskID, model.StatusPending, model.StatusWaitingConfirm).
@@ -126,13 +212,16 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	}
 	if taskCAS.RowsAffected == 0 {
 		var currentTask model.SummaryTask
-		if err := p.db.Select("status").First(&currentTask, taskID).Error; err != nil || currentTask.Status != model.StatusProcessing {
-			log.Printf("[personal-worker] task=%d not in processing state, aborting", taskID)
+		if err := p.db.Select("status").First(&currentTask, taskID).Error; err != nil ||
+			(currentTask.Status != model.StatusProcessing && !(allowCompletedTask && currentTask.Status == model.StatusCompleted)) {
+			log.Printf("[personal-worker] task=%d not in runnable state, aborting", taskID)
 			return
 		}
-		// Refresh deadline for already-processing task (prevents scheduler false-positive)
-		p.db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
-			Update("processing_deadline", deadline)
+		if currentTask.Status == model.StatusProcessing {
+			// Refresh deadline for already-processing task (prevents scheduler false-positive)
+			p.db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
+				Update("processing_deadline", deadline)
+		}
 	}
 
 	// Load task
@@ -204,14 +293,18 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	// Best-effort check: abort early if task is no longer Processing.
 	// Final safety is guaranteed by the task-level CAS in the completion path below.
 	var taskCheck model.SummaryTask
-	if err := p.db.Select("status").First(&taskCheck, taskID).Error; err != nil || taskCheck.Status != model.StatusProcessing {
-		log.Printf("[personal-worker] task=%d no longer processing before result write, aborting", taskID)
+	if err := p.db.Select("status").First(&taskCheck, taskID).Error; err != nil ||
+		(taskCheck.Status != model.StatusProcessing && !(allowCompletedTask && taskCheck.Status == model.StatusCompleted)) {
+		log.Printf("[personal-worker] task=%d no longer runnable before result write, aborting", taskID)
 		return
 	}
 
 	genAt := timezone.Now()
 	persistStart := time.Now()
-	p.db.Model(&pr).Updates(completedPersonalResultUpdates(pr, content, citations, msgCount, totalTokens, modelVer, genAt, isScheduledEmptyWindow))
+	if err := p.persistCompletedPersonalResult(task, pr, content, citations, msgCount, totalTokens, modelVer, genAt, isScheduledEmptyWindow); err != nil {
+		log.Printf("[personal-worker] persist personal result task=%d pr=%d: %v", taskID, pr.ID, err)
+		return
+	}
 	p.db.Model(&participant).Updates(map[string]interface{}{
 		"status": model.ParticipantCompleted,
 	})
@@ -275,6 +368,11 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
 		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
+	} else if allowCompletedTask && taskCheck.Status == model.StatusCompleted {
+		// Personal-only regenerate: keep the team summary as-is until the user
+		// explicitly submits this regenerated personal result. Submit will revive
+		// the task and trigger meta recompute.
+		log.Printf("[personal-worker] task=%d user=%s personal regenerate completed; waiting for submit", taskID, participant.UserID)
 	} else {
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
 		//
@@ -287,8 +385,8 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 		// submit_source=2 (system) when the participant has confirmed (status NOT IN
 		// Pending,Declined -- same gate as meta's totalAccepted), idempotently
 		// (WHERE submitted_at IS NULL, so a racing manual /submit is never overwritten).
-		if task.TriggerType == model.TriggerScheduled {
-			p.backfillScheduledSubmittedAt(taskID, &pr)
+		if task.TriggerType == model.TriggerScheduled || pr.SubmitSource == model.SubmitSourceSystem {
+			p.backfillSystemSubmittedAt(taskID, &pr)
 		}
 		p.meta.TriggerMetaSummary(taskID)
 	}
@@ -296,8 +394,8 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 	log.Printf("[personal-worker] completed task=%d user=%s msgs=%d", taskID, participant.UserID, msgCount)
 }
 
-// backfillScheduledSubmittedAt system-back-fills submitted_at for a scheduled
-// multi-person personal result so the meta gate (submitted_at IS NOT NULL) can
+// backfillSystemSubmittedAt system-back-fills submitted_at for a scheduled
+// or task-level-regenerated multi-person personal result so the meta gate (submitted_at IS NOT NULL) can
 // progress without a manual /submit (§4.4-2). It runs in a single transaction:
 //   - re-reads the participant's current status under the same tx (the confirm
 //     gate must reflect committed state, not the in-memory pr loaded earlier);
@@ -309,7 +407,7 @@ func (p *Processor) processPersonalSummary(ctx context.Context, taskID, particip
 //
 // participantCount>1 is the caller's branch invariant (this is only reached from
 // the multi-person path), so it is not re-checked here.
-func (p *Processor) backfillScheduledSubmittedAt(taskID int64, pr *model.PersonalResult) {
+func (p *Processor) backfillSystemSubmittedAt(taskID int64, pr *model.PersonalResult) {
 	now := timezone.Now()
 	err := p.db.Transaction(func(tx *gorm.DB) error {
 		var status int
@@ -811,6 +909,8 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		userName = userID
 	}
 
+	generationTopic := p.generationTopic(task)
+
 	var finalContent string
 	var totalTokens int
 
@@ -832,7 +932,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		var err error
 		finalContent, totalTokens, err = p.llm.CallMap(ctx,
 			joinStrings(formatted), sourceName, 0, len(userMessages),
-			startTime, endTime, task.Title, userName,
+			startTime, endTime, generationTopic, userName,
 		)
 		timing.RecordLLMSince(taskNo, "Map: 单次总结(跳过Map-Reduce)", mapCallStart, totalTokens)
 		timing.Observe(taskNo, "llm_map_summary", mapStart)
@@ -893,7 +993,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 				callStart := time.Now()
 				summary, tokens, err := p.llm.CallMap(ctx,
 					joinStrings(formatted), sourceName, idx, len(c),
-					startTime, endTime, task.Title, userName,
+					startTime, endTime, generationTopic, userName,
 				)
 				timing.RecordLLMSince(taskNo, fmt.Sprintf("Map: 分块总结 chunk#%d", idx), callStart, tokens)
 				if err != nil {
@@ -954,7 +1054,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 			var err error
 			reduceCallStart := time.Now()
 			finalContent, reduceTokens, err = p.llm.CallReduce(ctx,
-				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, task.Title,
+				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, generationTopic,
 			)
 			timing.RecordLLMSince(taskNo, "Reduce: 合并分块总结", reduceCallStart, reduceTokens)
 			if err != nil {

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/tokenizer"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func escapeCitationMarkers(content string) string {
@@ -88,7 +89,13 @@ func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr mo
 	}
 
 	return p.db.Transaction(func(tx *gorm.DB) error {
-		nextVer, err := service.GetNextPersonalVersion(tx, pr.TaskID, pr.UserID)
+		var lockedPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, pr.TaskID, pr.UserID).
+			First(&lockedPR).Error; err != nil {
+			return err
+		}
+		nextVer, err := service.GetNextPersonalVersion(tx, lockedPR.TaskID, lockedPR.UserID)
 		if err != nil {
 			return err
 		}
@@ -100,9 +107,9 @@ func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr mo
 		}
 
 		version := model.PersonalResultVersion{
-			TaskID:           pr.TaskID,
-			ParticipantRefID: pr.ParticipantRefID,
-			UserID:           pr.UserID,
+			TaskID:           lockedPR.TaskID,
+			ParticipantRefID: lockedPR.ParticipantRefID,
+			UserID:           lockedPR.UserID,
 			Content:          content,
 			MsgCount:         msgCount,
 			TotalTokenUsed:   totalTokens,
@@ -110,7 +117,7 @@ func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr mo
 			Version:          nextVer,
 			OperationType:    operationType,
 			OperationNote:    task.Title,
-			CreatedBy:        pr.UserID,
+			CreatedBy:        lockedPR.UserID,
 			GeneratedAt:      genAt,
 		}
 		version.SetCitations(citations)
@@ -118,7 +125,10 @@ func (p *Processor) persistCompletedPersonalResult(task model.SummaryTask, pr mo
 			return err
 		}
 		updates["current_version_id"] = version.ID
-		return tx.Model(&pr).Updates(updates).Error
+		if err := tx.Model(&lockedPR).Updates(updates).Error; err != nil {
+			return err
+		}
+		return service.PrunePersonalResultVersions(tx, lockedPR.TaskID, lockedPR.UserID, service.PersonalResultVersionKeepLimit)
 	})
 }
 

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/tokenizer"
@@ -255,6 +256,32 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 
 	workerStartAt := now
 	lastWorkflowStageAt := workerStartAt
+	runID := newSummaryRunID(taskID, participant.UserID)
+	var streamSender *summaryStreamSender
+	streamFinalized := false
+	ensureStream := func() *summaryStreamSender {
+		if streamSender == nil {
+			streamSender = newSummaryStreamSender(ctx, p.cfg, taskID, participant.UserID, streaming.ScopePersonal, runID)
+		}
+		return streamSender
+	}
+	finishStreamDone := func(status int) {
+		if streamSender != nil && !streamFinalized {
+			streamSender.Done(status)
+			streamFinalized = true
+		}
+	}
+	finishStreamError := func(message string) {
+		if streamSender != nil && !streamFinalized {
+			streamSender.Error(message)
+			streamFinalized = true
+		}
+	}
+	defer func() {
+		if streamSender != nil {
+			streamSender.Close()
+		}
+	}()
 	reportStage := func(stage string) {
 		stageAt := timezone.Now()
 		sinceWorkerStartMs := stageAt.Sub(workerStartAt).Milliseconds()
@@ -276,12 +303,20 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 		log.Printf("[personal-worker] workflow stage task=%s pr=%d stage=%s since_worker_start=%dms delta=%dms",
 			task.TaskNo, pr.ID, stage, sinceWorkerStartMs, deltaMs)
 		p.updatePersonalWorkflowStage(pr.ID, stage)
+		if stage == model.WorkflowStageGenerateSummary {
+			ensureStream().Stage(stage)
+		}
+	}
+
+	streamDelta := func(delta string) error {
+		return ensureStream().Delta(delta)
 	}
 
 	// Execute pipeline
-	content, citations, msgCount, totalTokens, modelVer, err := p.executePersonalPipeline(ctx, task, participant.UserID, reportStage)
+	content, citations, msgCount, totalTokens, modelVer, err := p.executePersonalPipeline(ctx, task, participant.UserID, reportStage, streamDelta)
 	if err != nil {
 		log.Printf("[personal-worker] pipeline error task=%d user=%s: %v", taskID, participant.UserID, err)
+		finishStreamError("summary generation failed")
 		p.markPersonalFailed(&pr, &participant, err.Error())
 		return
 	}
@@ -303,6 +338,7 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 	persistStart := time.Now()
 	if err := p.persistCompletedPersonalResult(task, pr, content, citations, msgCount, totalTokens, modelVer, genAt, isScheduledEmptyWindow); err != nil {
 		log.Printf("[personal-worker] persist personal result task=%d pr=%d: %v", taskID, pr.ID, err)
+		finishStreamError("summary persistence failed")
 		return
 	}
 	p.db.Model(&participant).Updates(map[string]interface{}{
@@ -364,16 +400,19 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 			Progress: 100,
 			Message:  "总结完成",
 		})
+		finishStreamDone(model.StatusCompleted)
 		// Task durably reached Completed above (saveLatestResultAndCompleteTask /
 		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
 		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
 	} else if allowCompletedTask && taskCheck.Status == model.StatusCompleted {
+		finishStreamDone(model.StatusCompleted)
 		// Personal-only regenerate: keep the team summary as-is until the user
 		// explicitly submits this regenerated personal result. Submit will revive
 		// the task and trigger meta recompute.
 		log.Printf("[personal-worker] task=%d user=%s personal regenerate completed; waiting for submit", taskID, participant.UserID)
 	} else {
+		finishStreamDone(model.StatusProcessing)
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
 		//
 		// System back-fill of submitted_at: the meta completion gate
@@ -606,7 +645,7 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }
 
-func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string)) (string, []model.Citation, int, int, string, error) {
+func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string), streamDelta func(string) error) (string, []model.Citation, int, int, string, error) {
 	totalStart := time.Now()
 	taskNo := task.TaskNo
 	defer func() {
@@ -930,9 +969,9 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		mapStart := time.Now()
 		mapCallStart := time.Now()
 		var err error
-		finalContent, totalTokens, err = p.llm.CallMap(ctx,
+		finalContent, totalTokens, err = p.llm.CallMapStream(ctx,
 			joinStrings(formatted), sourceName, 0, len(userMessages),
-			startTime, endTime, generationTopic, userName,
+			startTime, endTime, generationTopic, userName, streamDelta,
 		)
 		timing.RecordLLMSince(taskNo, "Map: 单次总结(跳过Map-Reduce)", mapCallStart, totalTokens)
 		timing.Observe(taskNo, "llm_map_summary", mapStart)
@@ -991,10 +1030,20 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 				}
 
 				callStart := time.Now()
-				summary, tokens, err := p.llm.CallMap(ctx,
-					joinStrings(formatted), sourceName, idx, len(c),
-					startTime, endTime, generationTopic, userName,
-				)
+				var summary string
+				var tokens int
+				var err error
+				if len(chunks) == 1 {
+					summary, tokens, err = p.llm.CallMapStream(ctx,
+						joinStrings(formatted), sourceName, idx, len(c),
+						startTime, endTime, generationTopic, userName, streamDelta,
+					)
+				} else {
+					summary, tokens, err = p.llm.CallMap(ctx,
+						joinStrings(formatted), sourceName, idx, len(c),
+						startTime, endTime, generationTopic, userName,
+					)
+				}
 				timing.RecordLLMSince(taskNo, fmt.Sprintf("Map: 分块总结 chunk#%d", idx), callStart, tokens)
 				if err != nil {
 					log.Printf("[personal-worker] Map chunk %d failed: %v", idx, err)
@@ -1053,8 +1102,8 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 			// Multiple chunks: execute Reduce to merge
 			var err error
 			reduceCallStart := time.Now()
-			finalContent, reduceTokens, err = p.llm.CallReduce(ctx,
-				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, generationTopic,
+			finalContent, reduceTokens, err = p.llm.CallReduceStream(ctx,
+				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, generationTopic, streamDelta,
 			)
 			timing.RecordLLMSince(taskNo, "Reduce: 合并分块总结", reduceCallStart, reduceTokens)
 			if err != nil {

--- a/internal/worker/personal_processor_test.go
+++ b/internal/worker/personal_processor_test.go
@@ -192,7 +192,7 @@ func TestBackfillSubmittedAt_SchedAccepted_BackfillsSystemSource(t *testing.T) {
 	}
 
 	p := &Processor{db: db}
-	p.backfillScheduledSubmittedAt(task.ID, &pr)
+	p.backfillSystemSubmittedAt(task.ID, &pr)
 
 	var got model.PersonalResult
 	if err := db.First(&got, pr.ID).Error; err != nil {
@@ -231,7 +231,7 @@ func TestBackfillSubmittedAt_DeclinedParticipant_NotBackfilled(t *testing.T) {
 	}
 
 	p := &Processor{db: db}
-	p.backfillScheduledSubmittedAt(task.ID, &pr)
+	p.backfillSystemSubmittedAt(task.ID, &pr)
 
 	var got model.PersonalResult
 	if err := db.First(&got, pr.ID).Error; err != nil {
@@ -273,7 +273,7 @@ func TestBackfillSubmittedAt_AlreadySubmitted_Idempotent(t *testing.T) {
 	}
 
 	p := &Processor{db: db}
-	p.backfillScheduledSubmittedAt(task.ID, &pr)
+	p.backfillSystemSubmittedAt(task.ID, &pr)
 
 	var got model.PersonalResult
 	if err := db.First(&got, pr.ID).Error; err != nil {

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -182,6 +182,10 @@ func (p *Processor) handleTrigger(req model.WorkerTriggerRequest) {
 		p.pool.Submit(func() {
 			p.processPersonalSummary(context.Background(), req.TaskID, req.ParticipantRefID)
 		})
+	case "personal_regenerate":
+		p.pool.Submit(func() {
+			p.processPersonalSummaryAllowCompleted(context.Background(), req.TaskID, req.ParticipantRefID)
+		})
 	case "meta_summary":
 		p.meta.TriggerMetaSummary(req.TaskID)
 	default:

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -388,6 +388,46 @@ func (p *Processor) processTask(task model.SummaryTask) {
 	}
 
 	if participantCount <= 1 {
+		var participants []model.SummaryParticipant
+		p.db.Where("task_id = ?", task.ID).Find(&participants)
+
+		// Scheduled single-person tasks must not depend on the best-effort
+		// processing_deadline refresh. The multi-person scheduled path already
+		// dispatches before refreshing the deadline for the same reason: a racing
+		// stuck-scan/claim can make the CAS miss even though this run is still
+		// valid. If we return on that miss, the task stays visually stuck at the
+		// first workflow step because no personal worker is ever dispatched.
+		if task.TriggerType == model.TriggerScheduled {
+			for _, pt := range participants {
+				p.db.Model(&model.SummaryParticipant{}).Where("id = ?", pt.ID).
+					Update("status", model.ParticipantAccepted)
+				ptID := pt.ID
+				p.dispatchPersonal(task.ID, ptID)
+			}
+
+			casResult := p.db.Model(&model.SummaryTask{}).
+				Where("id = ? AND status = ?", task.ID, model.StatusProcessing).
+				Updates(map[string]interface{}{
+					"processing_deadline": timezone.Now().Add(time.Duration(p.cfg.WorkerLeaseMinutes) * time.Minute),
+				})
+			if casResult.Error != nil {
+				log.Printf("[processor] task %d scheduled single deadline refresh failed (dispatch already done): %v", task.ID, casResult.Error)
+			} else if casResult.RowsAffected == 0 {
+				var cur model.SummaryTask
+				if err := p.db.Select("status").First(&cur, task.ID).Error; err == nil {
+					log.Printf("[processor] task %d scheduled single deadline refresh missed (status=%d); dispatch already issued for %d participant(s)", task.ID, cur.Status, len(participants))
+				}
+			}
+			p.sendCallback(model.TaskEvent{
+				TaskID:   task.ID,
+				Status:   model.StatusProcessing,
+				Progress: 50,
+				Message:  "单人模式，自动处理中",
+			})
+			log.Printf("[processor] task %d scheduled single participant, dispatched %d participant(s)", task.ID, len(participants))
+			return
+		}
+
 		casResult := p.db.Model(&model.SummaryTask{}).
 			Where("id = ? AND status = ?", task.ID, model.StatusProcessing).
 			Updates(map[string]interface{}{
@@ -398,11 +438,16 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			return
 		}
 		if casResult.RowsAffected == 0 {
-			log.Printf("[processor] task %d status changed (likely cancelled), skipping dispatch", task.ID)
-			return
+			var cur model.SummaryTask
+			if err := p.db.Select("status").First(&cur, task.ID).Error; err != nil {
+				log.Printf("[processor] task %d status reload failed after CAS miss: %v", task.ID, err)
+				return
+			}
+			if cur.Status != model.StatusProcessing {
+				log.Printf("[processor] task %d no longer Processing (status=%d), skipping single dispatch", task.ID, cur.Status)
+				return
+			}
 		}
-		var participants []model.SummaryParticipant
-		p.db.Where("task_id = ?", task.ID).Find(&participants)
 		for _, pt := range participants {
 			p.db.Model(&model.SummaryParticipant{}).Where("id = ?", pt.ID).
 				Update("status", model.ParticipantAccepted)

--- a/internal/worker/schedule_instruction.go
+++ b/internal/worker/schedule_instruction.go
@@ -1,0 +1,40 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+func (p *Processor) scheduleGenerationInstruction(task model.SummaryTask) string {
+	if task.TriggerType != model.TriggerScheduled || task.ScheduleID == nil {
+		return ""
+	}
+	var sched model.SummarySchedule
+	if err := p.db.Select("generation_instruction").
+		Where("id = ? AND deleted_at IS NULL", *task.ScheduleID).
+		First(&sched).Error; err != nil {
+		return ""
+	}
+	return strings.TrimSpace(sched.GenerationInstruction)
+}
+
+func (p *Processor) generationTopic(task model.SummaryTask) string {
+	instruction := p.scheduleGenerationInstruction(task)
+	if instruction == "" {
+		return task.Title
+	}
+	if strings.TrimSpace(task.Title) == "" {
+		return instruction
+	}
+	return fmt.Sprintf("%s\n\n定时生成要求：\n%s", task.Title, instruction)
+}
+
+func (p *Processor) scheduledOperationNote(task model.SummaryTask) string {
+	instruction := p.scheduleGenerationInstruction(task)
+	if instruction != "" {
+		return instruction
+	}
+	return task.Title
+}

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -421,15 +421,10 @@ func saveLatestResultAndCompleteTask(db *gorm.DB, taskID int64, result *model.Su
 			return err
 		}
 		if isScheduled {
-			// Scheduled-only: prune stale auto-generated prior-cycle versions after
-			// the replacement result is durably inserted. Hand-edited rows
-			// (edited_at IS NOT NULL) are retained permanently as user data, even
-			// across later scheduled cycles.
-			if err := tx.Where("task_id = ? AND id <> ? AND edited_at IS NULL", taskID, result.ID).Delete(&model.SummaryResult{}).Error; err != nil {
-				return err
-			}
-			// summary_chunk currently has no version column, so cleanup must happen
-			// only after the replacement result is durably inserted.
+			// Scheduled runs are versioned on the same task. Keep prior summary_result
+			// rows so the detail page can show scheduled_generate entries in Recent
+			// versions. summary_chunk has no version column, so only transient chunks
+			// are replaced after the new result is durably inserted.
 			if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryChunk{}).Error; err != nil {
 				return err
 			}

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -399,22 +399,38 @@ func saveLatestResultAndCompleteTask(db *gorm.DB, taskID int64, result *model.Su
 		}
 		result.TaskID = taskID
 		result.Version = nextVer
+		if result.OperationType == "" {
+			if nextVer <= 1 {
+				result.OperationType = "generate"
+			} else if isScheduled {
+				result.OperationType = "scheduled_generate"
+			} else {
+				result.OperationType = "regenerate"
+			}
+		}
+		if result.OperationNote == "" && result.OperationType != "scheduled_generate" {
+			var task model.SummaryTask
+			if err := tx.Select("title").Where("id = ?", taskID).First(&task).Error; err == nil {
+				result.OperationNote = task.Title
+			}
+		}
 		if err := tx.Create(result).Error; err != nil {
 			return err
 		}
+		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", result.ID).Error; err != nil {
+			return err
+		}
 		if isScheduled {
-			// Scheduled-only: prune stale auto-generated prior-cycle versions after
-			// the replacement result is durably inserted. Hand-edited rows
-			// (edited_at IS NOT NULL) are retained permanently as user data, even
-			// across later scheduled cycles.
-			if err := tx.Where("task_id = ? AND id <> ? AND edited_at IS NULL", taskID, result.ID).Delete(&model.SummaryResult{}).Error; err != nil {
-				return err
-			}
-			// summary_chunk currently has no version column, so cleanup must happen
-			// only after the replacement result is durably inserted.
+			// Scheduled runs are versioned on the same task. Keep prior summary_result
+			// rows so the detail page can show scheduled_generate entries in Recent
+			// versions. summary_chunk has no version column, so only transient chunks
+			// are replaced after the new result is durably inserted.
 			if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryChunk{}).Error; err != nil {
 				return err
 			}
+		}
+		if err := service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit); err != nil {
+			return err
 		}
 		return markTaskCompleted(tx, taskID)
 	})

--- a/internal/worker/scheduled_replace_helpers.go
+++ b/internal/worker/scheduled_replace_helpers.go
@@ -399,7 +399,25 @@ func saveLatestResultAndCompleteTask(db *gorm.DB, taskID int64, result *model.Su
 		}
 		result.TaskID = taskID
 		result.Version = nextVer
+		if result.OperationType == "" {
+			if nextVer <= 1 {
+				result.OperationType = "generate"
+			} else if isScheduled {
+				result.OperationType = "scheduled_generate"
+			} else {
+				result.OperationType = "regenerate"
+			}
+		}
+		if result.OperationNote == "" && result.OperationType != "scheduled_generate" {
+			var task model.SummaryTask
+			if err := tx.Select("title").Where("id = ?", taskID).First(&task).Error; err == nil {
+				result.OperationNote = task.Title
+			}
+		}
 		if err := tx.Create(result).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", result.ID).Error; err != nil {
 			return err
 		}
 		if isScheduled {
@@ -415,6 +433,9 @@ func saveLatestResultAndCompleteTask(db *gorm.DB, taskID int64, result *model.Su
 			if err := tx.Where("task_id = ?", taskID).Delete(&model.SummaryChunk{}).Error; err != nil {
 				return err
 			}
+		}
+		if err := service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit); err != nil {
+			return err
 		}
 		return markTaskCompleted(tx, taskID)
 	})

--- a/internal/worker/scheduled_replace_test.go
+++ b/internal/worker/scheduled_replace_test.go
@@ -376,3 +376,42 @@ func TestSameInt64Set(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduledResultAppendsVersionOnSameTask(t *testing.T) {
+	db := newReplaceTestDB(t)
+	now := time.Now()
+	task := model.SummaryTask{TaskNo: "T-SCHED-VERSION", CreatorID: "creator", SummaryMode: model.ModeByPerson, Status: model.StatusProcessing, TriggerType: model.TriggerScheduled, TimeRangeStart: now, TimeRangeEnd: now}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatal(err)
+	}
+	old := model.SummaryResult{TaskID: task.ID, Content: "old", Version: 1, OperationType: "generate", GeneratedAt: now}
+	if err := db.Create(&old).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", task.ID).Update("current_result_id", old.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	result := &model.SummaryResult{Content: "scheduled", OperationNote: "scheduled instruction", GeneratedAt: now.Add(time.Minute)}
+	if err := saveLatestResultAndCompleteTask(db, task.ID, result, true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var rows []model.SummaryResult
+	if err := db.Where("task_id = ?", task.ID).Order("version ASC").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected old and scheduled versions to be kept, got %d", len(rows))
+	}
+	if rows[1].Version != 2 || rows[1].OperationType != "scheduled_generate" {
+		t.Fatalf("expected scheduled version 2, got version=%d operation=%s", rows[1].Version, rows[1].OperationType)
+	}
+	var refreshed model.SummaryTask
+	if err := db.First(&refreshed, task.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.CurrentResultID == nil || *refreshed.CurrentResultID != rows[1].ID {
+		t.Fatalf("current_result_id should point to scheduled version, got %v want %d", refreshed.CurrentResultID, rows[1].ID)
+	}
+}

--- a/internal/worker/scheduled_replace_test.go
+++ b/internal/worker/scheduled_replace_test.go
@@ -70,9 +70,9 @@ func TestMarkTaskCompleted_CASOnlyFromProcessing(t *testing.T) {
 	}
 }
 
-// Scheduled runs overwrite in place: after inserting the new result, prior
-// auto-generated results are pruned so only the latest remains.
-func TestSaveLatestResult_ScheduledPrunesPriorAutoVersions(t *testing.T) {
+// Scheduled runs append a new result version on the same task. Prior result
+// rows are retained for the version-history UI, while stale chunks are cleared.
+func TestSaveLatestResult_ScheduledKeepsPriorVersions(t *testing.T) {
 	db := newReplaceTestDB(t)
 	taskID := seedProcessingTask(t, db)
 
@@ -84,13 +84,13 @@ func TestSaveLatestResult_ScheduledPrunesPriorAutoVersions(t *testing.T) {
 	if err := saveLatestResultAndCompleteTask(db, taskID, newRes, true, nil); err != nil {
 		t.Fatalf("save scheduled: %v", err)
 	}
-	if got := countResults(t, db, taskID); got != 1 {
-		t.Fatalf("scheduled run should keep only the latest result, got %d", got)
+	if got := countResults(t, db, taskID); got != 2 {
+		t.Fatalf("scheduled run should keep prior versions, got %d", got)
 	}
-	var remaining model.SummaryResult
-	db.Where("task_id = ?", taskID).First(&remaining)
-	if remaining.Content != "new" {
-		t.Errorf("remaining result content = %q, want \"new\"", remaining.Content)
+	var latest model.SummaryResult
+	db.Where("task_id = ?", taskID).Order("version DESC, id DESC").First(&latest)
+	if latest.Content != "new" || latest.OperationType != "scheduled_generate" {
+		t.Errorf("latest result = content %q operation %q, want new/scheduled_generate", latest.Content, latest.OperationType)
 	}
 	// Chunks are cleaned up on scheduled overwrite.
 	var chunkCount int64
@@ -374,5 +374,44 @@ func TestSameInt64Set(t *testing.T) {
 				t.Errorf("sameInt64Set(%v, %v) [reversed] = %v, want %v", tc.b, tc.a, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestScheduledResultAppendsVersionOnSameTask(t *testing.T) {
+	db := newReplaceTestDB(t)
+	now := time.Now()
+	task := model.SummaryTask{TaskNo: "T-SCHED-VERSION", CreatorID: "creator", SummaryMode: model.ModeByPerson, Status: model.StatusProcessing, TriggerType: model.TriggerScheduled, TimeRangeStart: now, TimeRangeEnd: now}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatal(err)
+	}
+	old := model.SummaryResult{TaskID: task.ID, Content: "old", Version: 1, OperationType: "generate", GeneratedAt: now}
+	if err := db.Create(&old).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", task.ID).Update("current_result_id", old.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	result := &model.SummaryResult{Content: "scheduled", OperationNote: "scheduled instruction", GeneratedAt: now.Add(time.Minute)}
+	if err := saveLatestResultAndCompleteTask(db, task.ID, result, true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var rows []model.SummaryResult
+	if err := db.Where("task_id = ?", task.ID).Order("version ASC").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected old and scheduled versions to be kept, got %d", len(rows))
+	}
+	if rows[1].Version != 2 || rows[1].OperationType != "scheduled_generate" {
+		t.Fatalf("expected scheduled version 2, got version=%d operation=%s", rows[1].Version, rows[1].OperationType)
+	}
+	var refreshed model.SummaryTask
+	if err := db.First(&refreshed, task.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.CurrentResultID == nil || *refreshed.CurrentResultID != rows[1].ID {
+		t.Fatalf("current_result_id should point to scheduled version, got %v want %d", refreshed.CurrentResultID, rows[1].ID)
 	}
 }

--- a/internal/worker/scheduled_replace_test.go
+++ b/internal/worker/scheduled_replace_test.go
@@ -70,9 +70,9 @@ func TestMarkTaskCompleted_CASOnlyFromProcessing(t *testing.T) {
 	}
 }
 
-// Scheduled runs overwrite in place: after inserting the new result, prior
-// auto-generated results are pruned so only the latest remains.
-func TestSaveLatestResult_ScheduledPrunesPriorAutoVersions(t *testing.T) {
+// Scheduled runs append a new result version on the same task. Prior result
+// rows are retained for the version-history UI, while stale chunks are cleared.
+func TestSaveLatestResult_ScheduledKeepsPriorVersions(t *testing.T) {
 	db := newReplaceTestDB(t)
 	taskID := seedProcessingTask(t, db)
 
@@ -84,13 +84,13 @@ func TestSaveLatestResult_ScheduledPrunesPriorAutoVersions(t *testing.T) {
 	if err := saveLatestResultAndCompleteTask(db, taskID, newRes, true, nil); err != nil {
 		t.Fatalf("save scheduled: %v", err)
 	}
-	if got := countResults(t, db, taskID); got != 1 {
-		t.Fatalf("scheduled run should keep only the latest result, got %d", got)
+	if got := countResults(t, db, taskID); got != 2 {
+		t.Fatalf("scheduled run should keep prior versions, got %d", got)
 	}
-	var remaining model.SummaryResult
-	db.Where("task_id = ?", taskID).First(&remaining)
-	if remaining.Content != "new" {
-		t.Errorf("remaining result content = %q, want \"new\"", remaining.Content)
+	var latest model.SummaryResult
+	db.Where("task_id = ?", taskID).Order("version DESC, id DESC").First(&latest)
+	if latest.Content != "new" || latest.OperationType != "scheduled_generate" {
+		t.Errorf("latest result = content %q operation %q, want new/scheduled_generate", latest.Content, latest.OperationType)
 	}
 	// Chunks are cleaned up on scheduled overwrite.
 	var chunkCount int64

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -63,7 +63,7 @@ func scanPendingSchedules(db *gorm.DB, imDB *gorm.DB, maxWindowDays int, feature
 	}
 
 	for _, sched := range schedules {
-		taskID, claimed, err := claimAndCreateScheduledTask(db, imDB, sched, now, maxWindowDays, featureTeamSchedule)
+		taskID, claimed, err := claimAndRequeueScheduledTask(db, imDB, sched, now, maxWindowDays, featureTeamSchedule)
 		if err != nil {
 			log.Printf("[scheduler] create task for schedule %d: %v", sched.ID, err)
 			continue
@@ -78,20 +78,19 @@ func scanPendingSchedules(db *gorm.DB, imDB *gorm.DB, maxWindowDays int, feature
 	}
 }
 
-func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int, featureTeamSchedule bool) (int64, bool, error) {
+func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int, featureTeamSchedule bool) (int64, bool, error) {
 	if sched.NextRunAt == nil {
 		return 0, false, nil
 	}
 
-	var newTask model.SummaryTask
+	var runTaskID int64
 	claimed := false
 	requeued := false
 
-	// The schedule claim (FOR UPDATE re-read + next_run advance) and the task reset share
-	// ONE transaction: a reset failure rolls back the next_run_at advance too (60s scan
-	// retries), avoiding a dropped cycle. Business skips (no bound task, overlapping
-	// Processing, multi-person) still commit the advanced next_run_at to avoid re-scanning
-	// forever; only real errors roll back.
+	// The schedule claim (FOR UPDATE re-read + next_run advance) and task requeue share
+	// one transaction. Scheduled runs are modeled as new versions of the bound summary
+	// task, not as new user-visible tasks: the left list keeps one item, and the result
+	// history grows via scheduled_generate versions on that same task.
 	if err := db.Transaction(func(tx *gorm.DB) error {
 		var lockedSched model.SummarySchedule
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -103,208 +102,157 @@ func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summary
 			return err
 		}
 		if lockedSched.IsActive != 1 || lockedSched.NextRunAt == nil || !lockedSched.NextRunAt.Equal(*sched.NextRunAt) || lockedSched.NextRunAt.After(now) {
-			// The due snapshot was deactivated, retimed or already claimed after scan().
-			// Skip instead of using stale schedule fields from the pre-scan snapshot.
 			return nil
 		}
 
-		// Recompute from the FOR UPDATE re-read row so claim sees the latest config
-		// even when non-recurrence fields changed without bumping next_run_at.
 		nextRun, err := service.NextRunScheduledAdvance(lockedSched.CronExpr, lockedSched.IntervalDays, lockedSched.IntervalMonths, lockedSched.RunTime, lockedSched.DayOfWeek, lockedSched.DayOfMonth, lockedSched.AnchorDOM, *lockedSched.NextRunAt, now)
 		if err != nil {
 			log.Printf("[scheduler] ALERT schedule %d has invalid recurrence (%v); disabling to stop repeated re-scan/cost", lockedSched.ID, err)
-			if err := tx.Model(&model.SummarySchedule{}).
+			return tx.Model(&model.SummarySchedule{}).
 				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error; err != nil {
-				return err
-			}
-			return nil
+				Update("is_active", 0).Error
 		}
 		start, end, err := service.ComputeTimeRange(lockedSched.TimeRangeType, now, lockedSched.LastRunAt, lockedSched.CronExpr, lockedSched.IntervalDays, lockedSched.IntervalMonths, maxWindowDays)
 		if err != nil {
 			log.Printf("[scheduler] ALERT schedule %d has invalid time range (%v); disabling to stop repeated re-scan/cost", lockedSched.ID, err)
-			if err := tx.Model(&model.SummarySchedule{}).
+			return tx.Model(&model.SummarySchedule{}).
 				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error; err != nil {
-				return err
-			}
-			return nil
+				Update("is_active", 0).Error
 		}
-		// Advance ONLY next_run_at here (the scheduling cadence) so a due schedule
-		// is not re-scanned every 60s. last_run_at (the type=4 incremental window
-		// anchor) must NOT advance at claim time: it is advanced later, only when we
-		// actually requeue the task to run (see below). Coupling them here was the
-		// bug -- a business skip would commit last_run_at=now without producing a
-		// summary, permanently dropping the skipped window for type=4.
 		if err := tx.Model(&model.SummarySchedule{}).
 			Where("id = ?", lockedSched.ID).
-			Updates(map[string]interface{}{
-				"next_run_at": nextRun,
-			}).Error; err != nil {
+			Update("next_run_at", nextRun).Error; err != nil {
 			return err
 		}
 		claimed = true
 
-		// 1->N model: find the LATEST task under this schedule only to enforce the
-		// overlap guard. We no longer reuse/reset it -- each run INSERTs a brand-new
-		// task. ErrRecordNotFound (no task yet) is fine: the very first run has no
-		// predecessor, so there is nothing to overlap with.
-		var latest model.SummaryTask
-		hasLatest := false
-		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("schedule_id = ? AND deleted_at IS NULL", lockedSched.ID).
-			Order("id DESC").
-			First(&latest).Error; err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				return err
-			}
-		} else {
-			hasLatest = true
-		}
-
-		// Overlap guard: skip creating a new run if ANY non-terminal task already
-		// exists under this schedule (status IN Pending/WaitingConfirm/Processing,
-		// not soft-deleted). Previously this only checked whether the LATEST task was
-		// Processing -- but scanStuckTasks revives an expired Processing run back to
-		// Pending, so the latest could be Pending (not Processing) while still being a
-		// live placeholder; the old guard then created a SECOND executable task for
-		// the same schedule/window (duplicate-execution race, no DB unique key).
-		// Treating every non-terminal status as an occupying placeholder closes that
-		// gap. Skip WITHOUT advancing last_run_at (same transient-overlap semantics):
-		// the window is preserved and covered by the next cycle once the in-flight run
-		// reaches a terminal state. A task hitting WorkerMaxRetry is marked Failed
-		// (terminal) by scanStuckTasks, which naturally releases this skip -- so it
-		// never blocks the schedule permanently.
-		var liveCount int64
-		if err := tx.Model(&model.SummaryTask{}).
-			Where("schedule_id = ? AND deleted_at IS NULL AND status IN ?",
-				lockedSched.ID,
-				[]int{model.StatusPending, model.StatusWaitingConfirm, model.StatusProcessing}).
-			Count(&liveCount).Error; err != nil {
-			return err
-		}
-		if liveCount > 0 {
-			log.Printf("[scheduler] schedule %d has %d non-terminal task(s); skipping overlapping new task (last_run_at preserved)", lockedSched.ID, liveCount)
+		acceptedCount := scheduledAcceptedParticipantCount(lockedSched, lockedSched.CreatorID)
+		if acceptedCount == 0 {
+			log.Printf("[scheduler] schedule %d: zero confirmed participants; skipping round without changing task (last_run_at preserved)", lockedSched.ID)
 			return nil
 		}
 
-		// Scheduled summary is single-person only unless FEATURE_TEAM_SCHEDULE is on.
-		// If the schedule's participant config went multi-person and the flag is OFF, it
-		// is structurally unsupported for scheduling: disable + alert. When the flag is
-		// ON, multi-person schedules are allowed through to the multi-person execution
-		// path (children built by buildScheduledTaskChildren, all participants Accepted
-		// under AUTO; meta aggregation via the submit-gate back-fill).
+		var task model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("schedule_id = ? AND deleted_at IS NULL", lockedSched.ID).
+			Order("id ASC").
+			First(&task).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				task = model.SummaryTask{
+					TaskNo:         service.GenerateTaskNo(),
+					SpaceID:        lockedSched.SpaceID,
+					CreatorID:      lockedSched.CreatorID,
+					Title:          lockedSched.Title,
+					SummaryMode:    lockedSched.SummaryMode,
+					TimeRangeStart: start,
+					TimeRangeEnd:   end,
+					Status:         model.StatusPending,
+					TriggerType:    model.TriggerScheduled,
+					ScheduleID:     &lockedSched.ID,
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				}
+				if err := tx.Create(&task).Error; err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+
+		if task.Status == model.StatusPending || task.Status == model.StatusWaitingConfirm || task.Status == model.StatusProcessing {
+			log.Printf("[scheduler] schedule %d task %d is non-terminal (status=%d); skipping overlapping run (last_run_at preserved)", lockedSched.ID, task.ID, task.Status)
+			return nil
+		}
+
 		if multiPerson, err := scheduleConfigMultiPerson(lockedSched); err != nil {
 			return err
 		} else if multiPerson && !featureTeamSchedule {
 			log.Printf("[scheduler] ALERT schedule %d participant config is multi-person; scheduled summary not supported for team tasks (FEATURE_TEAM_SCHEDULE off), disabling + notifying creator", lockedSched.ID)
-			if err := tx.Model(&model.SummarySchedule{}).
+			return tx.Model(&model.SummarySchedule{}).
 				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error; err != nil {
-				return err
-			}
-			// NOTE: creator notification is a follow-up.
-			return nil
+				Update("is_active", 0).Error
 		}
 
-		requeued = true
-
-		// INSERT a brand-new task for this run (1->N). Title/origin/space carry over
-		// from the schedule; the rest is a fresh Pending scheduled task.
-		newTask = model.SummaryTask{
-			TaskNo:         service.GenerateTaskNo(),
-			SpaceID:        lockedSched.SpaceID,
-			CreatorID:      lockedSched.CreatorID,
-			Title:          lockedSched.Title,
-			SummaryMode:    lockedSched.SummaryMode,
-			TimeRangeStart: start,
-			TimeRangeEnd:   end,
-			Status:         model.StatusPending,
-			TriggerType:    model.TriggerScheduled,
-			ScheduleID:     &lockedSched.ID,
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		}
-		if hasLatest {
-			// Preserve origin channel from the previous run so the new summary keeps
-			// the same delivery context.
-			newTask.OriginChannelID = latest.OriginChannelID
-			newTask.OriginChannelType = latest.OriginChannelType
-		}
-		if err := tx.Create(&newTask).Error; err != nil {
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummarySource{}).Error; err != nil {
 			return err
 		}
-
-		// Rebuild the three subtables (source / participant / personal_result) from
-		// the schedule config -- the new task_id starts with no children. The returned
-		// count is the number of Accepted participants materialized this round.
-		//
-		// V5 §4.3/Q2: for a CONFIRM schedule where NOBODY (creator included) has
-		// confirmed yet, no children are built (acceptedCount==0). The round is skipped:
-		// the freshly-created placeholder task is SOFT-DELETED (deleted_at set) so it
-		// produces no result, never surfaces in any deleted_at IS NULL query (list/
-		// detail), does not occupy the overlap guard, and is not picked up by the
-		// processor. The next cycle re-checks the confirm list (already-advanced
-		// next_run_at avoids a busy re-scan). last_run_at is NOT advanced for a skipped
-		// round so a type=4 incremental window is preserved.
-		acceptedCount, err := buildScheduledTaskChildren(tx, imDB, lockedSched, newTask, now)
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.PersonalResult{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummaryParticipant{}).Error; err != nil {
+			return err
+		}
+		if err := buildScheduledTaskSources(tx, imDB, task.ID, lockedSched.SourceConfig); err != nil {
+			return err
+		}
+		materialized, err := buildScheduledTaskParticipants(tx, task, lockedSched.ParticipantConfig, lockedSched.ConfirmPolicy, now)
 		if err != nil {
 			return err
 		}
-		if acceptedCount == 0 {
-			log.Printf("[scheduler] schedule %d: CONFIRM round has zero confirmed participants; skipping round (placeholder task %d soft-deleted, no result, last_run_at preserved)", lockedSched.ID, newTask.ID)
-			// Soft-delete the placeholder task instead of marking it Cancelled, so it
-			// never surfaces in any deleted_at IS NULL query (list/detail). DeletedAt is
-			// a plain *time.Time (not gorm.DeletedAt), so set it explicitly with now to
-			// stay transaction-consistent. The overlap guard ignores it (deleted_at non-
-			// null), next_run_at is already advanced, last_run_at stays put: the plan
-			// silently rolls to the next time point.
-			// Clean up the summary_source child rows already materialized this round.
-			// buildScheduledTaskChildren builds sources BEFORE counting accepted
-			// participants, so on a zero-confirm round the source rows exist while the
-			// parent task is only soft-deleted -- they would become invisible orphans
-			// accumulating every skipped round. SummarySource has no DeletedAt, so this
-			// is a physical delete (correct: they are valueless, unreferenced garbage).
-			if err := tx.Where("task_id = ?", newTask.ID).Delete(&model.SummarySource{}).Error; err != nil {
-				return err
-			}
-			if err := tx.Model(&model.SummaryTask{}).
-				Where("id = ?", newTask.ID).
-				Update("deleted_at", now).Error; err != nil {
-				return err
-			}
-			requeued = false
+		if materialized == 0 {
+			log.Printf("[scheduler] schedule %d: zero participants materialized; skipping round without running task %d", lockedSched.ID, task.ID)
 			return nil
 		}
 
-		// Advance last_run_at ONLY now that the new task is actually created to run.
-		// The type=4 incremental window anchor moves only on a real run, never on a
-		// business skip, so a skipped interval's messages are still covered by the
-		// next window instead of being permanently dropped.
+		updates := map[string]interface{}{
+			"title":               lockedSched.Title,
+			"summary_mode":        lockedSched.SummaryMode,
+			"time_range_start":    start,
+			"time_range_end":      end,
+			"status":              model.StatusPending,
+			"trigger_type":        model.TriggerScheduled,
+			"retry_count":         0,
+			"error_message":       nil,
+			"processing_deadline": nil,
+		}
+		if err := tx.Model(&model.SummaryTask{}).
+			Where("id = ?", task.ID).
+			Updates(updates).Error; err != nil {
+			return err
+		}
+
 		if err := tx.Model(&model.SummarySchedule{}).
 			Where("id = ?", lockedSched.ID).
 			Update("last_run_at", now).Error; err != nil {
 			return err
 		}
 
+		runTaskID = task.ID
+		requeued = true
 		return nil
 	}); err != nil {
-		// Technical failure: whole tx (including the next_run_at advance) rolled
-		// back. next_run_at stays in the past so the next 60s scan retries.
 		return 0, false, err
 	}
 
 	if !claimed {
 		return 0, false, nil
 	}
-
-	// Only report a real requeue when we actually created a new task. Skipped cases
-	// (still processing or multi-person guard) return taskID=0 so scanPendingSchedules
-	// does not log a misleading "requeued task" line.
 	if !requeued {
 		return 0, true, nil
 	}
-	return newTask.ID, true, nil
+	return runTaskID, true, nil
+}
+
+// claimAndCreateScheduledTask is kept as a compatibility wrapper for older tests.
+// Scheduled runs now requeue the bound task and append a new result version.
+func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int, featureTeamSchedule bool) (int64, bool, error) {
+	return claimAndRequeueScheduledTask(db, imDB, sched, now, maxWindowDays, featureTeamSchedule)
+}
+
+func scheduledAcceptedParticipantCount(sched model.SummarySchedule, creatorID string) int {
+	cfg := model.ParseScheduleParticipantConfig(sched.ParticipantConfig)
+	if sched.ConfirmPolicy == model.SchedConfirmAuto {
+		return len(cfg.EffectiveUserIDs(creatorID))
+	}
+	cfg.EnsureCreatorEntry(creatorID)
+	count := 0
+	for _, uid := range cfg.EffectiveUserIDs(creatorID) {
+		if cfg.IsConfirmed(uid) {
+			count++
+		}
+	}
+	return count
 }
 
 // scheduleConfigMultiPerson reports whether a schedule's participant config

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -182,6 +182,9 @@ func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summar
 		if err := tx.Where("task_id = ?", task.ID).Delete(&model.PersonalResult{}).Error; err != nil {
 			return err
 		}
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummaryNotification{}).Error; err != nil {
+			return err
+		}
 		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummaryParticipant{}).Error; err != nil {
 			return err
 		}

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -132,7 +132,17 @@ func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summar
 			return nil
 		}
 
+		if multiPerson, err := scheduleConfigMultiPerson(lockedSched); err != nil {
+			return err
+		} else if multiPerson && !featureTeamSchedule {
+			log.Printf("[scheduler] ALERT schedule %d participant config is multi-person; scheduled summary not supported for team tasks (FEATURE_TEAM_SCHEDULE off), disabling + notifying creator", lockedSched.ID)
+			return tx.Model(&model.SummarySchedule{}).
+				Where("id = ?", lockedSched.ID).
+				Update("is_active", 0).Error
+		}
+
 		var task model.SummaryTask
+		createdTask := false
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("schedule_id = ? AND deleted_at IS NULL", lockedSched.ID).
 			Order("id ASC").
@@ -155,23 +165,15 @@ func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summar
 				if err := tx.Create(&task).Error; err != nil {
 					return err
 				}
+				createdTask = true
 			} else {
 				return err
 			}
 		}
 
-		if task.Status == model.StatusPending || task.Status == model.StatusWaitingConfirm || task.Status == model.StatusProcessing {
+		if !createdTask && (task.Status == model.StatusPending || task.Status == model.StatusWaitingConfirm || task.Status == model.StatusProcessing) {
 			log.Printf("[scheduler] schedule %d task %d is non-terminal (status=%d); skipping overlapping run (last_run_at preserved)", lockedSched.ID, task.ID, task.Status)
 			return nil
-		}
-
-		if multiPerson, err := scheduleConfigMultiPerson(lockedSched); err != nil {
-			return err
-		} else if multiPerson && !featureTeamSchedule {
-			log.Printf("[scheduler] ALERT schedule %d participant config is multi-person; scheduled summary not supported for team tasks (FEATURE_TEAM_SCHEDULE off), disabling + notifying creator", lockedSched.ID)
-			return tx.Model(&model.SummarySchedule{}).
-				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error
 		}
 
 		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummarySource{}).Error; err != nil {

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
@@ -63,7 +64,7 @@ func scanPendingSchedules(db *gorm.DB, imDB *gorm.DB, maxWindowDays int, feature
 	}
 
 	for _, sched := range schedules {
-		taskID, claimed, err := claimAndCreateScheduledTask(db, imDB, sched, now, maxWindowDays, featureTeamSchedule)
+		taskID, claimed, err := claimAndRequeueScheduledTask(db, imDB, sched, now, maxWindowDays, featureTeamSchedule)
 		if err != nil {
 			log.Printf("[scheduler] create task for schedule %d: %v", sched.ID, err)
 			continue
@@ -78,20 +79,19 @@ func scanPendingSchedules(db *gorm.DB, imDB *gorm.DB, maxWindowDays int, feature
 	}
 }
 
-func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int, featureTeamSchedule bool) (int64, bool, error) {
+func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int, featureTeamSchedule bool) (int64, bool, error) {
 	if sched.NextRunAt == nil {
 		return 0, false, nil
 	}
 
-	var newTask model.SummaryTask
+	var runTaskID int64
 	claimed := false
 	requeued := false
 
-	// The schedule claim (FOR UPDATE re-read + next_run advance) and the task reset share
-	// ONE transaction: a reset failure rolls back the next_run_at advance too (60s scan
-	// retries), avoiding a dropped cycle. Business skips (no bound task, overlapping
-	// Processing, multi-person) still commit the advanced next_run_at to avoid re-scanning
-	// forever; only real errors roll back.
+	// The schedule claim (FOR UPDATE re-read + next_run advance) and task requeue share
+	// one transaction. Scheduled runs are modeled as new versions of the bound summary
+	// task, not as new user-visible tasks: the left list keeps one item, and the result
+	// history grows via scheduled_generate versions on that same task.
 	if err := db.Transaction(func(tx *gorm.DB) error {
 		var lockedSched model.SummarySchedule
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -103,208 +103,235 @@ func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summary
 			return err
 		}
 		if lockedSched.IsActive != 1 || lockedSched.NextRunAt == nil || !lockedSched.NextRunAt.Equal(*sched.NextRunAt) || lockedSched.NextRunAt.After(now) {
-			// The due snapshot was deactivated, retimed or already claimed after scan().
-			// Skip instead of using stale schedule fields from the pre-scan snapshot.
 			return nil
 		}
 
-		// Recompute from the FOR UPDATE re-read row so claim sees the latest config
-		// even when non-recurrence fields changed without bumping next_run_at.
 		nextRun, err := service.NextRunScheduledAdvance(lockedSched.CronExpr, lockedSched.IntervalDays, lockedSched.IntervalMonths, lockedSched.RunTime, lockedSched.DayOfWeek, lockedSched.DayOfMonth, lockedSched.AnchorDOM, *lockedSched.NextRunAt, now)
 		if err != nil {
 			log.Printf("[scheduler] ALERT schedule %d has invalid recurrence (%v); disabling to stop repeated re-scan/cost", lockedSched.ID, err)
-			if err := tx.Model(&model.SummarySchedule{}).
+			return tx.Model(&model.SummarySchedule{}).
 				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error; err != nil {
-				return err
-			}
-			return nil
+				Update("is_active", 0).Error
 		}
 		start, end, err := service.ComputeTimeRange(lockedSched.TimeRangeType, now, lockedSched.LastRunAt, lockedSched.CronExpr, lockedSched.IntervalDays, lockedSched.IntervalMonths, maxWindowDays)
 		if err != nil {
 			log.Printf("[scheduler] ALERT schedule %d has invalid time range (%v); disabling to stop repeated re-scan/cost", lockedSched.ID, err)
-			if err := tx.Model(&model.SummarySchedule{}).
+			return tx.Model(&model.SummarySchedule{}).
 				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error; err != nil {
-				return err
-			}
-			return nil
+				Update("is_active", 0).Error
 		}
-		// Advance ONLY next_run_at here (the scheduling cadence) so a due schedule
-		// is not re-scanned every 60s. last_run_at (the type=4 incremental window
-		// anchor) must NOT advance at claim time: it is advanced later, only when we
-		// actually requeue the task to run (see below). Coupling them here was the
-		// bug -- a business skip would commit last_run_at=now without producing a
-		// summary, permanently dropping the skipped window for type=4.
 		if err := tx.Model(&model.SummarySchedule{}).
 			Where("id = ?", lockedSched.ID).
-			Updates(map[string]interface{}{
-				"next_run_at": nextRun,
-			}).Error; err != nil {
+			Update("next_run_at", nextRun).Error; err != nil {
 			return err
 		}
 		claimed = true
 
-		// 1->N model: find the LATEST task under this schedule only to enforce the
-		// overlap guard. We no longer reuse/reset it -- each run INSERTs a brand-new
-		// task. ErrRecordNotFound (no task yet) is fine: the very first run has no
-		// predecessor, so there is nothing to overlap with.
-		var latest model.SummaryTask
-		hasLatest := false
-		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("schedule_id = ? AND deleted_at IS NULL", lockedSched.ID).
-			Order("id DESC").
-			First(&latest).Error; err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				return err
-			}
-		} else {
-			hasLatest = true
-		}
-
-		// Overlap guard: skip creating a new run if ANY non-terminal task already
-		// exists under this schedule (status IN Pending/WaitingConfirm/Processing,
-		// not soft-deleted). Previously this only checked whether the LATEST task was
-		// Processing -- but scanStuckTasks revives an expired Processing run back to
-		// Pending, so the latest could be Pending (not Processing) while still being a
-		// live placeholder; the old guard then created a SECOND executable task for
-		// the same schedule/window (duplicate-execution race, no DB unique key).
-		// Treating every non-terminal status as an occupying placeholder closes that
-		// gap. Skip WITHOUT advancing last_run_at (same transient-overlap semantics):
-		// the window is preserved and covered by the next cycle once the in-flight run
-		// reaches a terminal state. A task hitting WorkerMaxRetry is marked Failed
-		// (terminal) by scanStuckTasks, which naturally releases this skip -- so it
-		// never blocks the schedule permanently.
-		var liveCount int64
-		if err := tx.Model(&model.SummaryTask{}).
-			Where("schedule_id = ? AND deleted_at IS NULL AND status IN ?",
-				lockedSched.ID,
-				[]int{model.StatusPending, model.StatusWaitingConfirm, model.StatusProcessing}).
-			Count(&liveCount).Error; err != nil {
-			return err
-		}
-		if liveCount > 0 {
-			log.Printf("[scheduler] schedule %d has %d non-terminal task(s); skipping overlapping new task (last_run_at preserved)", lockedSched.ID, liveCount)
+		acceptedCount := scheduledAcceptedParticipantCount(lockedSched, lockedSched.CreatorID)
+		if acceptedCount == 0 {
+			log.Printf("[scheduler] schedule %d: zero confirmed participants; skipping round without changing task (last_run_at preserved)", lockedSched.ID)
 			return nil
 		}
 
-		// Scheduled summary is single-person only unless FEATURE_TEAM_SCHEDULE is on.
-		// If the schedule's participant config went multi-person and the flag is OFF, it
-		// is structurally unsupported for scheduling: disable + alert. When the flag is
-		// ON, multi-person schedules are allowed through to the multi-person execution
-		// path (children built by buildScheduledTaskChildren, all participants Accepted
-		// under AUTO; meta aggregation via the submit-gate back-fill).
 		if multiPerson, err := scheduleConfigMultiPerson(lockedSched); err != nil {
 			return err
 		} else if multiPerson && !featureTeamSchedule {
 			log.Printf("[scheduler] ALERT schedule %d participant config is multi-person; scheduled summary not supported for team tasks (FEATURE_TEAM_SCHEDULE off), disabling + notifying creator", lockedSched.ID)
-			if err := tx.Model(&model.SummarySchedule{}).
+			return tx.Model(&model.SummarySchedule{}).
 				Where("id = ?", lockedSched.ID).
-				Update("is_active", 0).Error; err != nil {
+				Update("is_active", 0).Error
+		}
+
+		var task model.SummaryTask
+		createdTask := false
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("schedule_id = ? AND deleted_at IS NULL", lockedSched.ID).
+			Order("id DESC").
+			First(&task).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				task = model.SummaryTask{
+					TaskNo:         service.GenerateTaskNo(),
+					SpaceID:        lockedSched.SpaceID,
+					CreatorID:      lockedSched.CreatorID,
+					Title:          lockedSched.Title,
+					SummaryMode:    lockedSched.SummaryMode,
+					TimeRangeStart: start,
+					TimeRangeEnd:   end,
+					Status:         model.StatusPending,
+					TriggerType:    model.TriggerScheduled,
+					ScheduleID:     &lockedSched.ID,
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				}
+				if err := tx.Create(&task).Error; err != nil {
+					return err
+				}
+				createdTask = true
+			} else {
 				return err
 			}
-			// NOTE: creator notification is a follow-up.
+		}
+
+		if !createdTask && (task.Status == model.StatusPending || task.Status == model.StatusWaitingConfirm || task.Status == model.StatusProcessing) {
+			log.Printf("[scheduler] schedule %d task %d is non-terminal (status=%d); skipping overlapping run (last_run_at preserved)", lockedSched.ID, task.ID, task.Status)
 			return nil
 		}
 
-		requeued = true
-
-		// INSERT a brand-new task for this run (1->N). Title/origin/space carry over
-		// from the schedule; the rest is a fresh Pending scheduled task.
-		newTask = model.SummaryTask{
-			TaskNo:         service.GenerateTaskNo(),
-			SpaceID:        lockedSched.SpaceID,
-			CreatorID:      lockedSched.CreatorID,
-			Title:          lockedSched.Title,
-			SummaryMode:    lockedSched.SummaryMode,
-			TimeRangeStart: start,
-			TimeRangeEnd:   end,
-			Status:         model.StatusPending,
-			TriggerType:    model.TriggerScheduled,
-			ScheduleID:     &lockedSched.ID,
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		}
-		if hasLatest {
-			// Preserve origin channel from the previous run so the new summary keeps
-			// the same delivery context.
-			newTask.OriginChannelID = latest.OriginChannelID
-			newTask.OriginChannelType = latest.OriginChannelType
-		}
-		if err := tx.Create(&newTask).Error; err != nil {
+		if err := preservePersonalResultVersionsBeforeRequeue(tx, task.ID); err != nil {
 			return err
 		}
-
-		// Rebuild the three subtables (source / participant / personal_result) from
-		// the schedule config -- the new task_id starts with no children. The returned
-		// count is the number of Accepted participants materialized this round.
-		//
-		// V5 §4.3/Q2: for a CONFIRM schedule where NOBODY (creator included) has
-		// confirmed yet, no children are built (acceptedCount==0). The round is skipped:
-		// the freshly-created placeholder task is SOFT-DELETED (deleted_at set) so it
-		// produces no result, never surfaces in any deleted_at IS NULL query (list/
-		// detail), does not occupy the overlap guard, and is not picked up by the
-		// processor. The next cycle re-checks the confirm list (already-advanced
-		// next_run_at avoids a busy re-scan). last_run_at is NOT advanced for a skipped
-		// round so a type=4 incremental window is preserved.
-		acceptedCount, err := buildScheduledTaskChildren(tx, imDB, lockedSched, newTask, now)
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummarySource{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.PersonalResult{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummaryNotification{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("task_id = ?", task.ID).Delete(&model.SummaryParticipant{}).Error; err != nil {
+			return err
+		}
+		if err := buildScheduledTaskSources(tx, imDB, task.ID, lockedSched.SourceConfig); err != nil {
+			return err
+		}
+		materialized, err := buildScheduledTaskParticipants(tx, task, lockedSched.ParticipantConfig, lockedSched.ConfirmPolicy, now)
 		if err != nil {
 			return err
 		}
-		if acceptedCount == 0 {
-			log.Printf("[scheduler] schedule %d: CONFIRM round has zero confirmed participants; skipping round (placeholder task %d soft-deleted, no result, last_run_at preserved)", lockedSched.ID, newTask.ID)
-			// Soft-delete the placeholder task instead of marking it Cancelled, so it
-			// never surfaces in any deleted_at IS NULL query (list/detail). DeletedAt is
-			// a plain *time.Time (not gorm.DeletedAt), so set it explicitly with now to
-			// stay transaction-consistent. The overlap guard ignores it (deleted_at non-
-			// null), next_run_at is already advanced, last_run_at stays put: the plan
-			// silently rolls to the next time point.
-			// Clean up the summary_source child rows already materialized this round.
-			// buildScheduledTaskChildren builds sources BEFORE counting accepted
-			// participants, so on a zero-confirm round the source rows exist while the
-			// parent task is only soft-deleted -- they would become invisible orphans
-			// accumulating every skipped round. SummarySource has no DeletedAt, so this
-			// is a physical delete (correct: they are valueless, unreferenced garbage).
-			if err := tx.Where("task_id = ?", newTask.ID).Delete(&model.SummarySource{}).Error; err != nil {
-				return err
-			}
-			if err := tx.Model(&model.SummaryTask{}).
-				Where("id = ?", newTask.ID).
-				Update("deleted_at", now).Error; err != nil {
-				return err
-			}
-			requeued = false
+		if materialized == 0 {
+			log.Printf("[scheduler] schedule %d: zero participants materialized; skipping round without running task %d", lockedSched.ID, task.ID)
 			return nil
 		}
 
-		// Advance last_run_at ONLY now that the new task is actually created to run.
-		// The type=4 incremental window anchor moves only on a real run, never on a
-		// business skip, so a skipped interval's messages are still covered by the
-		// next window instead of being permanently dropped.
+		updates := map[string]interface{}{
+			"title":               lockedSched.Title,
+			"summary_mode":        lockedSched.SummaryMode,
+			"time_range_start":    start,
+			"time_range_end":      end,
+			"status":              model.StatusPending,
+			"trigger_type":        model.TriggerScheduled,
+			"retry_count":         0,
+			"error_message":       nil,
+			"processing_deadline": nil,
+		}
+		if err := tx.Model(&model.SummaryTask{}).
+			Where("id = ?", task.ID).
+			Updates(updates).Error; err != nil {
+			return err
+		}
+
 		if err := tx.Model(&model.SummarySchedule{}).
 			Where("id = ?", lockedSched.ID).
 			Update("last_run_at", now).Error; err != nil {
 			return err
 		}
 
+		runTaskID = task.ID
+		requeued = true
 		return nil
 	}); err != nil {
-		// Technical failure: whole tx (including the next_run_at advance) rolled
-		// back. next_run_at stays in the past so the next 60s scan retries.
 		return 0, false, err
 	}
 
 	if !claimed {
 		return 0, false, nil
 	}
-
-	// Only report a real requeue when we actually created a new task. Skipped cases
-	// (still processing or multi-person guard) return taskID=0 so scanPendingSchedules
-	// does not log a misleading "requeued task" line.
 	if !requeued {
 		return 0, true, nil
 	}
-	return newTask.ID, true, nil
+	return runTaskID, true, nil
+}
+
+func preservePersonalResultVersionsBeforeRequeue(tx *gorm.DB, taskID int64) error {
+	var rows []model.PersonalResult
+	if err := tx.Where("task_id = ?", taskID).Find(&rows).Error; err != nil {
+		return err
+	}
+	for _, pr := range rows {
+		if strings.TrimSpace(pr.Content) == "" {
+			continue
+		}
+		var latest model.PersonalResultVersion
+		err := tx.Where("task_id = ? AND user_id = ?", pr.TaskID, pr.UserID).
+			Order("version DESC").Order("id DESC").First(&latest).Error
+		if err == nil && latest.Content == pr.Content && latest.CitationsJSON == pr.CitationsJSON {
+			if pr.CurrentVersionID == nil {
+				if err := tx.Model(&model.PersonalResult{}).Where("id = ?", pr.ID).Update("current_version_id", latest.ID).Error; err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		nextVer, err := service.GetNextPersonalVersion(tx, pr.TaskID, pr.UserID)
+		if err != nil {
+			return err
+		}
+		operationType := "generate"
+		var parentID *int64
+		if latest.ID > 0 {
+			operationType = "manual_edit"
+			parentID = &latest.ID
+		}
+		generatedAt := timezone.Now()
+		if pr.EditedAt != nil {
+			generatedAt = *pr.EditedAt
+		} else if pr.GeneratedAt != nil {
+			generatedAt = *pr.GeneratedAt
+		} else if !pr.CreatedAt.IsZero() {
+			generatedAt = pr.CreatedAt
+		}
+		snapshot := model.PersonalResultVersion{
+			TaskID:           pr.TaskID,
+			ParticipantRefID: pr.ParticipantRefID,
+			UserID:           pr.UserID,
+			Content:          pr.Content,
+			CitationsJSON:    pr.CitationsJSON,
+			MsgCount:         pr.MsgCount,
+			TotalTokenUsed:   pr.TotalTokenUsed,
+			ModelVersion:     pr.ModelVersion,
+			Version:          nextVer,
+			OperationType:    operationType,
+			ParentVersionID:  parentID,
+			CreatedBy:        pr.UserID,
+			GeneratedAt:      generatedAt,
+		}
+		if err := tx.Create(&snapshot).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.PersonalResult{}).Where("id = ?", pr.ID).Update("current_version_id", snapshot.ID).Error; err != nil {
+			return err
+		}
+		if err := service.PrunePersonalResultVersions(tx, pr.TaskID, pr.UserID, service.PersonalResultVersionKeepLimit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// claimAndCreateScheduledTask is kept as a compatibility wrapper for older tests.
+// Scheduled runs now requeue the bound task and append a new result version.
+func claimAndCreateScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.SummarySchedule, now time.Time, maxWindowDays int, featureTeamSchedule bool) (int64, bool, error) {
+	return claimAndRequeueScheduledTask(db, imDB, sched, now, maxWindowDays, featureTeamSchedule)
+}
+
+func scheduledAcceptedParticipantCount(sched model.SummarySchedule, creatorID string) int {
+	cfg := model.ParseScheduleParticipantConfig(sched.ParticipantConfig)
+	if sched.ConfirmPolicy == model.SchedConfirmAuto {
+		return len(cfg.EffectiveUserIDs(creatorID))
+	}
+	cfg.EnsureCreatorEntry(creatorID)
+	count := 0
+	for _, uid := range cfg.EffectiveUserIDs(creatorID) {
+		if cfg.IsConfirmed(uid) {
+			count++
+		}
+	}
+	return count
 }
 
 // scheduleConfigMultiPerson reports whether a schedule's participant config

--- a/internal/worker/scheduler_lastrun_test.go
+++ b/internal/worker/scheduler_lastrun_test.go
@@ -3,6 +3,7 @@
 package worker
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -24,6 +25,9 @@ func newSchedulerTestDB(t *testing.T) *gorm.DB {
 		&model.SummaryParticipant{},
 		&model.PersonalResult{},
 		&model.SummarySource{},
+		&model.SummaryNotification{},
+		&model.PersonalResultVersion{},
+		&model.SummaryEvent{},
 	); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -79,9 +83,13 @@ func seedDueScheduleWithPolicy(t *testing.T, db *gorm.DB, lastRunAt *time.Time, 
 
 func seedBoundTask(t *testing.T, db *gorm.DB, scheduleID int64, status int, participants int) model.SummaryTask {
 	t.Helper()
+	var existingTasks int64
 	now := time.Now().UTC()
+	if err := db.Model(&model.SummaryTask{}).Count(&existingTasks).Error; err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
 	task := model.SummaryTask{
-		TaskNo: "T", SpaceID: "sp", CreatorID: "u1", SummaryMode: model.ModeByPerson,
+		TaskNo: fmt.Sprintf("T-%d", existingTasks+1), SpaceID: "sp", CreatorID: "u1", SummaryMode: model.ModeByPerson,
 		Status: status, TimeRangeStart: now, TimeRangeEnd: now, ScheduleID: &scheduleID,
 	}
 	if err := db.Create(&task).Error; err != nil {
@@ -132,6 +140,93 @@ func TestClaim_RequeueAdvancesLastRunAt(t *testing.T) {
 	}
 	if got.NextRunAt == nil || !got.NextRunAt.After(now) {
 		t.Errorf("next_run_at should move forward, got %v", got.NextRunAt)
+	}
+}
+
+func TestClaim_RequeueClearsPriorNotifications(t *testing.T) {
+	db := newSchedulerTestDB(t)
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	sched := seedDueSchedule(t, db, &old)
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	now := time.Now().UTC()
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:       prior.ID,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "u1",
+		Status:       model.NotifyStatusSent,
+		CreatedAt:    now.Add(-time.Hour),
+		UpdatedAt:    now.Add(-time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("seed notification: %v", err)
+	}
+
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, false)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed || taskID != prior.ID {
+		t.Fatalf("expected requeue on same task, got claimed=%v taskID=%d want %d", claimed, taskID, prior.ID)
+	}
+
+	var notifCount int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", prior.ID).Count(&notifCount)
+	if notifCount != 0 {
+		t.Fatalf("requeue must clear stale notification dedup rows, got %d", notifCount)
+	}
+}
+
+func TestClaim_RequeueUsesLatestLegacyTask(t *testing.T) {
+	db := newSchedulerTestDB(t)
+	oldRun := time.Now().UTC().Add(-48 * time.Hour)
+	sched := seedDueSchedule(t, db, &oldRun)
+	oldTask := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	latestTask := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+
+	now := time.Now().UTC()
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, false)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed || taskID != latestTask.ID {
+		t.Fatalf("requeue should bind latest legacy task, got claimed=%v taskID=%d want %d (old=%d)", claimed, taskID, latestTask.ID, oldTask.ID)
+	}
+}
+
+func TestPersistCompletedPersonalResult_ScheduledEmptyCarriesLatestVersion(t *testing.T) {
+	db := newSchedulerTestDB(t)
+	now := time.Now().UTC()
+	task := model.SummaryTask{TaskNo: "T", CreatorID: "u1", SummaryMode: model.ModeByPerson, TriggerType: model.TriggerScheduled, Status: model.StatusProcessing, TimeRangeStart: now, TimeRangeEnd: now}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	participant := model.SummaryParticipant{TaskID: task.ID, UserID: "u1", Status: model.ParticipantAccepted}
+	if err := db.Create(&participant).Error; err != nil {
+		t.Fatalf("seed participant: %v", err)
+	}
+	pr := model.PersonalResult{TaskID: task.ID, ParticipantRefID: participant.ID, UserID: "u1", WorkerStatus: model.PersonalStatusProcessing}
+	if err := db.Create(&pr).Error; err != nil {
+		t.Fatalf("seed personal result: %v", err)
+	}
+	version := model.PersonalResultVersion{TaskID: task.ID, ParticipantRefID: participant.ID, UserID: "u1", Content: "previous personal summary", Version: 1, OperationType: "generate", CreatedBy: "u1", GeneratedAt: now.Add(-time.Hour)}
+	version.SetCitations([]model.Citation{{Index: 1, Content: "evidence"}})
+	if err := db.Create(&version).Error; err != nil {
+		t.Fatalf("seed version: %v", err)
+	}
+
+	processor := &Processor{db: db}
+	if err := processor.persistCompletedPersonalResult(task, pr, noRelevantContentMessage, nil, 0, 0, "model", now, true); err != nil {
+		t.Fatalf("persist skip content: %v", err)
+	}
+
+	var got model.PersonalResult
+	if err := db.First(&got, pr.ID).Error; err != nil {
+		t.Fatalf("load personal result: %v", err)
+	}
+	if got.Content != version.Content || got.CurrentVersionID == nil || *got.CurrentVersionID != version.ID {
+		t.Fatalf("empty scheduled window should carry latest version, content=%q current=%v want content=%q current=%d", got.Content, got.CurrentVersionID, version.Content, version.ID)
+	}
+	if got.WorkerStatus != model.PersonalStatusCompleted || got.WorkflowStage != model.WorkflowStageGenerateSummary {
+		t.Fatalf("status/stage = %d/%q, want completed/%q", got.WorkerStatus, got.WorkflowStage, model.WorkflowStageGenerateSummary)
 	}
 }
 
@@ -362,9 +457,10 @@ func TestClaim_AutoRequeue_AllParticipantsAccepted_DispatchSelectsAll(t *testing
 	old := time.Now().UTC().Add(-48 * time.Hour)
 	// AUTO (confirm_policy=0) + creator u1 + u2 + u3 configured.
 	sched := seedDueScheduleWithPolicy(t, db, &old, model.SchedConfirmAuto, "u2", "u3")
-	// Prior terminal bound task under the schedule => this is the REQUEUE path
-	// (latest exists, terminal so no overlap skip), distinct from first-run.
-	seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	// Prior terminal bound task under the schedule => this is the REQUEUE path.
+	// Scheduled runs reuse this task and append result versions instead of creating
+	// another user-visible task.
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
 
 	now := time.Now().UTC()
 	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, true /* featureTeamSchedule */)
@@ -372,10 +468,18 @@ func TestClaim_AutoRequeue_AllParticipantsAccepted_DispatchSelectsAll(t *testing
 		t.Fatalf("claim: %v", err)
 	}
 	if !claimed || taskID == 0 {
-		t.Fatalf("AUTO requeue should create a task, got claimed=%v taskID=%d", claimed, taskID)
+		t.Fatalf("AUTO requeue should reuse a task, got claimed=%v taskID=%d", claimed, taskID)
+	}
+	if taskID != prior.ID {
+		t.Fatalf("AUTO requeue should reuse bound task %d, got %d", prior.ID, taskID)
+	}
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("schedule_id = ? AND deleted_at IS NULL", sched.ID).Count(&taskCount)
+	if taskCount != 1 {
+		t.Fatalf("AUTO requeue must not create another visible task, got %d", taskCount)
 	}
 
-	// New task must be a scheduled task (trigger_type=2).
+	// Reused task must be a scheduled task (trigger_type=2).
 	var task model.SummaryTask
 	if err := db.First(&task, taskID).Error; err != nil {
 		t.Fatalf("load task: %v", err)
@@ -462,7 +566,7 @@ func TestClaim_ConfirmV5_PartialConfirm_OnlyConfirmedMaterialized(t *testing.T) 
 		t.Fatalf("claim: %v", err)
 	}
 	if !claimed || taskID == 0 {
-		t.Fatalf("partial-confirm round should create a task, got claimed=%v taskID=%d", claimed, taskID)
+		t.Fatalf("partial-confirm round should reuse a task, got claimed=%v taskID=%d", claimed, taskID)
 	}
 
 	var total, accepted int64
@@ -520,62 +624,45 @@ func TestClaim_ConfirmV5_ZeroConfirmed_NextRunAdvancesLastRunPreserved(t *testin
 	}
 }
 
-// V5 §4.3/Q2 (soft-delete behavior): when NOBODY (creator included) has confirmed,
-// the whole round is skipped. The freshly-created placeholder task is SOFT-DELETED
-// (deleted_at set), NOT left as a Cancelled shell -- so it never surfaces in any
-// deleted_at IS NULL query (list/detail). No participants/personal_results are
-// built and no result is produced. (creator is no longer auto-accepted.)
+// V5 §4.3/Q2: when NOBODY (creator included) has confirmed, the whole
+// round is skipped without creating another task or mutating the existing bound task.
 func TestClaim_ConfirmV5_ZeroConfirmed_RoundSkipped(t *testing.T) {
 	db := newSchedulerTestDB(t)
 	old := time.Now().UTC().Add(-48 * time.Hour)
 	// u1(creator)+u2+u3 all unconfirmed.
 	sched := seedDueScheduleV5Confirm(t, db, &old, []string{"u2", "u3"} /* none confirmed */)
-	seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
 
 	now := time.Now().UTC()
 	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, true)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
-	// The round is claimed (next_run_at advances) but produces no runnable task.
 	if !claimed {
 		t.Fatalf("zero-confirmed round should still claim (advance next_run), got claimed=%v", claimed)
 	}
 	if taskID != 0 {
 		t.Fatalf("zero-confirmed round must report taskID=0 (skipped), got %d", taskID)
 	}
-	// The placeholder task must NOT appear in a deleted_at IS NULL query (list/detail
-	// filter): it has been soft-deleted, so the schedule has zero LIVE tasks beyond
-	// the prior terminal one. Specifically the round's new task must be unfindable
-	// when filtering deleted_at IS NULL.
-	var liveLatest model.SummaryTask
-	err = db.Where("schedule_id = ? AND deleted_at IS NULL AND trigger_type = ?",
-		sched.ID, model.TriggerScheduled).Order("id DESC").First(&liveLatest).Error
-	if err != gorm.ErrRecordNotFound {
-		t.Fatalf("zero-confirmed placeholder must be soft-deleted (unfindable under deleted_at IS NULL), got err=%v task=%+v", err, liveLatest)
+
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("schedule_id = ? AND deleted_at IS NULL", sched.ID).Count(&taskCount)
+	if taskCount != 1 {
+		t.Fatalf("zero-confirmed skip must not create/delete visible tasks, got %d", taskCount)
 	}
-	// And the row physically still exists but with deleted_at set (Unscoped read).
 	var task model.SummaryTask
-	if err := db.Where("schedule_id = ?", sched.ID).Order("id DESC").First(&task).Error; err != nil {
-		t.Fatalf("load latest task (incl soft-deleted): %v", err)
+	if err := db.First(&task, prior.ID).Error; err != nil {
+		t.Fatalf("load prior task: %v", err)
 	}
-	if task.DeletedAt == nil {
-		t.Errorf("zero-confirmed placeholder must have deleted_at set (soft-deleted), got nil")
+	if task.Status != model.StatusCompleted || task.DeletedAt != nil {
+		t.Fatalf("prior task should remain completed and visible, got status=%d deleted_at=%v", task.Status, task.DeletedAt)
 	}
-	// No children built for the skipped round.
-	var parts, prs int64
-	db.Model(&model.SummaryParticipant{}).Where("task_id = ?", task.ID).Count(&parts)
-	db.Model(&model.PersonalResult{}).Where("task_id = ?", task.ID).Count(&prs)
-	if parts != 0 || prs != 0 {
-		t.Errorf("zero-confirmed round must build no children, got participants=%d personal_results=%d", parts, prs)
-	}
-	// summary_source rows are built BEFORE the accepted-count gate, so the
-	// zero-confirm branch must physically clean them up; otherwise they leak as
-	// orphans (parent task only soft-deleted) every skipped round.
-	var srcs int64
-	db.Model(&model.SummarySource{}).Where("task_id = ?", task.ID).Count(&srcs)
-	if srcs != 0 {
-		t.Errorf("zero-confirmed round must leave no orphan summary_source rows, got %d", srcs)
+	var parts, prs, srcs int64
+	db.Model(&model.SummaryParticipant{}).Where("task_id = ?", prior.ID).Count(&parts)
+	db.Model(&model.PersonalResult{}).Where("task_id = ?", prior.ID).Count(&prs)
+	db.Model(&model.SummarySource{}).Where("task_id = ?", prior.ID).Count(&srcs)
+	if parts != 1 || prs != 0 || srcs != 0 {
+		t.Errorf("zero-confirmed skip should preserve existing task children without rebuilding, got participants=%d personal_results=%d sources=%d", parts, prs, srcs)
 	}
 }
 
@@ -613,8 +700,13 @@ func TestClaim_ConfirmV5_AllConfirmed_MultiRoundNoReconfirm(t *testing.T) {
 
 	t1 := runRound("round1")
 	t2 := runRound("round2")
-	if t1 == t2 {
-		t.Fatalf("each round must create a distinct task, got %d twice", t1)
+	if t1 != t2 {
+		t.Fatalf("scheduled rounds should reuse the same task, got %d then %d", t1, t2)
+	}
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("schedule_id = ? AND deleted_at IS NULL", sched.ID).Count(&taskCount)
+	if taskCount != 1 {
+		t.Fatalf("multi-round schedule must keep one visible task, got %d", taskCount)
 	}
 }
 

--- a/internal/worker/scheduler_lastrun_test.go
+++ b/internal/worker/scheduler_lastrun_test.go
@@ -362,9 +362,10 @@ func TestClaim_AutoRequeue_AllParticipantsAccepted_DispatchSelectsAll(t *testing
 	old := time.Now().UTC().Add(-48 * time.Hour)
 	// AUTO (confirm_policy=0) + creator u1 + u2 + u3 configured.
 	sched := seedDueScheduleWithPolicy(t, db, &old, model.SchedConfirmAuto, "u2", "u3")
-	// Prior terminal bound task under the schedule => this is the REQUEUE path
-	// (latest exists, terminal so no overlap skip), distinct from first-run.
-	seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	// Prior terminal bound task under the schedule => this is the REQUEUE path.
+	// Scheduled runs reuse this task and append result versions instead of creating
+	// another user-visible task.
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
 
 	now := time.Now().UTC()
 	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, true /* featureTeamSchedule */)
@@ -372,10 +373,18 @@ func TestClaim_AutoRequeue_AllParticipantsAccepted_DispatchSelectsAll(t *testing
 		t.Fatalf("claim: %v", err)
 	}
 	if !claimed || taskID == 0 {
-		t.Fatalf("AUTO requeue should create a task, got claimed=%v taskID=%d", claimed, taskID)
+		t.Fatalf("AUTO requeue should reuse a task, got claimed=%v taskID=%d", claimed, taskID)
+	}
+	if taskID != prior.ID {
+		t.Fatalf("AUTO requeue should reuse bound task %d, got %d", prior.ID, taskID)
+	}
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("schedule_id = ? AND deleted_at IS NULL", sched.ID).Count(&taskCount)
+	if taskCount != 1 {
+		t.Fatalf("AUTO requeue must not create another visible task, got %d", taskCount)
 	}
 
-	// New task must be a scheduled task (trigger_type=2).
+	// Reused task must be a scheduled task (trigger_type=2).
 	var task model.SummaryTask
 	if err := db.First(&task, taskID).Error; err != nil {
 		t.Fatalf("load task: %v", err)
@@ -462,7 +471,7 @@ func TestClaim_ConfirmV5_PartialConfirm_OnlyConfirmedMaterialized(t *testing.T) 
 		t.Fatalf("claim: %v", err)
 	}
 	if !claimed || taskID == 0 {
-		t.Fatalf("partial-confirm round should create a task, got claimed=%v taskID=%d", claimed, taskID)
+		t.Fatalf("partial-confirm round should reuse a task, got claimed=%v taskID=%d", claimed, taskID)
 	}
 
 	var total, accepted int64
@@ -520,62 +529,45 @@ func TestClaim_ConfirmV5_ZeroConfirmed_NextRunAdvancesLastRunPreserved(t *testin
 	}
 }
 
-// V5 §4.3/Q2 (soft-delete behavior): when NOBODY (creator included) has confirmed,
-// the whole round is skipped. The freshly-created placeholder task is SOFT-DELETED
-// (deleted_at set), NOT left as a Cancelled shell -- so it never surfaces in any
-// deleted_at IS NULL query (list/detail). No participants/personal_results are
-// built and no result is produced. (creator is no longer auto-accepted.)
+// V5 §4.3/Q2: when NOBODY (creator included) has confirmed, the whole
+// round is skipped without creating another task or mutating the existing bound task.
 func TestClaim_ConfirmV5_ZeroConfirmed_RoundSkipped(t *testing.T) {
 	db := newSchedulerTestDB(t)
 	old := time.Now().UTC().Add(-48 * time.Hour)
 	// u1(creator)+u2+u3 all unconfirmed.
 	sched := seedDueScheduleV5Confirm(t, db, &old, []string{"u2", "u3"} /* none confirmed */)
-	seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
 
 	now := time.Now().UTC()
 	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, true)
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
-	// The round is claimed (next_run_at advances) but produces no runnable task.
 	if !claimed {
 		t.Fatalf("zero-confirmed round should still claim (advance next_run), got claimed=%v", claimed)
 	}
 	if taskID != 0 {
 		t.Fatalf("zero-confirmed round must report taskID=0 (skipped), got %d", taskID)
 	}
-	// The placeholder task must NOT appear in a deleted_at IS NULL query (list/detail
-	// filter): it has been soft-deleted, so the schedule has zero LIVE tasks beyond
-	// the prior terminal one. Specifically the round's new task must be unfindable
-	// when filtering deleted_at IS NULL.
-	var liveLatest model.SummaryTask
-	err = db.Where("schedule_id = ? AND deleted_at IS NULL AND trigger_type = ?",
-		sched.ID, model.TriggerScheduled).Order("id DESC").First(&liveLatest).Error
-	if err != gorm.ErrRecordNotFound {
-		t.Fatalf("zero-confirmed placeholder must be soft-deleted (unfindable under deleted_at IS NULL), got err=%v task=%+v", err, liveLatest)
+
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("schedule_id = ? AND deleted_at IS NULL", sched.ID).Count(&taskCount)
+	if taskCount != 1 {
+		t.Fatalf("zero-confirmed skip must not create/delete visible tasks, got %d", taskCount)
 	}
-	// And the row physically still exists but with deleted_at set (Unscoped read).
 	var task model.SummaryTask
-	if err := db.Where("schedule_id = ?", sched.ID).Order("id DESC").First(&task).Error; err != nil {
-		t.Fatalf("load latest task (incl soft-deleted): %v", err)
+	if err := db.First(&task, prior.ID).Error; err != nil {
+		t.Fatalf("load prior task: %v", err)
 	}
-	if task.DeletedAt == nil {
-		t.Errorf("zero-confirmed placeholder must have deleted_at set (soft-deleted), got nil")
+	if task.Status != model.StatusCompleted || task.DeletedAt != nil {
+		t.Fatalf("prior task should remain completed and visible, got status=%d deleted_at=%v", task.Status, task.DeletedAt)
 	}
-	// No children built for the skipped round.
-	var parts, prs int64
-	db.Model(&model.SummaryParticipant{}).Where("task_id = ?", task.ID).Count(&parts)
-	db.Model(&model.PersonalResult{}).Where("task_id = ?", task.ID).Count(&prs)
-	if parts != 0 || prs != 0 {
-		t.Errorf("zero-confirmed round must build no children, got participants=%d personal_results=%d", parts, prs)
-	}
-	// summary_source rows are built BEFORE the accepted-count gate, so the
-	// zero-confirm branch must physically clean them up; otherwise they leak as
-	// orphans (parent task only soft-deleted) every skipped round.
-	var srcs int64
-	db.Model(&model.SummarySource{}).Where("task_id = ?", task.ID).Count(&srcs)
-	if srcs != 0 {
-		t.Errorf("zero-confirmed round must leave no orphan summary_source rows, got %d", srcs)
+	var parts, prs, srcs int64
+	db.Model(&model.SummaryParticipant{}).Where("task_id = ?", prior.ID).Count(&parts)
+	db.Model(&model.PersonalResult{}).Where("task_id = ?", prior.ID).Count(&prs)
+	db.Model(&model.SummarySource{}).Where("task_id = ?", prior.ID).Count(&srcs)
+	if parts != 1 || prs != 0 || srcs != 0 {
+		t.Errorf("zero-confirmed skip should preserve existing task children without rebuilding, got participants=%d personal_results=%d sources=%d", parts, prs, srcs)
 	}
 }
 
@@ -613,8 +605,13 @@ func TestClaim_ConfirmV5_AllConfirmed_MultiRoundNoReconfirm(t *testing.T) {
 
 	t1 := runRound("round1")
 	t2 := runRound("round2")
-	if t1 == t2 {
-		t.Fatalf("each round must create a distinct task, got %d twice", t1)
+	if t1 != t2 {
+		t.Fatalf("scheduled rounds should reuse the same task, got %d then %d", t1, t2)
+	}
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("schedule_id = ? AND deleted_at IS NULL", sched.ID).Count(&taskCount)
+	if taskCount != 1 {
+		t.Fatalf("multi-round schedule must keep one visible task, got %d", taskCount)
 	}
 }
 

--- a/internal/worker/scheduler_lastrun_test.go
+++ b/internal/worker/scheduler_lastrun_test.go
@@ -24,6 +24,7 @@ func newSchedulerTestDB(t *testing.T) *gorm.DB {
 		&model.SummaryParticipant{},
 		&model.PersonalResult{},
 		&model.SummarySource{},
+		&model.SummaryEvent{},
 	); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/worker/scheduler_lastrun_test.go
+++ b/internal/worker/scheduler_lastrun_test.go
@@ -24,6 +24,7 @@ func newSchedulerTestDB(t *testing.T) *gorm.DB {
 		&model.SummaryParticipant{},
 		&model.PersonalResult{},
 		&model.SummarySource{},
+		&model.SummaryNotification{},
 		&model.SummaryEvent{},
 	); err != nil {
 		t.Fatalf("migrate: %v", err)
@@ -133,6 +134,38 @@ func TestClaim_RequeueAdvancesLastRunAt(t *testing.T) {
 	}
 	if got.NextRunAt == nil || !got.NextRunAt.After(now) {
 		t.Errorf("next_run_at should move forward, got %v", got.NextRunAt)
+	}
+}
+
+func TestClaim_RequeueClearsPriorNotifications(t *testing.T) {
+	db := newSchedulerTestDB(t)
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	sched := seedDueSchedule(t, db, &old)
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	now := time.Now().UTC()
+	if err := db.Create(&model.SummaryNotification{
+		TaskID:       prior.ID,
+		NotifyKind:   model.NotifyKindCompleted,
+		RecipientUID: "u1",
+		Status:       model.NotifyStatusSent,
+		CreatedAt:    now.Add(-time.Hour),
+		UpdatedAt:    now.Add(-time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("seed notification: %v", err)
+	}
+
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, now, 30, false)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed || taskID != prior.ID {
+		t.Fatalf("expected requeue on same task, got claimed=%v taskID=%d want %d", claimed, taskID, prior.ID)
+	}
+
+	var notifCount int64
+	db.Model(&model.SummaryNotification{}).Where("task_id = ?", prior.ID).Count(&notifCount)
+	if notifCount != 0 {
+		t.Fatalf("requeue must clear stale notification dedup rows, got %d", notifCount)
 	}
 }
 

--- a/internal/worker/summary_stream_client.go
+++ b/internal/worker/summary_stream_client.go
@@ -1,0 +1,181 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
+)
+
+var summaryStreamHTTPClient = &http.Client{Timeout: 0}
+
+type summaryStreamSender struct {
+	url          string
+	taskID       int64
+	runID        string
+	scope        string
+	targetUserID string
+	ch           chan streaming.Event
+	closed       chan struct{}
+	once         sync.Once
+	degraded     atomic.Bool
+}
+
+func newSummaryStreamSender(ctx context.Context, cfg *config.Config, taskID int64, targetUserID, scope, runID string) *summaryStreamSender {
+	callbackURL := ""
+	if cfg != nil {
+		callbackURL = cfg.WorkerCallbackURL
+	}
+	url := summaryStreamURL(callbackURL)
+	s := &summaryStreamSender{
+		url:          url,
+		taskID:       taskID,
+		runID:        runID,
+		scope:        streaming.NormalizeScope(scope),
+		targetUserID: targetUserID,
+		ch:           make(chan streaming.Event, 256),
+		closed:       make(chan struct{}),
+	}
+	if url == "" {
+		s.degraded.Store(true)
+		close(s.closed)
+		return s
+	}
+	s.start(ctx)
+	s.Send(streaming.Event{Type: streaming.EventStart})
+	return s
+}
+
+func summaryStreamURL(callbackURL string) string {
+	callbackURL = strings.TrimRight(strings.TrimSpace(callbackURL), "/")
+	if callbackURL == "" {
+		return ""
+	}
+	if strings.HasSuffix(callbackURL, "/internal/task-event") {
+		return strings.TrimSuffix(callbackURL, "/internal/task-event") + "/internal/summary-stream"
+	}
+	return strings.TrimRight(callbackURL, "/") + "/summary-stream"
+}
+
+func (s *summaryStreamSender) start(ctx context.Context) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer close(s.closed)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, pr)
+		if err != nil {
+			s.markDegraded("create internal stream request", err)
+			_ = pr.CloseWithError(err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-ndjson")
+		resp, err := summaryStreamHTTPClient.Do(req)
+		if err != nil {
+			s.markDegraded("post internal stream", err)
+			_ = pr.CloseWithError(err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			s.markDegraded("internal stream non-2xx", fmt.Errorf("status=%d body=%s", resp.StatusCode, string(body)))
+		}
+	}()
+
+	go func() {
+		enc := json.NewEncoder(pw)
+		defer pw.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-s.ch:
+				if !ok {
+					return
+				}
+				if err := enc.Encode(ev); err != nil {
+					s.markDegraded("write internal stream", err)
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (s *summaryStreamSender) Send(ev streaming.Event) bool {
+	if s == nil || s.degraded.Load() {
+		return false
+	}
+	ev.TaskID = s.taskID
+	ev.RunID = s.runID
+	ev.Scope = s.scope
+	ev.TargetUserID = s.targetUserID
+	select {
+	case s.ch <- ev:
+		return true
+	default:
+		s.markDegraded("enqueue internal stream", fmt.Errorf("buffer full"))
+		return false
+	}
+}
+
+func (s *summaryStreamSender) Stage(stage string) {
+	if stage == "" {
+		return
+	}
+	s.Send(streaming.Event{Type: streaming.EventStage, Stage: stage})
+}
+
+func (s *summaryStreamSender) Delta(delta string) error {
+	if delta == "" {
+		return nil
+	}
+	s.Send(streaming.Event{Type: streaming.EventDelta, Delta: delta})
+	return nil
+}
+
+func (s *summaryStreamSender) Done(status int) {
+	s.Send(streaming.Event{Type: streaming.EventDone, Status: status})
+}
+
+func (s *summaryStreamSender) Error(message string) {
+	s.Send(streaming.Event{Type: streaming.EventError, Message: message})
+}
+
+func (s *summaryStreamSender) Close() {
+	if s == nil || s.url == "" {
+		return
+	}
+	s.once.Do(func() {
+		close(s.ch)
+		select {
+		case <-s.closed:
+		case <-time.After(2 * time.Second):
+		}
+	})
+}
+
+func (s *summaryStreamSender) markDegraded(where string, err error) {
+	if s == nil {
+		return
+	}
+	if s.degraded.CompareAndSwap(false, true) {
+		log.Printf("[summary-stream] degraded task=%d user=%s run=%s at %s: %v", s.taskID, s.targetUserID, s.runID, where, err)
+	}
+}
+
+func newSummaryRunID(taskID int64, userID string) string {
+	var b bytes.Buffer
+	_, _ = fmt.Fprintf(&b, "%d:%s:%d", taskID, userID, time.Now().UnixNano())
+	return b.String()
+}

--- a/migrations/sql/20260710-01-summary-result-refine.sql
+++ b/migrations/sql/20260710-01-summary-result-refine.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+ALTER TABLE `summary_result`
+  ADD COLUMN `operation_type` varchar(32) NOT NULL DEFAULT 'generate' AFTER `version`,
+  ADD COLUMN `operation_note` text NULL AFTER `operation_type`,
+  ADD COLUMN `parent_result_id` bigint NULL AFTER `operation_note`,
+  ADD COLUMN `created_by` varchar(64) NOT NULL DEFAULT '' AFTER `parent_result_id`;
+
+-- +migrate Down
+ALTER TABLE `summary_result`
+  DROP COLUMN `created_by`,
+  DROP COLUMN `parent_result_id`,
+  DROP COLUMN `operation_note`,
+  DROP COLUMN `operation_type`;

--- a/migrations/sql/20260710-02-personal-result-refine.sql
+++ b/migrations/sql/20260710-02-personal-result-refine.sql
@@ -18,9 +18,9 @@ CREATE TABLE IF NOT EXISTS `summary_personal_result_version` (
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
-  KEY `idx_personal_result_version_task_user_version` (`task_id`, `user_id`, `version`),
+  UNIQUE KEY `uk_personal_result_version_task_user_version` (`task_id`, `user_id`, `version`),
   KEY `idx_personal_result_version_parent` (`parent_version_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- +migrate Down
 DROP TABLE IF EXISTS `summary_personal_result_version`;

--- a/migrations/sql/20260710-02-personal-result-refine.sql
+++ b/migrations/sql/20260710-02-personal-result-refine.sql
@@ -1,0 +1,26 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS `summary_personal_result_version` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `task_id` bigint NOT NULL,
+  `participant_ref_id` bigint NOT NULL,
+  `user_id` varchar(64) NOT NULL,
+  `content` mediumtext NOT NULL,
+  `citations_json` mediumtext NULL,
+  `msg_count` int NOT NULL DEFAULT 0,
+  `total_token_used` int NOT NULL DEFAULT 0,
+  `model_version` varchar(50) NOT NULL DEFAULT '',
+  `version` int NOT NULL DEFAULT 1,
+  `operation_type` varchar(32) NOT NULL DEFAULT 'generate',
+  `operation_note` text NULL,
+  `parent_version_id` bigint NULL,
+  `created_by` varchar(64) NOT NULL DEFAULT '',
+  `generated_at` datetime(6) NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_personal_result_version_task_user_version` (`task_id`, `user_id`, `version`),
+  KEY `idx_personal_result_version_parent` (`parent_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_personal_result_version`;

--- a/migrations/sql/20260710-02-personal-result-refine.sql
+++ b/migrations/sql/20260710-02-personal-result-refine.sql
@@ -1,0 +1,26 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS `summary_personal_result_version` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `task_id` bigint NOT NULL,
+  `participant_ref_id` bigint NOT NULL,
+  `user_id` varchar(64) NOT NULL,
+  `content` mediumtext NOT NULL,
+  `citations_json` mediumtext NULL,
+  `msg_count` int NOT NULL DEFAULT 0,
+  `total_token_used` int NOT NULL DEFAULT 0,
+  `model_version` varchar(50) NOT NULL DEFAULT '',
+  `version` int NOT NULL DEFAULT 1,
+  `operation_type` varchar(32) NOT NULL DEFAULT 'generate',
+  `operation_note` text NULL,
+  `parent_version_id` bigint NULL,
+  `created_by` varchar(64) NOT NULL DEFAULT '',
+  `generated_at` datetime(6) NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  KEY `idx_personal_result_version_task_user_version` (`task_id`, `user_id`, `version`),
+  KEY `idx_personal_result_version_parent` (`parent_version_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_personal_result_version`;

--- a/migrations/sql/20260710-03-current-summary-version.sql
+++ b/migrations/sql/20260710-03-current-summary-version.sql
@@ -1,0 +1,53 @@
+-- +migrate Up
+ALTER TABLE `summary_task`
+  ADD COLUMN `current_result_id` bigint NULL AFTER `schedule_id`,
+  ADD KEY `idx_summary_task_current_result_id` (`current_result_id`);
+
+UPDATE `summary_task` t
+JOIN (
+  SELECT r.`task_id`, r.`id`
+  FROM `summary_result` r
+  JOIN (
+    SELECT `task_id`, MAX(`version`) AS `max_version`
+    FROM `summary_result`
+    GROUP BY `task_id`
+  ) mv ON mv.`task_id` = r.`task_id` AND mv.`max_version` = r.`version`
+  JOIN (
+    SELECT `task_id`, `version`, MAX(`id`) AS `max_id`
+    FROM `summary_result`
+    GROUP BY `task_id`, `version`
+  ) mi ON mi.`task_id` = r.`task_id` AND mi.`version` = r.`version` AND mi.`max_id` = r.`id`
+) latest ON latest.`task_id` = t.`id`
+SET t.`current_result_id` = latest.`id`
+WHERE t.`current_result_id` IS NULL;
+
+ALTER TABLE `summary_personal_result`
+  ADD COLUMN `current_version_id` bigint NULL AFTER `model_version`,
+  ADD KEY `idx_personal_result_current_version_id` (`current_version_id`);
+
+UPDATE `summary_personal_result` pr
+JOIN (
+  SELECT v.`task_id`, v.`user_id`, v.`id`
+  FROM `summary_personal_result_version` v
+  JOIN (
+    SELECT `task_id`, `user_id`, MAX(`version`) AS `max_version`
+    FROM `summary_personal_result_version`
+    GROUP BY `task_id`, `user_id`
+  ) mv ON mv.`task_id` = v.`task_id` AND mv.`user_id` = v.`user_id` AND mv.`max_version` = v.`version`
+  JOIN (
+    SELECT `task_id`, `user_id`, `version`, MAX(`id`) AS `max_id`
+    FROM `summary_personal_result_version`
+    GROUP BY `task_id`, `user_id`, `version`
+  ) mi ON mi.`task_id` = v.`task_id` AND mi.`user_id` = v.`user_id` AND mi.`version` = v.`version` AND mi.`max_id` = v.`id`
+) latest ON latest.`task_id` = pr.`task_id` AND latest.`user_id` = pr.`user_id`
+SET pr.`current_version_id` = latest.`id`
+WHERE pr.`current_version_id` IS NULL;
+
+-- +migrate Down
+ALTER TABLE `summary_personal_result`
+  DROP KEY `idx_personal_result_current_version_id`,
+  DROP COLUMN `current_version_id`;
+
+ALTER TABLE `summary_task`
+  DROP KEY `idx_summary_task_current_result_id`,
+  DROP COLUMN `current_result_id`;

--- a/migrations/sql/20260714-01-schedule-generation-instruction.sql
+++ b/migrations/sql/20260714-01-schedule-generation-instruction.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE `summary_schedule`
+  ADD COLUMN `generation_instruction` text NULL AFTER `title`;
+
+-- +migrate Down
+ALTER TABLE `summary_schedule`
+  DROP COLUMN `generation_instruction`;

--- a/migrations/sql/20260714-01-schedule-generation-instruction.sql
+++ b/migrations/sql/20260714-01-schedule-generation-instruction.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE `summary_schedule`
+  ADD COLUMN `generation_instruction` text COLLATE utf8mb4_unicode_ci NULL AFTER `title`;
+
+-- +migrate Down
+ALTER TABLE `summary_schedule`
+  DROP COLUMN `generation_instruction`;

--- a/migrations/sql/20260714-01-schedule-generation-instruction.sql
+++ b/migrations/sql/20260714-01-schedule-generation-instruction.sql
@@ -1,6 +1,6 @@
 -- +migrate Up
 ALTER TABLE `summary_schedule`
-  ADD COLUMN `generation_instruction` text NULL AFTER `title`;
+  ADD COLUMN `generation_instruction` text COLLATE utf8mb4_unicode_ci NULL AFTER `title`;
 
 -- +migrate Down
 ALTER TABLE `summary_schedule`


### PR DESCRIPTION
## Summary
- Add streaming support for smart-summary generation output.
- Add internal worker-to-api stream delivery and public summary stream endpoints.
- Add LLM streaming call path and wire it into summary generation.
- Support streaming for initial generation, regenerate, and refine flows where applicable.
- Keep persisted database results as the final source of truth after generation completes.
- Preserve existing non-streaming behavior as fallback.
- Improve scheduled single-person task dispatch so scheduled runs continue through the generation pipeline reliably.

## Implementation
- Add stream event types and in-memory stream hub for summary output.
- Add API handlers/routes for summary stream and refine stream.
- Add worker stream client for sending incremental output to summary-api.
- Add streaming LLM call support.
- Wire streaming into personal summary, team summary, regenerate, and refine flows.
- Add hub tests for stream publish/subscribe behavior.

## Testing
- `GOCACHE=/tmp/octo-go-build-cache CGO_ENABLED=0 go test ./...`

Closes #155
