### PR TITLE
feat(summary): stream smart summary generation output

### DIFF
--- a/cmd/summary-api/main.go
+++ b/cmd/summary-api/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 )
 
 func main() {
@@ -68,8 +69,10 @@ func main() {
 	httpResolver := auth.NewHTTPTokenResolver(cfg.OctoAPIURL)
 	authResolver := auth.NewCachedResolver(httpResolver, 30*time.Second, 10000)
 
-	// Init WebSocket hub
+	// Init realtime hubs. streamHub is in-memory and Phase 1 requires summary-api single-replica
+	// deployment (or sticky routing); multi-replica needs Redis Pub/Sub.
 	hub := ws.NewHub(summaryDB)
+	streamHub := streaming.NewHub(60 * time.Second)
 
 	// Inject IM DB resolvers
 	if imDB != nil {
@@ -100,14 +103,14 @@ func main() {
 	if cfg.LLMApiURL != "" && cfg.LLMApiKey != "" && cfg.LLMModel != "" {
 		refineLLM = service.NewLLMClient(cfg.LLMApiURL, cfg.LLMApiKey, cfg.LLMModel, cfg.LLMTimeout, cfg.LLMMaxToken, cfg.LLMEnableThinking, cfg.ToolCallTimeout)
 	}
-	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit, refineLLM)
+	publicRouter := router.SetupPublic(summaryDB, imDB, hub, authResolver, cfg.WorkerTriggerURL, cfg.CandidateQueryLimit, cfg.FeatureTeamSchedule, cfg.SummaryCustomTemplateLimit, streamHub, refineLLM)
 	publicSrv := &http.Server{
 		Addr:    ":" + cfg.APIPort,
 		Handler: publicRouter,
 	}
 
 	// Internal callback server (Docker network accessible for worker callbacks)
-	internalRouter, _ := router.SetupInternal(hub)
+	internalRouter, _ := router.SetupInternal(hub, streamHub)
 	internalSrv := &http.Server{
 		Addr:    ":" + cfg.APIInternalPort,
 		Handler: internalRouter,

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -372,6 +372,184 @@ func (h *EditHandler) RefineSummary(c *gin.Context) {
 	})
 }
 
+func (h *EditHandler) RefineSummaryStream(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid task id"})
+		return
+	}
+	var req refineSummaryReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+
+	spaceID := middleware.GetSpaceID(c)
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if task.CreatorID != userID {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "仅创建者可调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	baseResult, err := queryDisplayResult(h.db, taskID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "总结结果不存在"})
+		return
+	}
+	if baseResult.ID != req.BaseResultID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	w := c.Writer
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	_ = writeSSE(w, "start", gin.H{"type": "start", "task_id": taskID, "scope": "team"})
+	w.Flush()
+
+	writeStreamError := func(message string) {
+		_ = writeSSE(w, "error", gin.H{"type": "error", "task_id": taskID, "scope": "team", "message": message})
+		w.Flush()
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.CallStream(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", baseResult.Content, feedback)},
+	}, 0.1, func(delta string) error {
+		if delta == "" {
+			return nil
+		}
+		if err := writeSSE(w, "delta", gin.H{"type": "delta", "task_id": taskID, "scope": "team", "delta": delta}); err != nil {
+			return err
+		}
+		w.Flush()
+		return nil
+	})
+	if err != nil {
+		log.Printf("[refine-stream] llm error task=%d result=%d: %v", taskID, baseResult.ID, err)
+		writeStreamError("调整失败，请稍后重试")
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		writeStreamError("调整结果为空")
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		writeStreamError("调整结果超过 500KB 限制")
+		return
+	}
+
+	basePlainCitations := baseResult.GetCitations()
+	if !callerPlainCitationsVisible(h.db, &task, userID, &baseResult) {
+		basePlainCitations = []model.Citation{}
+	}
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, basePlainCitations)
+	cleanedTeamCitations := cleanUnreferencedTeamCitations(newContent, baseResult.GetTeamCitations())
+	newResult := model.SummaryResult{
+		TaskID:         taskID,
+		Content:        newContent,
+		TotalMsgCount:  baseResult.TotalMsgCount,
+		TotalTokenUsed: baseResult.TotalTokenUsed + tokens,
+		ModelVersion:   h.llm.ModelVersion(),
+		OperationType:  "refine",
+		OperationNote:  feedback,
+		ParentResultID: &baseResult.ID,
+		CreatedBy:      userID,
+		GeneratedAt:    timezone.Now(),
+	}
+	newResult.SetCitations(cleanedCitations)
+	newResult.SetTeamCitations(cleanedTeamCitations)
+
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var taskCheck model.SummaryTask
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", taskID).First(&taskCheck).Error; err != nil {
+			return err
+		}
+		latest, err := queryDisplayResult(tx, taskID)
+		if err != nil {
+			return err
+		}
+		if latest.ID != baseResult.ID {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		if taskCheck.Status != model.StatusCompleted {
+			return service.NewBizError(40005, "任务状态已变更", http.StatusBadRequest)
+		}
+		nextVer, err := service.GetNextVersion(tx, taskID)
+		if err != nil {
+			return err
+		}
+		newResult.Version = nextVer
+		if err := tx.Create(&newResult).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", newResult.ID).Error; err != nil {
+			return err
+		}
+		if err := service.PruneSummaryResultVersions(tx, taskID, service.SummaryResultVersionKeepLimit); err != nil {
+			return err
+		}
+		return appendBoundScheduleGenerationInstruction(tx, taskCheck, feedback)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			writeStreamError(bizError.Message)
+			return
+		}
+		log.Printf("[refine-stream] transaction error task=%d: %v", taskID, err)
+		writeStreamError("internal error")
+		return
+	}
+
+	_ = writeSSE(w, "done", gin.H{
+		"type":             "done",
+		"task_id":          taskID,
+		"scope":            "team",
+		"result_id":        newResult.ID,
+		"version":          newResult.Version,
+		"content":          newResult.Content,
+		"citations":        newResult.GetCitations(),
+		"team_citations":   newResult.GetTeamCitations(),
+		"total_msg_count":  newResult.TotalMsgCount,
+		"total_token_used": newResult.TotalTokenUsed,
+		"model_version":    newResult.ModelVersion,
+		"operation_type":   newResult.OperationType,
+		"operation_note":   newResult.OperationNote,
+		"parent_result_id": newResult.ParentResultID,
+		"generated_at":     newResult.GeneratedAt.Format(time.RFC3339),
+	})
+	w.Flush()
+}
+
 func (h *EditHandler) ListSummaryVersions(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -248,6 +248,243 @@ func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
 	})
 }
 
+func (h *PersonalHandler) RefinePersonalSummaryStream(c *gin.Context) {
+	if h.llm == nil {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50001, Message: "refine service is not configured"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	taskID, valid := h.parseTaskID(c)
+	if !valid {
+		return
+	}
+	var req refinePersonalReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid request body"})
+		return
+	}
+	feedback := strings.TrimSpace(req.Feedback)
+	if feedback == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback cannot be empty"})
+		return
+	}
+	if utf8.RuneCountInString(feedback) > maxFeedbackRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "feedback 不能超过 2000 字符"})
+		return
+	}
+	if req.BaseVersion <= 0 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40010, Message: "base_version is required"})
+		return
+	}
+
+	task, taskOK := h.requireTaskInSpace(c, taskID)
+	if !taskOK {
+		return
+	}
+	if task.SummaryMode != model.ModeByPerson {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "该任务不支持个人调整"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "仅已完成的任务可调整"})
+		return
+	}
+
+	var pr model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", taskID, userID).First(&pr).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "个人总结不存在"})
+		return
+	}
+	if req.BaseResultID > 0 && req.BaseResultID != pr.ID {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+	if pr.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(pr.Content) == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "个人总结未完成，无法调整"})
+		return
+	}
+
+	currentVersion, err := currentPersonalVersion(h.db, taskID, userID, pr)
+	if err != nil {
+		log.Printf("[personal-refine-stream] query current version task=%d user=%s: %v", taskID, userID, err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "internal error"})
+		return
+	}
+	if req.BaseVersion != currentVersion {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "内容已更新，请刷新后重试"})
+		return
+	}
+
+	w := c.Writer
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	_ = writeSSE(w, "start", gin.H{"type": "start", "task_id": taskID, "scope": "personal"})
+	w.Flush()
+
+	writeStreamError := func(message string) {
+		_ = writeSSE(w, "error", gin.H{"type": "error", "task_id": taskID, "scope": "personal", "message": message})
+		w.Flush()
+	}
+
+	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	defer cancel()
+	newContent, tokens, err := h.llm.CallStream(llmCtx, []service.ChatMessage{
+		{Role: "system", Content: buildRefineSystemPrompt()},
+		{Role: "user", Content: fmt.Sprintf("当前总结：\n%s\n\n用户修改意见：\n%s", pr.Content, feedback)},
+	}, 0.1, func(delta string) error {
+		if delta == "" {
+			return nil
+		}
+		if err := writeSSE(w, "delta", gin.H{"type": "delta", "task_id": taskID, "scope": "personal", "delta": delta}); err != nil {
+			return err
+		}
+		w.Flush()
+		return nil
+	})
+	if err != nil {
+		log.Printf("[personal-refine-stream] llm error task=%d personal_result=%d: %v", taskID, pr.ID, err)
+		writeStreamError("调整失败，请稍后重试")
+		return
+	}
+	newContent = strings.TrimSpace(stripMarkdownFence(newContent))
+	if newContent == "" {
+		writeStreamError("调整结果为空")
+		return
+	}
+	if len(newContent) > maxContentBytes {
+		writeStreamError("调整结果超过 500KB 限制")
+		return
+	}
+
+	cleanedCitations := service.CleanUnreferencedCitations(newContent, pr.GetCitations())
+	tmp := &model.PersonalResult{}
+	tmp.SetCitations(cleanedCitations)
+	citationsJSON := tmp.CitationsJSON
+
+	now := timezone.Now()
+	var newVersion model.PersonalResultVersion
+	shouldTriggerMeta := false
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		var latestPR model.PersonalResult
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND task_id = ? AND user_id = ?", pr.ID, taskID, userID).
+			First(&latestPR).Error; err != nil {
+			return err
+		}
+		if latestPR.WorkerStatus != model.PersonalStatusCompleted || strings.TrimSpace(latestPR.Content) == "" {
+			return service.NewBizError(40005, "个人总结状态已变更", http.StatusBadRequest)
+		}
+		versionBeforeBaseline, err := currentPersonalVersion(tx, taskID, userID, latestPR)
+		if err != nil {
+			return err
+		}
+		if req.BaseVersion != versionBeforeBaseline {
+			return service.NewBizError(40009, "内容已更新，请刷新后重试", http.StatusConflict)
+		}
+		latestVersion, err := ensurePersonalVersionBaseline(tx, latestPR)
+		if err != nil {
+			return err
+		}
+
+		nextVer, err := service.GetNextPersonalVersion(tx, taskID, userID)
+		if err != nil {
+			return err
+		}
+		newVersion = model.PersonalResultVersion{
+			TaskID:           taskID,
+			ParticipantRefID: latestPR.ParticipantRefID,
+			UserID:           userID,
+			Content:          newContent,
+			CitationsJSON:    citationsJSON,
+			MsgCount:         latestPR.MsgCount,
+			TotalTokenUsed:   latestPR.TotalTokenUsed + tokens,
+			ModelVersion:     h.llm.ModelVersion(),
+			Version:          nextVer,
+			OperationType:    "refine",
+			OperationNote:    feedback,
+			ParentVersionID:  &latestVersion.ID,
+			CreatedBy:        userID,
+			GeneratedAt:      now,
+		}
+		if err := tx.Create(&newVersion).Error; err != nil {
+			return err
+		}
+		res := tx.Model(&model.PersonalResult{}).
+			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
+			Updates(map[string]interface{}{
+				"content":            newContent,
+				"citations_json":     citationsJSON,
+				"total_token_used":   latestPR.TotalTokenUsed + tokens,
+				"model_version":      h.llm.ModelVersion(),
+				"current_version_id": newVersion.ID,
+				"generated_at":       now,
+				"edited_at":          now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return errPersonalResultGone
+		}
+		if err := service.PrunePersonalResultVersions(tx, taskID, userID, service.PersonalResultVersionKeepLimit); err != nil {
+			return err
+		}
+		var participantCount int64
+		if err := tx.Model(&model.SummaryParticipant{}).Where("task_id = ?", taskID).Count(&participantCount).Error; err != nil {
+			return err
+		}
+		if participantCount > 1 {
+			if err := h.reviveCompletedForRecompute(tx, taskID); err != nil {
+				return err
+			}
+			shouldTriggerMeta = true
+		}
+		return appendBoundScheduleGenerationInstruction(tx, *task, feedback)
+	})
+	if err != nil {
+		if bizError, isBiz := err.(*service.BizError); isBiz {
+			writeStreamError(bizError.Message)
+			return
+		}
+		if err == gorm.ErrRecordNotFound || err == errPersonalResultGone {
+			writeStreamError("个人总结不存在")
+			return
+		}
+		log.Printf("[personal-refine-stream] transaction error task=%d user=%s: %v", taskID, userID, err)
+		writeStreamError("internal error")
+		return
+	}
+	if shouldTriggerMeta {
+		go h.triggerWorker(model.WorkerTriggerRequest{
+			Type:   "meta_summary",
+			TaskID: taskID,
+		})
+	}
+
+	_ = writeSSE(w, "done", gin.H{
+		"type":             "done",
+		"task_id":          taskID,
+		"scope":            "personal",
+		"result_id":        pr.ID,
+		"version_id":       newVersion.ID,
+		"version":          newVersion.Version,
+		"content":          newContent,
+		"citations":        newVersion.GetCitations(),
+		"msg_count":        newVersion.MsgCount,
+		"total_token_used": newVersion.TotalTokenUsed,
+		"model_version":    newVersion.ModelVersion,
+		"operation_type":   newVersion.OperationType,
+		"operation_note":   newVersion.OperationNote,
+		"parent_result_id": newVersion.ParentVersionID,
+		"generated_at":     newVersion.GeneratedAt.Format(time.RFC3339),
+	})
+	w.Flush()
+}
+
 func (h *PersonalHandler) ListPersonalVersions(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	taskID, valid := h.parseTaskID(c)

--- a/internal/api/handler/stream.go
+++ b/internal/api/handler/stream.go
@@ -1,0 +1,177 @@
+package handler
+
+import (
+	"bufio"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+const sseHeartbeatInterval = 5 * time.Second
+
+type StreamHandler struct {
+	db  *gorm.DB
+	hub *streaming.Hub
+}
+
+func NewStreamHandler(db *gorm.DB, hub *streaming.Hub) *StreamHandler {
+	return &StreamHandler{db: db, hub: hub}
+}
+
+// Ingest handles POST /internal/summary-stream. It reads worker-produced NDJSON
+// over a single chunked request and publishes events to the in-memory SSE hub.
+func (h *StreamHandler) Ingest(c *gin.Context) {
+	if h == nil || h.hub == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "summary stream hub not configured"})
+		return
+	}
+	if expected := strings.TrimSpace(os.Getenv("SUMMARY_STREAM_INTERNAL_TOKEN")); expected != "" {
+		got := c.GetHeader("X-Internal-Token")
+		if subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+	}
+	defer c.Request.Body.Close()
+
+	scanner := bufio.NewScanner(c.Request.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev streaming.Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			log.Printf("[summary-stream] invalid event: %v", err)
+			continue
+		}
+		h.hub.Publish(ev)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("[summary-stream] ingest read error: %v", err)
+	}
+	c.JSON(http.StatusOK, gin.H{"code": 0, "message": "ok"})
+}
+
+// StreamSummary handles GET /api/v1/summaries/:id/stream.
+func (h *StreamHandler) StreamSummary(c *gin.Context) {
+	if h == nil || h.hub == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "summary stream hub not configured"})
+		return
+	}
+	taskID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || taskID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid task id"})
+		return
+	}
+	spaceID := middleware.GetSpaceID(c)
+	userID := middleware.GetUserID(c)
+	if spaceID == "" || userID == "" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "missing auth context"})
+		return
+	}
+	if !h.canAccessTask(taskID, spaceID, userID) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "task not found"})
+		return
+	}
+
+	scope := streaming.NormalizeScope(c.DefaultQuery("scope", streaming.ScopePersonal))
+	targetUserID := userID
+	if scope == streaming.ScopeTeam {
+		// Team summary is task-level rather than user-level: all authorized
+		// participants subscribe to the same stream key.
+		targetUserID = ""
+	}
+
+	w := c.Writer
+	// Keep SSE alive even if a future http.Server WriteTimeout is configured.
+	// Streaming endpoints must not inherit finite write deadlines.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	w.Flush()
+
+	ch, snapshot, done, cancel := h.hub.Subscribe(taskID, scope, targetUserID)
+	defer cancel()
+
+	if snapshot != "" {
+		_ = writeSSE(w, streaming.EventSnapshot, streaming.Event{Type: streaming.EventSnapshot, TaskID: taskID, Scope: scope, Content: snapshot})
+		w.Flush()
+	}
+	if done {
+		_ = writeSSE(w, streaming.EventDone, streaming.Event{Type: streaming.EventDone, TaskID: taskID, Scope: scope, Content: snapshot})
+		w.Flush()
+		return
+	}
+
+	ticker := time.NewTicker(sseHeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case <-ticker.C:
+			_, _ = fmt.Fprint(w, ": ping\n\n")
+			w.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := writeSSE(w, ev.Type, ev); err != nil {
+				return
+			}
+			w.Flush()
+			if ev.Type == streaming.EventDone || ev.Type == streaming.EventError {
+				return
+			}
+		}
+	}
+}
+
+func (h *StreamHandler) canAccessTask(taskID int64, spaceID, userID string) bool {
+	if h == nil || h.db == nil {
+		return false
+	}
+	var count int64
+	err := h.db.Raw(`
+SELECT COUNT(1)
+FROM summary_task t
+WHERE t.id = ?
+  AND t.space_id = ?
+  AND t.deleted_at IS NULL
+  AND (
+    t.creator_id = ?
+    OR EXISTS (
+      SELECT 1 FROM summary_participant p
+      WHERE p.task_id = t.id AND p.user_id = ?
+    )
+  )
+`, taskID, spaceID, userID, userID).Scan(&count).Error
+	return err == nil && count > 0
+}
+
+func writeSSE(w http.ResponseWriter, event string, data interface{}) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, b)
+	return err
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
 // SetupPublic configures the public API router on :8080.
-func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int, llm ...*service.LLMClient) *gin.Engine {
+func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middleware.TokenResolver, workerTriggerURL string, candidateQueryLimit int, featureTeamSchedule bool, customTemplateLimit int, streamHub *streaming.Hub, llm ...*service.LLMClient) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -20,7 +21,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	r.Use(func(c *gin.Context) {
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id")
+		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id,Accept,Accept-Language")
 		if c.Request.Method == http.MethodOptions {
 			c.AbortWithStatus(http.StatusNoContent)
 			return
@@ -47,6 +48,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	}
 	editH := handler.NewEditHandler(db, refineLLM)
 	personalH.SetLLM(refineLLM)
+	streamH := handler.NewStreamHandler(db, streamHub)
 
 	v1 := r.Group("/api/v1")
 	v1.Use(middleware.StrictAuthMiddleware(authResolver), middleware.StrictSpaceMiddleware())
@@ -55,13 +57,16 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.POST("/summaries/batch-status", taskH.BatchStatus)
 		v1.GET("/summaries", taskH.ListSummaries)
 		v1.GET("/summaries/:id", taskH.GetSummary)
+		v1.GET("/summaries/:id/stream", streamH.StreamSummary)
 		v1.GET("/summaries/:id/result", taskH.GetResult)
 		v1.POST("/summaries/:id/regenerate", taskH.Regenerate)
 		v1.POST("/summaries/:id/refine", editH.RefineSummary)
+		v1.POST("/summaries/:id/refine/stream", editH.RefineSummaryStream)
 		v1.GET("/summaries/:id/versions", editH.ListSummaryVersions)
 		v1.GET("/summaries/:id/versions/:result_id", editH.GetSummaryVersion)
 		v1.POST("/summaries/:id/versions/:result_id/restore", editH.RestoreSummaryVersion)
 		v1.POST("/summaries/:id/personal-refine", personalH.RefinePersonalSummary)
+		v1.POST("/summaries/:id/personal-refine/stream", personalH.RefinePersonalSummaryStream)
 		v1.POST("/summaries/:id/personal-regenerate", personalH.RegeneratePersonalSummary)
 		v1.GET("/summaries/:id/personal-versions", personalH.ListPersonalVersions)
 		v1.GET("/summaries/:id/personal-versions/:version_id", personalH.GetPersonalVersion)
@@ -124,7 +129,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 
 // SetupInternal configures the internal API router on :8081.
 // Returns the engine and the InternalHandler so the caller can wire the worker trigger channel.
-func SetupInternal(hub *ws.Hub) (*gin.Engine, *handler.InternalHandler) {
+func SetupInternal(hub *ws.Hub, streamHub ...*streaming.Hub) (*gin.Engine, *handler.InternalHandler) {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -134,6 +139,10 @@ func SetupInternal(hub *ws.Hub) (*gin.Engine, *handler.InternalHandler) {
 	})
 	r.POST("/internal/task-event", intH.TaskEvent)
 	r.POST("/internal/worker-trigger", intH.WorkerTrigger)
+	if len(streamHub) > 0 && streamHub[0] != nil {
+		streamH := handler.NewStreamHandler(nil, streamHub[0])
+		r.POST("/internal/summary-stream", streamH.Ingest)
+	}
 
 	return r, intH
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,10 @@ type Config struct {
 	// volume. <=0 disables the cap.
 	ScheduleMaxWindowDays int
 	WorkerCallbackURL     string
+	// SummaryStreamInternalToken optionally authenticates worker -> API
+	// POST /internal/summary-stream via X-Internal-Token. Empty preserves the
+	// existing internal-network trust model used by other internal endpoints.
+	SummaryStreamInternalToken string
 
 	// Message table count
 	MsgTableCount int
@@ -157,13 +161,14 @@ func Load() *Config {
 		WorkerInternalPort:        envStr("WORKER_INTERNAL_PORT", "8082"),
 		WorkerListenAllInterfaces: envStr("WORKER_LISTEN_ADDR", "0.0.0.0"),
 
-		WorkerMaxConcurrent:   envInt("WORKER_MAX_CONCURRENT_TASKS", 20),
-		WorkerMapConcurrency:  envInt("WORKER_MAP_CONCURRENCY", 5),
-		WorkerPollInterval:    envInt("WORKER_POLL_INTERVAL_SECONDS", 2),
-		WorkerLeaseMinutes:    envInt("WORKER_TASK_LEASE_MINUTES", 20),
-		WorkerMaxRetry:        envInt("WORKER_MAX_RETRY", 3),
-		ScheduleMaxWindowDays: envInt("SCHEDULE_MAX_WINDOW_DAYS", 30),
-		WorkerCallbackURL:     envStr("WORKER_API_CALLBACK_URL", ""),
+		WorkerMaxConcurrent:        envInt("WORKER_MAX_CONCURRENT_TASKS", 20),
+		WorkerMapConcurrency:       envInt("WORKER_MAP_CONCURRENCY", 5),
+		WorkerPollInterval:         envInt("WORKER_POLL_INTERVAL_SECONDS", 2),
+		WorkerLeaseMinutes:         envInt("WORKER_TASK_LEASE_MINUTES", 20),
+		WorkerMaxRetry:             envInt("WORKER_MAX_RETRY", 3),
+		ScheduleMaxWindowDays:      envInt("SCHEDULE_MAX_WINDOW_DAYS", 30),
+		WorkerCallbackURL:          envStr("WORKER_API_CALLBACK_URL", ""),
+		SummaryStreamInternalToken: envStr("SUMMARY_STREAM_INTERNAL_TOKEN", ""),
 
 		MsgTableCount: envInt("MSG_TABLE_COUNT", 5),
 

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -92,6 +93,7 @@ type chatRequestWithTools struct {
 	ToolChoice         interface{}            `json:"tool_choice"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
+	Stream             bool                   `json:"stream,omitempty"`
 }
 
 type chatResponseWithTools struct {
@@ -112,6 +114,10 @@ type chatResponseWithTools struct {
 	} `json:"usage"`
 }
 
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
 type chatRequest struct {
 	Model              string                 `json:"model"`
 	Messages           []ChatMessage          `json:"messages"`
@@ -119,6 +125,8 @@ type chatRequest struct {
 	MaxTokens          int                    `json:"max_tokens"`
 	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 	Thinking           *ThinkingParam         `json:"thinking,omitempty"`
+	Stream             bool                   `json:"stream,omitempty"`
+	StreamOptions      *streamOptions         `json:"stream_options,omitempty"`
 }
 
 type chatResponse struct {
@@ -222,6 +230,133 @@ func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperatur
 	}
 
 	return content, chatResp.Usage.TotalTokens, nil
+}
+
+type chatStreamResponse struct {
+	Choices []struct {
+		Delta struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			Reasoning        string `json:"reasoning"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		TotalTokens      int `json:"total_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// CallStream makes a chat completion streaming request. onDelta is called for
+// each user-visible content delta. It returns the accumulated full content so
+// downstream citation building and DB persistence remain source-of-truth.
+func (c *LLMClient) CallStream(ctx context.Context, messages []ChatMessage, temperature float64, onDelta func(string) error) (string, int, error) {
+	if config.IsKimiModel(c.model) && temperature != kimiRequiredTemperature {
+		log.Printf("[llm] overriding stream temperature from %.2f to %.2f (model constraint)",
+			temperature, kimiRequiredTemperature)
+		temperature = kimiRequiredTemperature
+	} else if config.IsKimiModel(c.model) {
+		temperature = kimiRequiredTemperature
+	}
+	log.Printf("[llm] streaming model=%s temperature=%.2f max_tokens=%d", c.model, temperature, c.maxTokens)
+
+	reqBody := chatRequest{
+		Model:         c.model,
+		Messages:      messages,
+		Temperature:   temperature,
+		MaxTokens:     c.maxTokens,
+		Stream:        true,
+		StreamOptions: &streamOptions{IncludeUsage: true},
+	}
+	thinking, kwargs := c.buildThinkingConfig()
+	reqBody.Thinking = thinking
+	reqBody.ChatTemplateKwargs = kwargs
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", 0, fmt.Errorf("LLM stream API error: status=%d body=%s", resp.StatusCode, string(respBody))
+	}
+
+	var sb strings.Builder
+	var totalTokens int
+	var reasoningLen int
+	terminalSeen := false
+	finishReason := ""
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			terminalSeen = true
+			break
+		}
+		var chunk chatStreamResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return sb.String(), totalTokens, fmt.Errorf("unmarshal LLM stream chunk: %w", err)
+		}
+		if chunk.Usage.TotalTokens > 0 {
+			totalTokens = chunk.Usage.TotalTokens
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		if chunk.Choices[0].FinishReason != "" {
+			terminalSeen = true
+			finishReason = chunk.Choices[0].FinishReason
+		}
+		delta := chunk.Choices[0].Delta.Content
+		if delta == "" {
+			reasoningLen += len(chunk.Choices[0].Delta.ReasoningContent) + len(chunk.Choices[0].Delta.Reasoning)
+			continue
+		}
+		sb.WriteString(delta)
+		if onDelta != nil {
+			if err := onDelta(delta); err != nil {
+				return sb.String(), totalTokens, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return sb.String(), totalTokens, fmt.Errorf("read LLM stream: %w", err)
+	}
+	if !terminalSeen {
+		return sb.String(), totalTokens, fmt.Errorf("LLM stream ended without terminal marker")
+	}
+	content := sb.String()
+	if content == "" && reasoningLen > 0 {
+		return "", totalTokens, fmt.Errorf("LLM returned empty streamed content: reasoning consumed output budget")
+	}
+	if content == "" && finishReason == "length" {
+		return "", totalTokens, fmt.Errorf("LLM returned empty streamed content due to token limit")
+	}
+	if content == "" {
+		return "", totalTokens, fmt.Errorf("LLM returned empty streamed content")
+	}
+	return content, totalTokens, nil
 }
 
 // CallRaw is a simple single-turn call returning text only. Used for topic narrowing.
@@ -524,9 +659,73 @@ func (c *LLMClient) CallReduce(ctx context.Context, chunkSummaries []string, sou
 	}, 0.1)
 }
 
-// CallReduceByPerson merges participant-level summaries.
-// Each participant is assigned a [Pn] tag that the LLM should reference in the output.
-func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
+// CallMapStream runs the Map phase for a user-visible single chunk and streams
+// the generated summary deltas.
+func (c *LLMClient) CallMapStream(ctx context.Context, formattedMessages string, sourceName string, chunkIndex int, msgCount int, timeStart, timeEnd string, topic string, userName string, onDelta func(string) error) (string, int, error) {
+	if strings.TrimSpace(formattedMessages) == "" {
+		return "(该时段无文本消息)", 0, nil
+	}
+	systemPrompt := buildMapSystemPrompt(userName, topic)
+	userPrompt := fmt.Sprintf("来源：%s\n时间范围：%s ~ %s\n消息数：%d 条\n\n聊天记录：\n%s",
+		sourceName, timeStart, timeEnd, msgCount, formattedMessages)
+
+	var emitted bool
+	wrappedDelta := func(delta string) error {
+		emitted = true
+		if onDelta == nil {
+			return nil
+		}
+		return onDelta(delta)
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		content, tokens, err := c.CallStream(ctx, []ChatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userPrompt},
+		}, 0.1, wrappedDelta)
+		if err == nil {
+			return content, tokens, nil
+		}
+		log.Printf("[llm] Stream Map chunk %d attempt %d failed: %v", chunkIndex, attempt+1, err)
+		if emitted {
+			return content, tokens, err
+		}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "reasoning consumed") || strings.Contains(errMsg, "empty content") {
+			return "", tokens, fmt.Errorf("reasoning budget exhausted on chunk %d", chunkIndex)
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(1<<uint(attempt)) * time.Second)
+		}
+	}
+	return fmt.Sprintf("(分片 %d %s)", chunkIndex, MapFailedMarker), 0, nil
+}
+
+// CallReduceStream merges chunk summaries and streams the final user-visible
+// reduced summary.
+func (c *LLMClient) CallReduceStream(ctx context.Context, chunkSummaries []string, sourceNames string, startTime, endTime string, totalMsgCount int, topic string, onDelta func(string) error) (string, int, error) {
+	if len(chunkSummaries) == 1 {
+		if onDelta != nil && chunkSummaries[0] != "" {
+			_ = onDelta(chunkSummaries[0])
+		}
+		return chunkSummaries[0], 0, nil
+	}
+
+	var parts []string
+	for i, s := range chunkSummaries {
+		parts = append(parts, fmt.Sprintf("【分片 %d】\n%s", i+1, s))
+	}
+	summariesText := strings.Join(parts, "\n\n---\n\n")
+	system := buildReduceSystemPrompt(topic)
+	userPrompt := fmt.Sprintf("信息来源：%s\n时间范围：%s ~ %s\n消息总量：%d 条\n\n以下是各分片的总结，请合并：\n\n%s",
+		sourceNames, startTime, endTime, totalMsgCount, summariesText)
+
+	return c.CallStream(ctx, []ChatMessage{
+		{Role: "system", Content: system},
+		{Role: "user", Content: userPrompt},
+	}, 0.1, onDelta)
+}
+
+func buildReduceByPersonMessages(participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) []ChatMessage {
 	var parts []string
 	for i, ps := range participantSummaries {
 		parts = append(parts, fmt.Sprintf("[P%d]【%s 的工作总结】\n%s", i+1, ps.Name, ps.Summary))
@@ -544,8 +743,21 @@ func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries
 - 如果总结主题中包含输出结构、详细程度、分点方式、待办格式等要求，必须优先遵循；如果主题没有指定结构，再根据实际内容自行组织结构
 - 用显示名称指代人，绝对不要输出 UID 或用户 ID`
 
-	return c.Call(ctx, []ChatMessage{
+	return []ChatMessage{
 		{Role: "system", Content: system},
 		{Role: "user", Content: fmt.Sprintf("总结主题：%s\n时间范围：%s ~ %s\n\n%s", topic, startTime, endTime, text)},
-	}, 0.1)
+	}
+}
+
+// CallReduceByPerson merges participant-level summaries.
+// Each participant is assigned a [Pn] tag that the LLM should reference in the output.
+func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
+	return c.Call(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1)
+}
+
+// CallReduceByPersonStream merges participant-level summaries and streams the
+// final team summary. Each participant is assigned a [Pn] tag that the LLM should
+// reference in the output.
+func (c *LLMClient) CallReduceByPersonStream(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string, onDelta func(string) error) (string, int, error) {
+	return c.CallStream(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta)
 }

--- a/internal/streaming/event.go
+++ b/internal/streaming/event.go
@@ -1,0 +1,39 @@
+package streaming
+
+const (
+	EventStart    = "start"
+	EventStage    = "stage"
+	EventDelta    = "delta"
+	EventSnapshot = "snapshot"
+	EventDone     = "done"
+	EventError    = "error"
+)
+
+const (
+	ScopePersonal = "personal"
+	ScopeTeam     = "team"
+)
+
+// Event is the internal worker→api stream payload and the api→web SSE payload.
+// Phase 1 treats api as the source of truth for Snapshot: api appends Delta into
+// an in-memory snapshot; worker-sent Snapshot is accepted only as a best-effort
+// reconciliation hint for degraded paths.
+type Event struct {
+	Type         string `json:"type"`
+	TaskID       int64  `json:"task_id"`
+	RunID        string `json:"run_id,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	TargetUserID string `json:"target_user_id,omitempty"`
+	Stage        string `json:"stage,omitempty"`
+	Delta        string `json:"delta,omitempty"`
+	Content      string `json:"content,omitempty"`
+	Message      string `json:"message,omitempty"`
+	Status       int    `json:"status,omitempty"`
+}
+
+func NormalizeScope(scope string) string {
+	if scope == ScopeTeam {
+		return ScopeTeam
+	}
+	return ScopePersonal
+}

--- a/internal/streaming/hub.go
+++ b/internal/streaming/hub.go
@@ -1,0 +1,228 @@
+package streaming
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+const defaultClientBuffer = 128
+
+const defaultIdleTTLMul = 10
+
+// maxSnapshotBytes matches the current persisted-result size guard used by the
+// summary handlers. Normal summaries stay fully replayable; abnormal streams are
+// capped so a single in-memory hub entry cannot grow without bound.
+const maxSnapshotBytes = 512 * 1024
+
+type streamState struct {
+	activeRunID string
+	snapshot    string
+	done        bool
+	lastEventAt time.Time
+	clients     map[chan Event]struct{}
+	cleanup     *time.Timer
+}
+
+// Hub is an in-memory, single-api-instance bridge from worker NDJSON streams to
+// browser SSE streams. Phase 1 deployment contract: summary-api runs as a single
+// replica (or traffic is sticky). Multi-replica requires Redis Pub/Sub.
+type Hub struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	idleTTL time.Duration
+	m       map[string]*streamState
+}
+
+func NewHub(ttl time.Duration) *Hub {
+	if ttl <= 0 {
+		ttl = 60 * time.Second
+	}
+	return &Hub{ttl: ttl, idleTTL: ttl * defaultIdleTTLMul, m: make(map[string]*streamState)}
+}
+
+func Key(taskID int64, scope, targetUserID string) string {
+	return fmt.Sprintf("%d:%s:%s", taskID, NormalizeScope(scope), targetUserID)
+}
+
+func (h *Hub) Subscribe(taskID int64, scope, targetUserID string) (<-chan Event, string, bool, func()) {
+	key := Key(taskID, scope, targetUserID)
+	ch := make(chan Event, defaultClientBuffer)
+	var once sync.Once
+
+	h.mu.Lock()
+	st := h.ensureLocked(key)
+	if st.cleanup != nil && !st.done {
+		st.cleanup.Stop()
+		st.cleanup = nil
+	}
+	st.clients[ch] = struct{}{}
+	snapshot := st.snapshot
+	done := st.done
+	h.mu.Unlock()
+
+	cancel := func() {
+		once.Do(func() {
+			h.mu.Lock()
+			if cur := h.m[key]; cur != nil {
+				delete(cur.clients, ch)
+				if len(cur.clients) == 0 && !cur.done {
+					h.scheduleIdleCleanupLocked(key, cur)
+				}
+			}
+			h.mu.Unlock()
+			// Do not close ch here. Publish copies subscriber channels and sends
+			// after releasing h.mu; closing from cancel races with that send and can
+			// panic. The SSE handler exits via request context cancellation, and the
+			// unreferenced channel is garbage-collected.
+		})
+	}
+	return ch, snapshot, done, cancel
+}
+
+func (h *Hub) Publish(ev Event) {
+	if ev.TaskID == 0 || ev.Type == "" {
+		return
+	}
+	ev.Scope = NormalizeScope(ev.Scope)
+	key := Key(ev.TaskID, ev.Scope, ev.TargetUserID)
+
+	h.mu.Lock()
+	st := h.ensureLocked(key)
+
+	if ev.Type == EventStart {
+		if st.cleanup != nil {
+			st.cleanup.Stop()
+			st.cleanup = nil
+		}
+		st.activeRunID = ev.RunID
+		st.snapshot = ""
+		st.done = false
+	} else if st.activeRunID != "" && ev.RunID != "" && ev.RunID != st.activeRunID {
+		// Old worker run arrived late after a newer run started; discard to avoid
+		// mixing regenerated content with a previous run.
+		h.mu.Unlock()
+		return
+	}
+
+	st.lastEventAt = time.Now()
+
+	switch ev.Type {
+	case EventDelta:
+		st.snapshot = trimSnapshot(st.snapshot + ev.Delta)
+		// Keep the accumulated content on delta events so slow clients that miss a
+		// previous delta can self-heal on the next delivered frame. The snapshot is
+		// capped above to keep memory and wire size bounded.
+		ev.Content = st.snapshot
+	case EventSnapshot:
+		if ev.Content != "" {
+			st.snapshot = trimSnapshot(ev.Content)
+		}
+	case EventDone, EventError:
+		st.done = true
+		ev.Content = st.snapshot
+		if st.cleanup != nil {
+			st.cleanup.Stop()
+		}
+		state := st
+		runID := st.activeRunID
+		st.cleanup = time.AfterFunc(h.ttl, func() { h.deleteKeyIfState(key, state, runID) })
+	}
+	if !st.done {
+		h.scheduleIdleCleanupLocked(key, st)
+	}
+
+	clients := make([]chan Event, 0, len(st.clients))
+	for ch := range st.clients {
+		clients = append(clients, ch)
+	}
+	h.mu.Unlock()
+
+	for _, ch := range clients {
+		deliver(ch, ev)
+	}
+}
+
+func deliver(ch chan Event, ev Event) {
+	select {
+	case ch <- ev:
+		return
+	default:
+	}
+
+	// Delta backpressure is best-effort: the next delta carries a bounded snapshot
+	// and repairs missed text. Terminal events should not be silently dropped; make
+	// room by discarding one stale buffered event and try once more.
+	if ev.Type != EventDone && ev.Type != EventError {
+		return
+	}
+	select {
+	case <-ch:
+	default:
+	}
+	select {
+	case ch <- ev:
+	default:
+	}
+}
+
+func trimSnapshot(s string) string {
+	if len(s) <= maxSnapshotBytes {
+		return s
+	}
+	start := len(s) - maxSnapshotBytes
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return s[start:]
+}
+
+func (h *Hub) ensureLocked(key string) *streamState {
+	st := h.m[key]
+	if st == nil {
+		st = &streamState{clients: make(map[chan Event]struct{})}
+		h.m[key] = st
+	}
+	return st
+}
+
+func (h *Hub) scheduleIdleCleanupLocked(key string, st *streamState) {
+	if h.idleTTL <= 0 || st.done {
+		return
+	}
+	if st.cleanup != nil {
+		st.cleanup.Stop()
+	}
+	lastEventAt := st.lastEventAt
+	state := st
+	st.cleanup = time.AfterFunc(h.idleTTL, func() { h.deleteKeyIfIdle(key, state, lastEventAt) })
+}
+
+func (h *Hub) deleteKeyIfIdle(key string, state *streamState, lastEventAt time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	st := h.m[key]
+	if st == nil || st != state {
+		return
+	}
+	if st.done {
+		delete(h.m, key)
+		return
+	}
+	if len(st.clients) > 0 || !st.lastEventAt.Equal(lastEventAt) {
+		h.scheduleIdleCleanupLocked(key, st)
+		return
+	}
+	delete(h.m, key)
+}
+
+func (h *Hub) deleteKeyIfState(key string, state *streamState, runID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	st := h.m[key]
+	if st == nil || st != state || st.activeRunID != runID {
+		return
+	}
+	delete(h.m, key)
+}

--- a/internal/streaming/hub_test.go
+++ b/internal/streaming/hub_test.go
@@ -1,0 +1,161 @@
+package streaming
+
+import (
+	"testing"
+	"time"
+)
+
+func readEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout waiting for stream event")
+	}
+	return Event{}
+}
+
+func TestHubDeltaCarriesSnapshotAndLateSubscribe(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run-1", Scope: ScopePersonal, TargetUserID: "u1"})
+
+	ch, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "" || done {
+		t.Fatalf("initial snapshot=%q done=%v, want empty/false", snapshot, done)
+	}
+
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run-1", Scope: ScopePersonal, TargetUserID: "u1", Delta: "你"})
+	if ev := readEvent(t, ch); ev.Content != "你" || ev.Delta != "你" {
+		t.Fatalf("first delta content=%q delta=%q, want snapshot delta", ev.Content, ev.Delta)
+	}
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run-1", Scope: ScopePersonal, TargetUserID: "u1", Delta: "好"})
+	if ev := readEvent(t, ch); ev.Content != "你好" || ev.Delta != "好" {
+		t.Fatalf("second delta content=%q delta=%q, want accumulated snapshot", ev.Content, ev.Delta)
+	}
+
+	_, lateSnapshot, lateDone, lateCancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer lateCancel()
+	if lateSnapshot != "你好" || lateDone {
+		t.Fatalf("late snapshot=%q done=%v, want accumulated/false", lateSnapshot, lateDone)
+	}
+}
+
+func TestHubDropsOldRunEvents(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1", Delta: "old"})
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "new", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1", Delta: "-stale"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "new", Scope: ScopePersonal, TargetUserID: "u1", Delta: "new"})
+
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "new" || done {
+		t.Fatalf("snapshot=%q done=%v, want new/false", snapshot, done)
+	}
+}
+
+func TestHubDoneKeepsShortSnapshotThenExpires(t *testing.T) {
+	h := NewHub(20 * time.Millisecond)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: "done"})
+	h.Publish(Event{Type: EventDone, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	cancel()
+	if snapshot != "done" || !done {
+		t.Fatalf("snapshot=%q done=%v, want done snapshot/true", snapshot, done)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	_, snapshot, done, cancel = h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "" || done {
+		t.Fatalf("expired snapshot=%q done=%v, want empty/false", snapshot, done)
+	}
+}
+
+func TestHubUnfinishedIdleCleanup(t *testing.T) {
+	h := NewHub(time.Second)
+	h.idleTTL = 20 * time.Millisecond
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: "leak"})
+
+	time.Sleep(60 * time.Millisecond)
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "" || done {
+		t.Fatalf("idle-cleaned snapshot=%q done=%v, want empty/false", snapshot, done)
+	}
+}
+
+func TestHubCancelThenPublishDoesNotPanic(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	_, _, _, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	cancel()
+	cancel() // idempotent
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Publish after cancel panicked: %v", r)
+		}
+	}()
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: "x"})
+}
+
+func TestHubTerminalEventMakesRoomWhenBufferFull(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	ch, _, _, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+
+	for i := 0; i < defaultClientBuffer+10; i++ {
+		h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: "x"})
+	}
+	h.Publish(Event{Type: EventDone, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+
+	seenDone := false
+	for i := 0; i < defaultClientBuffer; i++ {
+		select {
+		case ev := <-ch:
+			if ev.Type == EventDone {
+				seenDone = true
+			}
+		default:
+		}
+	}
+	if !seenDone {
+		t.Fatal("terminal event was not retained for a full client buffer")
+	}
+}
+
+func TestHubDoneCleanupDoesNotDeleteNewRun(t *testing.T) {
+	h := NewHub(20 * time.Millisecond)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1", Delta: "old"})
+	h.Publish(Event{Type: EventDone, TaskID: 1, RunID: "old", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "new", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "new", Scope: ScopePersonal, TargetUserID: "u1", Delta: "new"})
+
+	time.Sleep(60 * time.Millisecond)
+	_, snapshot, done, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if snapshot != "new" || done {
+		t.Fatalf("new run was deleted by stale cleanup: snapshot=%q done=%v", snapshot, done)
+	}
+}
+
+func TestHubSnapshotIsCapped(t *testing.T) {
+	h := NewHub(time.Second)
+	h.Publish(Event{Type: EventStart, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1"})
+	h.Publish(Event{Type: EventDelta, TaskID: 1, RunID: "run", Scope: ScopePersonal, TargetUserID: "u1", Delta: string(make([]byte, maxSnapshotBytes+1024))})
+
+	_, snapshot, _, cancel := h.Subscribe(1, ScopePersonal, "u1")
+	defer cancel()
+	if len(snapshot) > maxSnapshotBytes {
+		t.Fatalf("snapshot len=%d exceeds cap=%d", len(snapshot), maxSnapshotBytes)
+	}
+}

--- a/internal/worker/meta_processor.go
+++ b/internal/worker/meta_processor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"gorm.io/gorm"
@@ -149,6 +150,28 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			return
 		}
 
+		runID := newSummaryRunID(taskID, "team")
+		teamStream := newSummaryStreamSender(ctx, m.proc.cfg, taskID, "", streaming.ScopeTeam, runID)
+		teamStreamFinalized := false
+		finishTeamDone := func() {
+			if teamStream != nil && !teamStreamFinalized {
+				teamStream.Done(model.StatusCompleted)
+				teamStreamFinalized = true
+			}
+		}
+		finishTeamError := func(message string) {
+			if teamStream != nil && !teamStreamFinalized {
+				teamStream.Error(message)
+				teamStreamFinalized = true
+			}
+		}
+		closeTeamStream := func() {
+			if teamStream != nil {
+				teamStream.Close()
+			}
+		}
+		teamStream.Stage(model.WorkflowStageGenerateSummary)
+
 		var finalContent string
 		var totalTokens int
 		var teamCitations []model.TeamCitation
@@ -157,6 +180,7 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			// Single submission: copy content directly, no LLM call
 			finalContent = submitted[0].Content
 			totalTokens = 0
+			_ = teamStream.Delta(finalContent)
 
 			var participant model.SummaryParticipant
 			m.proc.db.First(&participant, submitted[0].ParticipantRefID)
@@ -176,6 +200,8 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 			var task model.SummaryTask
 			if err := m.proc.db.First(&task, taskID).Error; err != nil {
 				log.Printf("[meta-worker] task %d not found: %v", taskID, err)
+				finishTeamError("team summary task not found")
+				closeTeamStream()
 				return
 			}
 
@@ -202,12 +228,14 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 
 			generationTopic := m.proc.generationTopic(task)
 			reduceStart := time.Now()
-			content, tokens, err := m.proc.llm.CallReduceByPerson(ctx, participantSummaries, startTime, endTime, generationTopic)
+			content, tokens, err := m.proc.llm.CallReduceByPersonStream(ctx, participantSummaries, startTime, endTime, generationTopic, teamStream.Delta)
 			reportKey := "team#" + strconv.FormatInt(taskID, 10)
 			timing.RecordLLMSince(reportKey, "团队汇总: 合并各成员总结", reduceStart, tokens)
 			timing.FlushReport(reportKey, time.Since(reduceStart).Milliseconds(), nil)
 			if err != nil {
 				log.Printf("[meta-worker] reduce error task=%d: %v", taskID, err)
+				finishTeamError("team summary generation failed")
+				closeTeamStream()
 				return
 			}
 			finalContent = content
@@ -255,6 +283,8 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 		var taskCheck model.SummaryTask
 		if err := m.proc.db.Select("status").First(&taskCheck, taskID).Error; err != nil || taskCheck.Status != model.StatusProcessing {
 			log.Printf("[meta-worker] task %d no longer processing before result write, aborting", taskID)
+			finishTeamError("team summary task stopped before persistence")
+			closeTeamStream()
 			return
 		}
 
@@ -274,20 +304,29 @@ func (m *MetaProcessor) processMetaSummary(ctx context.Context, taskID int64) {
 		if err := saveLatestResultAndCompleteTask(m.proc.db, taskID, &result, isScheduled, snapshotContributorIDs); err != nil {
 			if errors.Is(err, errTaskNoLongerProcessing) {
 				log.Printf("[meta-worker] task %d status changed during processing (likely cancelled), skipping completion", taskID)
+				finishTeamError("team summary task stopped during persistence")
+				closeTeamStream()
 				return
 			}
 			if errors.Is(err, errRosterChangedDuringMerge) {
 				rosterRetries++
 				if rosterRetries > maxRosterRetries {
 					log.Printf("[meta-worker] task %d: exceeded roster-recompute retries (%d), aborting to avoid livelock", taskID, maxRosterRetries)
+					finishTeamError("team summary roster changed too often")
+					closeTeamStream()
 					return
 				}
 				log.Printf("[meta-worker] task %d: contributor roster changed during merge (member left/removed); recomputing with the updated roster (attempt %d)", taskID, rosterRetries)
+				closeTeamStream()
 				continue // re-read submitted snapshot at loop top and re-aggregate with the new roster
 			}
 			log.Printf("[meta-worker] save result error task=%d: %v", taskID, err)
+			finishTeamError("team summary persistence failed")
+			closeTeamStream()
 			return
 		}
+		finishTeamDone()
+		closeTeamStream()
 
 		// Send WS notification (META_SUMMARY_UPDATED, broadcast to all)
 		m.proc.sendCallback(model.TaskEvent{

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timing"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/tokenizer"
@@ -255,6 +256,32 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 
 	workerStartAt := now
 	lastWorkflowStageAt := workerStartAt
+	runID := newSummaryRunID(taskID, participant.UserID)
+	var streamSender *summaryStreamSender
+	streamFinalized := false
+	ensureStream := func() *summaryStreamSender {
+		if streamSender == nil {
+			streamSender = newSummaryStreamSender(ctx, p.cfg, taskID, participant.UserID, streaming.ScopePersonal, runID)
+		}
+		return streamSender
+	}
+	finishStreamDone := func(status int) {
+		if streamSender != nil && !streamFinalized {
+			streamSender.Done(status)
+			streamFinalized = true
+		}
+	}
+	finishStreamError := func(message string) {
+		if streamSender != nil && !streamFinalized {
+			streamSender.Error(message)
+			streamFinalized = true
+		}
+	}
+	defer func() {
+		if streamSender != nil {
+			streamSender.Close()
+		}
+	}()
 	reportStage := func(stage string) {
 		stageAt := timezone.Now()
 		sinceWorkerStartMs := stageAt.Sub(workerStartAt).Milliseconds()
@@ -276,12 +303,20 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 		log.Printf("[personal-worker] workflow stage task=%s pr=%d stage=%s since_worker_start=%dms delta=%dms",
 			task.TaskNo, pr.ID, stage, sinceWorkerStartMs, deltaMs)
 		p.updatePersonalWorkflowStage(pr.ID, stage)
+		if stage == model.WorkflowStageGenerateSummary {
+			ensureStream().Stage(stage)
+		}
+	}
+
+	streamDelta := func(delta string) error {
+		return ensureStream().Delta(delta)
 	}
 
 	// Execute pipeline
-	content, citations, msgCount, totalTokens, modelVer, err := p.executePersonalPipeline(ctx, task, participant.UserID, reportStage)
+	content, citations, msgCount, totalTokens, modelVer, err := p.executePersonalPipeline(ctx, task, participant.UserID, reportStage, streamDelta)
 	if err != nil {
 		log.Printf("[personal-worker] pipeline error task=%d user=%s: %v", taskID, participant.UserID, err)
+		finishStreamError("summary generation failed")
 		p.markPersonalFailed(&pr, &participant, err.Error())
 		return
 	}
@@ -296,6 +331,7 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 	if err := p.db.Select("status").First(&taskCheck, taskID).Error; err != nil ||
 		(taskCheck.Status != model.StatusProcessing && !(allowCompletedTask && taskCheck.Status == model.StatusCompleted)) {
 		log.Printf("[personal-worker] task=%d no longer runnable before result write, aborting", taskID)
+		finishStreamError("summary generation cancelled")
 		return
 	}
 
@@ -303,6 +339,7 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 	persistStart := time.Now()
 	if err := p.persistCompletedPersonalResult(task, pr, content, citations, msgCount, totalTokens, modelVer, genAt, isScheduledEmptyWindow); err != nil {
 		log.Printf("[personal-worker] persist personal result task=%d pr=%d: %v", taskID, pr.ID, err)
+		finishStreamError("summary persistence failed")
 		return
 	}
 	p.db.Model(&participant).Updates(map[string]interface{}{
@@ -330,9 +367,11 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 			if err := completeTaskWithoutNewResult(p.db, taskID); err != nil {
 				if errors.Is(err, errTaskNoLongerProcessing) {
 					log.Printf("[personal-worker] task %d status changed during processing (likely cancelled), skipping completion", taskID)
+					finishStreamError("summary generation cancelled")
 					return
 				}
 				log.Printf("[personal-worker] task=%d complete-without-result error: %v", taskID, err)
+				finishStreamError("summary completion failed")
 				return
 			}
 			log.Printf("[personal-worker] task %d scheduled empty-window: kept previous result, skipped prune", taskID)
@@ -352,9 +391,11 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 			if err := saveLatestResultAndCompleteTask(p.db, taskID, &result, isScheduled, nil); err != nil {
 				if errors.Is(err, errTaskNoLongerProcessing) {
 					log.Printf("[personal-worker] task %d status changed during processing (likely cancelled), skipping completion", taskID)
+					finishStreamError("summary generation cancelled")
 					return
 				}
 				log.Printf("[personal-worker] save result error task=%d: %v", taskID, err)
+				finishStreamError("summary completion failed")
 				return
 			}
 		}
@@ -364,16 +405,19 @@ func (p *Processor) processPersonalSummaryWithOptions(ctx context.Context, taskI
 			Progress: 100,
 			Message:  "总结完成",
 		})
+		finishStreamDone(model.StatusCompleted)
 		// Task durably reached Completed above (saveLatestResultAndCompleteTask /
 		// completeTaskWithoutNewResult succeeded). Fire the terminal notification.
 		p.notifyTaskTerminal(taskID, model.StatusCompleted)
 		log.Printf("[personal-worker] task %d single-person completed directly", taskID)
 	} else if allowCompletedTask && taskCheck.Status == model.StatusCompleted {
+		finishStreamDone(model.StatusCompleted)
 		// Personal-only regenerate: keep the team summary as-is until the user
 		// explicitly submits this regenerated personal result. Submit will revive
 		// the task and trigger meta recompute.
 		log.Printf("[personal-worker] task=%d user=%s personal regenerate completed; waiting for submit", taskID, participant.UserID)
 	} else {
+		finishStreamDone(model.StatusProcessing)
 		// Multi-person mode: trigger meta-summary to check if all participants completed.
 		//
 		// System back-fill of submitted_at: the meta completion gate
@@ -606,7 +650,7 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }
 
-func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string)) (string, []model.Citation, int, int, string, error) {
+func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string), streamDelta func(string) error) (string, []model.Citation, int, int, string, error) {
 	totalStart := time.Now()
 	taskNo := task.TaskNo
 	defer func() {
@@ -930,9 +974,9 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		mapStart := time.Now()
 		mapCallStart := time.Now()
 		var err error
-		finalContent, totalTokens, err = p.llm.CallMap(ctx,
+		finalContent, totalTokens, err = p.llm.CallMapStream(ctx,
 			joinStrings(formatted), sourceName, 0, len(userMessages),
-			startTime, endTime, generationTopic, userName,
+			startTime, endTime, generationTopic, userName, streamDelta,
 		)
 		timing.RecordLLMSince(taskNo, "Map: 单次总结(跳过Map-Reduce)", mapCallStart, totalTokens)
 		timing.Observe(taskNo, "llm_map_summary", mapStart)
@@ -991,10 +1035,20 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 				}
 
 				callStart := time.Now()
-				summary, tokens, err := p.llm.CallMap(ctx,
-					joinStrings(formatted), sourceName, idx, len(c),
-					startTime, endTime, generationTopic, userName,
-				)
+				var summary string
+				var tokens int
+				var err error
+				if len(chunks) == 1 {
+					summary, tokens, err = p.llm.CallMapStream(ctx,
+						joinStrings(formatted), sourceName, idx, len(c),
+						startTime, endTime, generationTopic, userName, streamDelta,
+					)
+				} else {
+					summary, tokens, err = p.llm.CallMap(ctx,
+						joinStrings(formatted), sourceName, idx, len(c),
+						startTime, endTime, generationTopic, userName,
+					)
+				}
 				timing.RecordLLMSince(taskNo, fmt.Sprintf("Map: 分块总结 chunk#%d", idx), callStart, tokens)
 				if err != nil {
 					log.Printf("[personal-worker] Map chunk %d failed: %v", idx, err)
@@ -1053,8 +1107,8 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 			// Multiple chunks: execute Reduce to merge
 			var err error
 			reduceCallStart := time.Now()
-			finalContent, reduceTokens, err = p.llm.CallReduce(ctx,
-				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, generationTopic,
+			finalContent, reduceTokens, err = p.llm.CallReduceStream(ctx,
+				chunkSummaries, sourceName, startTime, endTime, targetMsgCount, generationTopic, streamDelta,
 			)
 			timing.RecordLLMSince(taskNo, "Reduce: 合并分块总结", reduceCallStart, reduceTokens)
 			if err != nil {

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -388,6 +388,46 @@ func (p *Processor) processTask(task model.SummaryTask) {
 	}
 
 	if participantCount <= 1 {
+		var participants []model.SummaryParticipant
+		p.db.Where("task_id = ?", task.ID).Find(&participants)
+
+		// Scheduled single-person tasks must not depend on the best-effort
+		// processing_deadline refresh. The multi-person scheduled path already
+		// dispatches before refreshing the deadline for the same reason: a racing
+		// stuck-scan/claim can make the CAS miss even though this run is still
+		// valid. If we return on that miss, the task stays visually stuck at the
+		// first workflow step because no personal worker is ever dispatched.
+		if task.TriggerType == model.TriggerScheduled {
+			for _, pt := range participants {
+				p.db.Model(&model.SummaryParticipant{}).Where("id = ?", pt.ID).
+					Update("status", model.ParticipantAccepted)
+				ptID := pt.ID
+				p.dispatchPersonal(task.ID, ptID)
+			}
+
+			casResult := p.db.Model(&model.SummaryTask{}).
+				Where("id = ? AND status = ?", task.ID, model.StatusProcessing).
+				Updates(map[string]interface{}{
+					"processing_deadline": timezone.Now().Add(time.Duration(p.cfg.WorkerLeaseMinutes) * time.Minute),
+				})
+			if casResult.Error != nil {
+				log.Printf("[processor] task %d scheduled single deadline refresh failed (dispatch already done): %v", task.ID, casResult.Error)
+			} else if casResult.RowsAffected == 0 {
+				var cur model.SummaryTask
+				if err := p.db.Select("status").First(&cur, task.ID).Error; err == nil {
+					log.Printf("[processor] task %d scheduled single deadline refresh missed (status=%d); dispatch already issued for %d participant(s)", task.ID, cur.Status, len(participants))
+				}
+			}
+			p.sendCallback(model.TaskEvent{
+				TaskID:   task.ID,
+				Status:   model.StatusProcessing,
+				Progress: 50,
+				Message:  "单人模式，自动处理中",
+			})
+			log.Printf("[processor] task %d scheduled single participant, dispatched %d participant(s)", task.ID, len(participants))
+			return
+		}
+
 		casResult := p.db.Model(&model.SummaryTask{}).
 			Where("id = ? AND status = ?", task.ID, model.StatusProcessing).
 			Updates(map[string]interface{}{
@@ -398,11 +438,16 @@ func (p *Processor) processTask(task model.SummaryTask) {
 			return
 		}
 		if casResult.RowsAffected == 0 {
-			log.Printf("[processor] task %d status changed (likely cancelled), skipping dispatch", task.ID)
-			return
+			var cur model.SummaryTask
+			if err := p.db.Select("status").First(&cur, task.ID).Error; err != nil {
+				log.Printf("[processor] task %d status reload failed after CAS miss: %v", task.ID, err)
+				return
+			}
+			if cur.Status != model.StatusProcessing {
+				log.Printf("[processor] task %d no longer Processing (status=%d), skipping single dispatch", task.ID, cur.Status)
+				return
+			}
 		}
-		var participants []model.SummaryParticipant
-		p.db.Where("task_id = ?", task.ID).Find(&participants)
 		for _, pt := range participants {
 			p.db.Model(&model.SummaryParticipant{}).Where("id = ?", pt.ID).
 				Update("status", model.ParticipantAccepted)

--- a/internal/worker/summary_stream_client.go
+++ b/internal/worker/summary_stream_client.go
@@ -1,0 +1,188 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
+)
+
+var summaryStreamHTTPClient = &http.Client{Timeout: 0}
+
+type summaryStreamSender struct {
+	url           string
+	internalToken string
+	taskID        int64
+	runID         string
+	scope         string
+	targetUserID  string
+	ch            chan streaming.Event
+	closed        chan struct{}
+	once          sync.Once
+	degraded      atomic.Bool
+}
+
+func newSummaryStreamSender(ctx context.Context, cfg *config.Config, taskID int64, targetUserID, scope, runID string) *summaryStreamSender {
+	callbackURL := ""
+	internalToken := ""
+	if cfg != nil {
+		callbackURL = cfg.WorkerCallbackURL
+		internalToken = cfg.SummaryStreamInternalToken
+	}
+	url := summaryStreamURL(callbackURL)
+	s := &summaryStreamSender{
+		url:           url,
+		internalToken: internalToken,
+		taskID:        taskID,
+		runID:         runID,
+		scope:         streaming.NormalizeScope(scope),
+		targetUserID:  targetUserID,
+		ch:            make(chan streaming.Event, 256),
+		closed:        make(chan struct{}),
+	}
+	if url == "" {
+		s.degraded.Store(true)
+		close(s.closed)
+		return s
+	}
+	s.start(ctx)
+	s.Send(streaming.Event{Type: streaming.EventStart})
+	return s
+}
+
+func summaryStreamURL(callbackURL string) string {
+	callbackURL = strings.TrimRight(strings.TrimSpace(callbackURL), "/")
+	if callbackURL == "" {
+		return ""
+	}
+	if strings.HasSuffix(callbackURL, "/internal/task-event") {
+		return strings.TrimSuffix(callbackURL, "/internal/task-event") + "/internal/summary-stream"
+	}
+	return strings.TrimRight(callbackURL, "/") + "/summary-stream"
+}
+
+func (s *summaryStreamSender) start(ctx context.Context) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer close(s.closed)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, pr)
+		if err != nil {
+			s.markDegraded("create internal stream request", err)
+			_ = pr.CloseWithError(err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-ndjson")
+		if s.internalToken != "" {
+			req.Header.Set("X-Internal-Token", s.internalToken)
+		}
+		resp, err := summaryStreamHTTPClient.Do(req)
+		if err != nil {
+			s.markDegraded("post internal stream", err)
+			_ = pr.CloseWithError(err)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			s.markDegraded("internal stream non-2xx", fmt.Errorf("status=%d body=%s", resp.StatusCode, string(body)))
+		}
+	}()
+
+	go func() {
+		enc := json.NewEncoder(pw)
+		defer pw.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-s.ch:
+				if !ok {
+					return
+				}
+				if err := enc.Encode(ev); err != nil {
+					s.markDegraded("write internal stream", err)
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (s *summaryStreamSender) Send(ev streaming.Event) bool {
+	if s == nil || s.degraded.Load() {
+		return false
+	}
+	ev.TaskID = s.taskID
+	ev.RunID = s.runID
+	ev.Scope = s.scope
+	ev.TargetUserID = s.targetUserID
+	select {
+	case s.ch <- ev:
+		return true
+	default:
+		s.markDegraded("enqueue internal stream", fmt.Errorf("buffer full"))
+		return false
+	}
+}
+
+func (s *summaryStreamSender) Stage(stage string) {
+	if stage == "" {
+		return
+	}
+	s.Send(streaming.Event{Type: streaming.EventStage, Stage: stage})
+}
+
+func (s *summaryStreamSender) Delta(delta string) error {
+	if delta == "" {
+		return nil
+	}
+	s.Send(streaming.Event{Type: streaming.EventDelta, Delta: delta})
+	return nil
+}
+
+func (s *summaryStreamSender) Done(status int) {
+	s.Send(streaming.Event{Type: streaming.EventDone, Status: status})
+}
+
+func (s *summaryStreamSender) Error(message string) {
+	s.Send(streaming.Event{Type: streaming.EventError, Message: message})
+}
+
+func (s *summaryStreamSender) Close() {
+	if s == nil || s.url == "" {
+		return
+	}
+	s.once.Do(func() {
+		close(s.ch)
+		select {
+		case <-s.closed:
+		case <-time.After(2 * time.Second):
+		}
+	})
+}
+
+func (s *summaryStreamSender) markDegraded(where string, err error) {
+	if s == nil {
+		return
+	}
+	if s.degraded.CompareAndSwap(false, true) {
+		log.Printf("[summary-stream] degraded task=%d user=%s run=%s at %s: %v", s.taskID, s.targetUserID, s.runID, where, err)
+	}
+}
+
+func newSummaryRunID(taskID int64, userID string) string {
+	var b bytes.Buffer
+	_, _ = fmt.Fprintf(&b, "%d:%s:%d", taskID, userID, time.Now().UnixNano())
+	return b.String()
+}


### PR DESCRIPTION
## Summary

- Add streaming support for smart-summary generation output.
- Add internal worker-to-api stream delivery and public summary stream endpoints.
- Add LLM streaming call path and wire it into summary generation.
- Support streaming for initial generation, regenerate, and refine flows where applicable.
- Keep persisted database results as the final source of truth after generation completes.
- Preserve existing non-streaming behavior as fallback.
- Improve scheduled single-person task dispatch so scheduled runs continue through the generation pipeline reliably.

## Implementation

- Add stream event types and in-memory stream hub for summary output.
- Add API handlers/routes for summary stream and refine stream.
- Add worker stream client for sending incremental output to summary-api.
- Add streaming LLM call support.
- Wire streaming into personal summary, team summary, regenerate, and refine flows.
- Add hub tests for stream publish/subscribe behavior.

## Testing

- `GOCACHE=/tmp/octo-go-build-cache CGO_ENABLED=0 go test ./...`

Closes #155
