### PR TITLE
feat(summary): add per-user unread state and attention ordering

### DIFF
--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -361,7 +361,11 @@ func setupListTestDBs(t *testing.T) (db *gorm.DB, imDB *gorm.DB) {
 	if err != nil {
 		t.Fatalf("open summary db: %v", err)
 	}
-	db.AutoMigrate(&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{}, &model.SummaryResult{})
+	db.AutoMigrate(
+		&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{},
+		&model.SummaryResult{}, &model.PersonalResult{}, &model.PersonalResultVersion{},
+		&model.SummaryUserRead{},
+	)
 
 	imDB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {

--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -3,6 +3,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -382,6 +383,129 @@ func setupListRouter(h *TaskHandler) *gin.Engine {
 	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
 	r.GET("/api/v1/summaries", h.ListSummaries)
 	return r
+}
+
+func setupReadRouter(h *TaskHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.POST("/api/v1/summaries/:id/read", h.MarkSummaryRead)
+	return r
+}
+
+func markReadRequest(r *gin.Engine, taskID int64, userID string, body string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/summaries/%d/read", taskID), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Token", userID)
+	req.Header.Set("X-Space-Id", "space1")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+type markReadResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		IsUnread             bool `json:"is_unread"`
+		HasPendingInvitation bool `json:"has_pending_invitation"`
+		NeedsAttention       bool `json:"needs_attention"`
+	} `json:"data"`
+}
+
+func parseMarkReadResponse(t *testing.T, w *httptest.ResponseRecorder) markReadResponse {
+	t.Helper()
+	var resp markReadResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal mark-read response: %v; body=%s", err, w.Body.String())
+	}
+	return resp
+}
+
+func TestMarkSummaryRead_RecordsRenderedVersionsAndKeepsPendingInvitation(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedTask(t, db, imDB)
+	var task model.SummaryTask
+	db.First(&task, taskID)
+
+	oldResult := model.SummaryResult{TaskID: taskID, Content: "old", GeneratedAt: timezone.Now(), CreatedAt: timezone.Now(), UpdatedAt: timezone.Now()}
+	newResult := model.SummaryResult{TaskID: taskID, Content: "new", GeneratedAt: timezone.Now(), CreatedAt: timezone.Now(), UpdatedAt: timezone.Now()}
+	db.Create(&oldResult)
+	db.Create(&newResult)
+	db.Model(&task).Update("current_result_id", newResult.ID)
+	db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, "participant1").Update("status", model.ParticipantPending)
+
+	r := setupReadRouter(NewTaskHandler(db, imDB, ""))
+	w := markReadRequest(r, taskID, "participant1", fmt.Sprintf(`{"team_result_id":%d}`, oldResult.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseMarkReadResponse(t, w)
+	if !resp.Data.IsUnread || !resp.Data.HasPendingInvitation || !resp.Data.NeedsAttention {
+		t.Fatalf("expected stale result and pending invitation to keep attention, got %+v", resp.Data)
+	}
+
+	w = markReadRequest(r, taskID, "participant1", fmt.Sprintf(`{"team_result_id":%d}`, newResult.ID))
+	resp = parseMarkReadResponse(t, w)
+	if resp.Data.IsUnread || !resp.Data.HasPendingInvitation || !resp.Data.NeedsAttention {
+		t.Fatalf("expected result read but pending invitation to keep attention, got %+v", resp.Data)
+	}
+}
+
+func TestMarkSummaryRead_UpdatesTeamAndPersonalCursorsIndependently(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedTask(t, db, imDB)
+	db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND user_id = ?", taskID, "participant1").Update("status", model.ParticipantAccepted)
+	now := timezone.Now()
+	team := model.SummaryResult{TaskID: taskID, Content: "team", GeneratedAt: now, CreatedAt: now, UpdatedAt: now}
+	personalVersion := model.PersonalResultVersion{TaskID: taskID, UserID: "participant1", Content: "personal", Version: 1, GeneratedAt: now, CreatedAt: now, UpdatedAt: now}
+	db.Create(&team)
+	db.Create(&personalVersion)
+	db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("current_result_id", team.ID)
+	db.Create(&model.PersonalResult{TaskID: taskID, UserID: "participant1", Content: "personal", CurrentVersionID: &personalVersion.ID, CreatedAt: now, UpdatedAt: now})
+
+	r := setupReadRouter(NewTaskHandler(db, imDB, ""))
+	w := markReadRequest(r, taskID, "participant1", fmt.Sprintf(`{"team_result_id":%d,"personal_version_id":%d}`, team.ID, personalVersion.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseMarkReadResponse(t, w)
+	if resp.Data.IsUnread || resp.Data.NeedsAttention {
+		t.Fatalf("expected both current versions read, got %+v", resp.Data)
+	}
+	var read model.SummaryUserRead
+	if err := db.Where("task_id = ? AND user_id = ?", taskID, "participant1").First(&read).Error; err != nil {
+		t.Fatalf("read cursor not persisted: %v", err)
+	}
+	if read.LastReadTeamResultID == nil || *read.LastReadTeamResultID != team.ID || read.LastReadPersonalVersionID == nil || *read.LastReadPersonalVersionID != personalVersion.ID {
+		t.Fatalf("unexpected persisted cursors: %+v", read)
+	}
+}
+
+func TestMarkSummaryRead_RejectsForeignAndUnauthorizedVersions(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedTask(t, db, imDB)
+	otherTask := model.SummaryTask{TaskNo: "TST-OTHER", SpaceID: "space1", CreatorID: "other", SummaryMode: model.ModeByPerson, Status: model.StatusCompleted}
+	db.Create(&otherTask)
+	now := timezone.Now()
+	foreignResult := model.SummaryResult{TaskID: otherTask.ID, Content: "foreign", GeneratedAt: now, CreatedAt: now, UpdatedAt: now}
+	foreignPersonal := model.PersonalResultVersion{TaskID: taskID, UserID: "someone-else", Content: "foreign", Version: 1, GeneratedAt: now, CreatedAt: now, UpdatedAt: now}
+	db.Create(&foreignResult)
+	db.Create(&foreignPersonal)
+	r := setupReadRouter(NewTaskHandler(db, imDB, ""))
+
+	for _, body := range []string{
+		fmt.Sprintf(`{"team_result_id":%d}`, foreignResult.ID),
+		fmt.Sprintf(`{"personal_version_id":%d}`, foreignPersonal.ID),
+	} {
+		w := markReadRequest(r, taskID, "participant1", body)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for foreign version, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+	w := markReadRequest(r, taskID, "stranger", fmt.Sprintf(`{"team_result_id":%d}`, foreignResult.ID))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unauthorized caller, got %d: %s", w.Code, w.Body.String())
+	}
 }
 
 type listResponse struct {

--- a/internal/api/handler/origin_channel_test.go
+++ b/internal/api/handler/origin_channel_test.go
@@ -29,7 +29,9 @@ func setupOriginTestDB(t *testing.T) (db *gorm.DB, imDB *gorm.DB) {
 		&model.SummarySource{},
 		&model.SummaryParticipant{},
 		&model.PersonalResult{},
+		&model.PersonalResultVersion{},
 		&model.SummaryResult{},
+		&model.SummaryUserRead{},
 	)
 	imDB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {

--- a/internal/api/handler/personal.go
+++ b/internal/api/handler/personal.go
@@ -452,15 +452,16 @@ func (h *PersonalHandler) GetPersonal(c *gin.Context) {
 	}
 
 	result := gin.H{
-		"id":             pr.ID,
-		"version":        version,
-		"worker_status":  pr.WorkerStatus,
-		"workflow_stage": pr.WorkflowStage,
-		"content":        pr.Content,
-		"citations":      pr.GetCitations(),
-		"submitted_at":   nil,
-		"generated_at":   nil,
-		"msg_count":      pr.MsgCount,
+		"id":                 pr.ID,
+		"version":            version,
+		"worker_status":      pr.WorkerStatus,
+		"workflow_stage":     pr.WorkflowStage,
+		"content":            pr.Content,
+		"citations":          pr.GetCitations(),
+		"submitted_at":       nil,
+		"generated_at":       nil,
+		"msg_count":          pr.MsgCount,
+		"current_version_id": pr.CurrentVersionID,
 	}
 	if pr.SubmittedAt != nil {
 		result["submitted_at"] = pr.SubmittedAt.Format(time.RFC3339)

--- a/internal/api/handler/schedule_attention_mysql_test.go
+++ b/internal/api/handler/schedule_attention_mysql_test.go
@@ -1,0 +1,101 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// This integration test is opt-in because the schedule roster predicate uses
+// MySQL JSON_TABLE, which SQLite cannot parse. Point SUMMARY_MYSQL_TEST_DSN at
+// an isolated database to exercise the production dialect.
+func TestListSummaries_MySQL_ConfigOnlyScheduleInviteeGetsAttention(t *testing.T) {
+	dsn := os.Getenv("SUMMARY_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("SUMMARY_MYSQL_TEST_DSN is not set")
+	}
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	for _, table := range []string{
+		"summary_task", "summary_source", "summary_participant", "summary_result",
+		"summary_personal_result", "summary_personal_result_version", "summary_user_read", "summary_schedule",
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Fatalf("mysql integration database is not migrated: missing %s", table)
+		}
+	}
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin transaction: %v", tx.Error)
+	}
+	defer tx.Rollback()
+
+	schedule := model.SummarySchedule{
+		SpaceID: "attention-mysql-space", CreatorID: "schedule-creator", Title: "scheduled",
+		SummaryMode: model.ModeByPerson, CronExpr: "0 0 * * *", TimeRangeType: 1,
+		ParticipantConfig: model.JSON(`{"participants":[{"user_id":"config-only-user","confirmed":false}],"confirm_gate_passed":false}`),
+		ConfirmPolicy:     model.SchedConfirmRequire, IsActive: 1,
+	}
+	if err := tx.Create(&schedule).Error; err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+	task := model.SummaryTask{
+		TaskNo: "MYSQL-CONFIG-ONLY-INVITEE", SpaceID: schedule.SpaceID,
+		CreatorID: schedule.CreatorID, SummaryMode: model.ModeByPerson,
+		Status: model.StatusCompleted, TriggerType: model.TriggerScheduled, ScheduleID: &schedule.ID,
+		TimeRangeStart: time.Now().Add(-time.Hour), TimeRangeEnd: time.Now(),
+	}
+	if err := tx.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	// CONFIRM intentionally materializes only confirmed users. The invitee has
+	// no summary_participant row and must still be admitted through the schedule
+	// roster predicate.
+	if err := tx.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: schedule.CreatorID, Status: model.ParticipantAccepted,
+	}).Error; err != nil {
+		t.Fatalf("create creator participant: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(tx, nil, ""))
+	w := doRequestWithSpace(r, http.MethodGet, "/api/v1/summaries", "config-only-user", schedule.SpaceID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			Total                  int `json:"total"`
+			AttentionCount         int `json:"attention_count"`
+			PendingInvitationCount int `json:"pending_invitation_count"`
+			Items                  []struct {
+				TaskID               int64 `json:"task_id"`
+				HasPendingInvitation bool  `json:"has_pending_invitation"`
+				NeedsAttention       bool  `json:"needs_attention"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.Total != 1 || len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != task.ID {
+		t.Fatalf("config-only invitee did not receive scheduled task: %+v", resp.Data)
+	}
+	if !resp.Data.Items[0].HasPendingInvitation || !resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("scheduled invitation was not marked for attention: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 1 || resp.Data.PendingInvitationCount != 1 {
+		t.Fatalf("unexpected attention counts: attention=%d pending=%d", resp.Data.AttentionCount, resp.Data.PendingInvitationCount)
+	}
+}

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -507,7 +507,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	if strings.ToLower(sortOrder) != "asc" {
 		sortOrder = "desc"
 	}
-	orderClause := sortBy + " " + sortOrder
+	orderClause := "sub." + sortBy + " " + sortOrder
 
 	// Folding (1->N): scheduled tasks fold by schedule_id (only the latest run per
 	// schedule shows); manual tasks (schedule_id IS NULL) each form their own group.
@@ -525,11 +525,62 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	countSQL := "SELECT COUNT(*) FROM (" + innerSQL + ") sub WHERE sub.rn = 1"
 	h.db.Raw(countSQL, args...).Scan(&total)
 
-	pageSQL := "SELECT * FROM (" + innerSQL + ") sub WHERE sub.rn = 1 ORDER BY " + orderClause + " LIMIT ? OFFSET ?"
-	pageArgs := append(append([]interface{}{}, args...), pageSize, (page-1)*pageSize)
+	// Attention is caller-specific. Compute it only after schedule folding, then
+	// sort before pagination. A pending invitation outranks unread content; team
+	// and personal cursors are compared independently because their ids belong to
+	// different tables.
+	attentionJoins := `
+ LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
+ LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
+ LEFT JOIN summary_personal_result pr ON pr.task_id = sub.id AND pr.user_id = ?
+ LEFT JOIN summary_personal_result_version pv ON pv.id = pr.current_version_id AND pv.task_id = sub.id AND pv.user_id = ?
+ LEFT JOIN summary_participant me ON me.task_id = sub.id AND me.user_id = ?`
+	schedulePendingExpr := "0"
+	if h.db.Dialector.Name() == "mysql" {
+		// Schedule-level confirmation lives in participant_config rather than
+		// summary_participant. Expand the V5 roster so these invitations share the
+		// same attention/red-dot semantics as ordinary task invitations.
+		schedulePendingExpr = `EXISTS (SELECT 1 FROM summary_schedule ss
+ JOIN JSON_TABLE(JSON_EXTRACT(ss.participant_config, '$.participants'), '$[*]'
+ COLUMNS(user_id VARCHAR(64) PATH '$.user_id', confirmed BOOL PATH '$.confirmed' DEFAULT 'false' ON EMPTY)) sc
+ WHERE ss.id=sub.schedule_id AND ss.deleted_at IS NULL AND ss.is_active=1
+ AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
+	}
+	attentionSelect := `,
+ CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
+ CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
+        OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id <> pr.current_version_id))
+      THEN 1 ELSE 0 END AS is_unread,
+ sub.current_result_id AS list_current_result_id,
+ pr.current_version_id AS current_personal_version_id,
+	 CASE WHEN cr.generated_at IS NOT NULL AND pv.generated_at IS NOT NULL
+	      THEN CASE WHEN cr.generated_at >= pv.generated_at THEN cr.generated_at ELSE pv.generated_at END
+	      ELSE COALESCE(cr.generated_at, pv.generated_at, sub.created_at) END AS activity_at`
+	pageSQL := "SELECT sub.*" + attentionSelect + " FROM (" + innerSQL + ") sub" + attentionJoins +
+		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, sub.id DESC, " + orderClause + " LIMIT ? OFFSET ?"
+	pageArgs := []interface{}{model.ParticipantPending}
+	if h.db.Dialector.Name() == "mysql" {
+		pageArgs = append(pageArgs, userID)
+	}
+	pageArgs = append(pageArgs, args...)
+	pageArgs = append(pageArgs, userID, userID, userID, userID, pageSize, (page-1)*pageSize)
 
-	var tasks []model.SummaryTask
-	h.db.Raw(pageSQL, pageArgs...).Scan(&tasks)
+	type listTaskRow struct {
+		model.SummaryTask        `gorm:"embedded"`
+		HasPendingInvitation     bool   `gorm:"column:has_pending_invitation"`
+		IsUnread                 bool   `gorm:"column:is_unread"`
+		ListCurrentResultID      *int64 `gorm:"column:list_current_result_id"`
+		CurrentPersonalVersionID *int64 `gorm:"column:current_personal_version_id"`
+		ActivityAt               string `gorm:"column:activity_at"`
+	}
+	var taskRows []listTaskRow
+	h.db.Raw(pageSQL, pageArgs...).Scan(&taskRows)
+	tasks := make([]model.SummaryTask, 0, len(taskRows))
+	rowByTask := make(map[int64]listTaskRow, len(taskRows))
+	for _, row := range taskRows {
+		tasks = append(tasks, row.SummaryTask)
+		rowByTask[row.ID] = row
+	}
 
 	// FIX2: batch-load participants for ALL listed tasks in ONE query (avoid N+1),
 	// grouped by task_id. The frontend SummaryCard needs task.participants to decide
@@ -559,6 +610,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 
 	items := make([]gin.H, 0, len(tasks))
 	for _, t := range tasks {
+		attention := rowByTask[t.ID]
 		var sources []model.SummarySource
 		h.db.Where("task_id = ?", t.ID).Find(&sources)
 
@@ -613,30 +665,129 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		}
 
 		items = append(items, gin.H{
-			"task_id":             t.ID,
-			"task_no":             t.TaskNo,
-			"title":               t.Title,
-			"summary_mode":        t.SummaryMode,
-			"status":              t.Status,
-			"trigger_type":        t.TriggerType,
-			"schedule_id":         scheduleIDOut,
-			"creator_id":          t.CreatorID,
-			"participants":        parts,
-			"time_range_start":    t.TimeRangeStart.Format(time.RFC3339),
-			"time_range_end":      t.TimeRangeEnd.Format(time.RFC3339),
-			"sources":             srcList,
-			"total_msg_count":     totalMsgCount,
-			"creator_name":        creatorName,
-			"origin_channel_id":   t.OriginChannelID,
-			"origin_channel_type": t.OriginChannelType,
-			"created_at":          t.CreatedAt.Format(time.RFC3339),
-			"completed_at":        completedAt,
-			"result_is_edited":    resultIsEdited,
-			"result_edited_at":    resultEditedAt,
+			"task_id":                     t.ID,
+			"task_no":                     t.TaskNo,
+			"title":                       t.Title,
+			"summary_mode":                t.SummaryMode,
+			"status":                      t.Status,
+			"trigger_type":                t.TriggerType,
+			"schedule_id":                 scheduleIDOut,
+			"creator_id":                  t.CreatorID,
+			"participants":                parts,
+			"time_range_start":            t.TimeRangeStart.Format(time.RFC3339),
+			"time_range_end":              t.TimeRangeEnd.Format(time.RFC3339),
+			"sources":                     srcList,
+			"total_msg_count":             totalMsgCount,
+			"creator_name":                creatorName,
+			"origin_channel_id":           t.OriginChannelID,
+			"origin_channel_type":         t.OriginChannelType,
+			"created_at":                  t.CreatedAt.Format(time.RFC3339),
+			"completed_at":                completedAt,
+			"result_is_edited":            resultIsEdited,
+			"result_edited_at":            resultEditedAt,
+			"is_unread":                   attention.IsUnread,
+			"has_pending_invitation":      attention.HasPendingInvitation,
+			"needs_attention":             attention.IsUnread || attention.HasPendingInvitation,
+			"current_result_id":           attention.ListCurrentResultID,
+			"current_personal_version_id": attention.CurrentPersonalVersionID,
+			"activity_at":                 attention.ActivityAt,
 		})
 	}
 
-	ok(c, gin.H{"total": total, "items": items})
+	// Counts deliberately ignore the current list filters: the navigation badge
+	// represents all cards that require this user's attention in the space.
+	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?))"
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
+	var counts struct {
+		AttentionCount         int64 `gorm:"column:attention_count"`
+		UnreadCount            int64 `gorm:"column:unread_count"`
+		PendingInvitationCount int64 `gorm:"column:pending_invitation_count"`
+	}
+	countArgs := []interface{}{model.ParticipantPending}
+	if h.db.Dialector.Name() == "mysql" {
+		countArgs = append(countArgs, userID)
+	}
+	countArgs = append(countArgs, spaceID, userID, userID, userID, userID, userID, userID)
+	h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts)
+	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount})
+}
+
+type markSummaryReadRequest struct {
+	TeamResultID      *int64 `json:"team_result_id"`
+	PersonalVersionID *int64 `json:"personal_version_id"`
+}
+
+// MarkSummaryRead records exactly the versions rendered by the caller. It does
+// not blindly mark the latest version, so a result completed concurrently with
+// an older detail request remains unread.
+func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
+	taskID, resolved := h.resolveSummaryTaskParam(c)
+	if !resolved {
+		return
+	}
+	if _, authorized := h.authorizeTaskAccess(c, taskID); !authorized {
+		return
+	}
+	var req markSummaryReadRequest
+	if err := c.ShouldBindJSON(&req); err != nil || (req.TeamResultID == nil && req.PersonalVersionID == nil) {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "team_result_id or personal_version_id is required"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+	if req.TeamResultID != nil {
+		var count int64
+		h.db.Model(&model.SummaryResult{}).Where("id = ? AND task_id = ?", *req.TeamResultID, taskID).Count(&count)
+		if count == 0 {
+			c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "result does not belong to task"})
+			return
+		}
+	}
+	if req.PersonalVersionID != nil {
+		var count int64
+		h.db.Model(&model.PersonalResultVersion{}).Where("id = ? AND task_id = ? AND user_id = ?", *req.PersonalVersionID, taskID, userID).Count(&count)
+		if count == 0 {
+			c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "personal version is not visible to caller"})
+			return
+		}
+	}
+	now := timezone.Now()
+	row := model.SummaryUserRead{TaskID: taskID, UserID: userID, LastReadTeamResultID: req.TeamResultID, LastReadPersonalVersionID: req.PersonalVersionID, ReadAt: &now, CreatedAt: now, UpdatedAt: now}
+	assignments := map[string]interface{}{"read_at": now, "updated_at": now}
+	if req.TeamResultID != nil {
+		assignments["last_read_team_result_id"] = *req.TeamResultID
+	}
+	if req.PersonalVersionID != nil {
+		assignments["last_read_personal_version_id"] = *req.PersonalVersionID
+	}
+	if err := h.db.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "task_id"}, {Name: "user_id"}}, DoUpdates: clause.Assignments(assignments)}).Create(&row).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: err.Error()})
+		return
+	}
+	var state struct {
+		CurrentTeamID     *int64 `gorm:"column:current_team_id"`
+		CurrentPersonalID *int64 `gorm:"column:current_personal_id"`
+		ReadTeamID        *int64 `gorm:"column:read_team_id"`
+		ReadPersonalID    *int64 `gorm:"column:read_personal_id"`
+		PendingInvitation bool   `gorm:"column:pending_invitation"`
+	}
+	h.db.Raw(`SELECT t.current_result_id AS current_team_id,
+ pr.current_version_id AS current_personal_id,
+ sur.last_read_team_result_id AS read_team_id,
+ sur.last_read_personal_version_id AS read_personal_id,
+ CASE WHEN p.status = ? THEN 1 ELSE 0 END AS pending_invitation
+ FROM summary_task t
+ LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
+ LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?
+ LEFT JOIN summary_participant p ON p.task_id=t.id AND p.user_id=?
+ WHERE t.id=?`, model.ParticipantPending, userID, userID, userID, taskID).Scan(&state)
+	teamUnread := state.CurrentTeamID != nil && (state.ReadTeamID == nil || *state.CurrentTeamID != *state.ReadTeamID)
+	personalUnread := state.CurrentPersonalID != nil && (state.ReadPersonalID == nil || *state.CurrentPersonalID != *state.ReadPersonalID)
+	isUnread := teamUnread || personalUnread
+	ok(c, gin.H{
+		"task_id": taskID, "team_result_id": req.TeamResultID, "personal_version_id": req.PersonalVersionID,
+		"is_unread": isUnread, "has_pending_invitation": state.PendingInvitation,
+		"needs_attention": isUnread || state.PendingInvitation,
+	})
 }
 
 // GetSummary handles GET /api/v1/summaries/:id

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -477,8 +477,15 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	// Build the shared filter fragment (applied identically to the folded COUNT and
 	// the folded page query). All business filters live INSIDE the window subquery
 	// so "latest per schedule" is computed over the already-filtered set.
-	whereSQL := "space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?))"
+	// Under schedule-level CONFIRM, an unconfirmed roster member is intentionally
+	// not materialized in summary_participant. Admit that config-only invitee here;
+	// otherwise the later attention expression never gets a row to mark pending.
+	scheduleVisibilityExpr := h.schedulePendingInvitationExpr("summary_task")
+	whereSQL := "space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
 	args := []interface{}{spaceID, userID, userID}
+	if h.db.Dialector.Name() == "mysql" {
+		args = append(args, userID)
+	}
 
 	if s := c.Query("status"); s != "" {
 		if v, err := strconv.Atoi(s); err == nil {
@@ -568,7 +575,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	      THEN CASE WHEN cr.generated_at >= pv.generated_at THEN cr.generated_at ELSE pv.generated_at END
 	      ELSE COALESCE(cr.generated_at, pv.generated_at, sub.created_at) END AS activity_at`
 	pageSQL := "SELECT sub.*" + attentionSelect + " FROM (" + innerSQL + ") sub" + attentionJoins +
-		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, sub.id DESC, " + orderClause + " LIMIT ? OFFSET ?"
+		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
 	pageArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		pageArgs = append(pageArgs, userID)
@@ -711,7 +718,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 
 	// Counts deliberately ignore the current list filters: the navigation badge
 	// represents all cards that require this user's attention in the space.
-	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?))"
+	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
 	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
 	var counts struct {
 		AttentionCount         int64 `gorm:"column:attention_count"`
@@ -722,7 +729,11 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	if h.db.Dialector.Name() == "mysql" {
 		countArgs = append(countArgs, userID)
 	}
-	countArgs = append(countArgs, spaceID, userID, userID, userID, userID, userID, userID)
+	countArgs = append(countArgs, spaceID, userID, userID)
+	if h.db.Dialector.Name() == "mysql" {
+		countArgs = append(countArgs, userID)
+	}
+	countArgs = append(countArgs, userID, userID, userID, userID)
 	if err := h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts).Error; err != nil {
 		log.Printf("list summaries attention count query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -58,6 +58,20 @@ func (h *TaskHandler) getCustomTemplateLimit() int {
 	return h.customTemplateLimit
 }
 
+// schedulePendingInvitationExpr returns the schedule-level pending-confirmation
+// predicate for the given summary_task alias. SQLite does not support
+// JSON_TABLE, so its unit-test path deliberately has no schedule-config branch.
+func (h *TaskHandler) schedulePendingInvitationExpr(taskAlias string) string {
+	if h.db.Dialector.Name() != "mysql" {
+		return "0"
+	}
+	return `EXISTS (SELECT 1 FROM summary_schedule ss
+ JOIN JSON_TABLE(JSON_EXTRACT(ss.participant_config, '$.participants'), '$[*]'
+ COLUMNS(user_id VARCHAR(64) PATH '$.user_id', confirmed BOOL PATH '$.confirmed' DEFAULT 'false' ON EMPTY)) sc
+ WHERE ss.id=` + taskAlias + `.schedule_id AND ss.deleted_at IS NULL AND ss.is_active=1
+ AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
+}
+
 // canAccessTask reports whether userID may read the task: creator or explicit
 // participant. This is the single source of truth shared by the detail path
 // (authorizeTaskAccess) and conceptually the batch path (batchAuthorize) and the
@@ -523,7 +537,11 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 
 	var total int64
 	countSQL := "SELECT COUNT(*) FROM (" + innerSQL + ") sub WHERE sub.rn = 1"
-	h.db.Raw(countSQL, args...).Scan(&total)
+	if err := h.db.Raw(countSQL, args...).Scan(&total).Error; err != nil {
+		log.Printf("list summaries count query failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
+		return
+	}
 
 	// Attention is caller-specific. Compute it only after schedule folding, then
 	// sort before pagination. A pending invitation outranks unread content; team
@@ -535,17 +553,10 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
  LEFT JOIN summary_personal_result pr ON pr.task_id = sub.id AND pr.user_id = ?
  LEFT JOIN summary_personal_result_version pv ON pv.id = pr.current_version_id AND pv.task_id = sub.id AND pv.user_id = ?
  LEFT JOIN summary_participant me ON me.task_id = sub.id AND me.user_id = ?`
-	schedulePendingExpr := "0"
-	if h.db.Dialector.Name() == "mysql" {
-		// Schedule-level confirmation lives in participant_config rather than
-		// summary_participant. Expand the V5 roster so these invitations share the
-		// same attention/red-dot semantics as ordinary task invitations.
-		schedulePendingExpr = `EXISTS (SELECT 1 FROM summary_schedule ss
- JOIN JSON_TABLE(JSON_EXTRACT(ss.participant_config, '$.participants'), '$[*]'
- COLUMNS(user_id VARCHAR(64) PATH '$.user_id', confirmed BOOL PATH '$.confirmed' DEFAULT 'false' ON EMPTY)) sc
- WHERE ss.id=sub.schedule_id AND ss.deleted_at IS NULL AND ss.is_active=1
- AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
-	}
+	// Schedule-level confirmation lives in participant_config rather than
+	// summary_participant. Expand the V5 roster so these invitations share the
+	// same attention/red-dot semantics as ordinary task invitations.
+	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
 	attentionSelect := `,
  CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
  CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
@@ -574,7 +585,11 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		ActivityAt               string `gorm:"column:activity_at"`
 	}
 	var taskRows []listTaskRow
-	h.db.Raw(pageSQL, pageArgs...).Scan(&taskRows)
+	if err := h.db.Raw(pageSQL, pageArgs...).Scan(&taskRows).Error; err != nil {
+		log.Printf("list summaries page query failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
+		return
+	}
 	tasks := make([]model.SummaryTask, 0, len(taskRows))
 	rowByTask := make(map[int64]listTaskRow, len(taskRows))
 	for _, row := range taskRows {
@@ -708,7 +723,11 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		countArgs = append(countArgs, userID)
 	}
 	countArgs = append(countArgs, spaceID, userID, userID, userID, userID, userID, userID)
-	h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts)
+	if err := h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts).Error; err != nil {
+		log.Printf("list summaries attention count query failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
+		return
+	}
 	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount})
 }
 
@@ -770,16 +789,27 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 		ReadPersonalID    *int64 `gorm:"column:read_personal_id"`
 		PendingInvitation bool   `gorm:"column:pending_invitation"`
 	}
-	h.db.Raw(`SELECT t.current_result_id AS current_team_id,
+	schedulePendingExpr := h.schedulePendingInvitationExpr("t")
+	stateSQL := `SELECT t.current_result_id AS current_team_id,
  pr.current_version_id AS current_personal_id,
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
- CASE WHEN p.status = ? THEN 1 ELSE 0 END AS pending_invitation
+ CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?
  LEFT JOIN summary_participant p ON p.task_id=t.id AND p.user_id=?
- WHERE t.id=?`, model.ParticipantPending, userID, userID, userID, taskID).Scan(&state)
+ WHERE t.id=?`
+	stateArgs := []interface{}{model.ParticipantPending}
+	if h.db.Dialector.Name() == "mysql" {
+		stateArgs = append(stateArgs, userID)
+	}
+	stateArgs = append(stateArgs, userID, userID, userID, taskID)
+	if err := h.db.Raw(stateSQL, stateArgs...).Scan(&state).Error; err != nil {
+		log.Printf("mark summary read state query failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to load summary attention state"})
+		return
+	}
 	teamUnread := state.CurrentTeamID != nil && (state.ReadTeamID == nil || *state.CurrentTeamID != *state.ReadTeamID)
 	personalUnread := state.CurrentPersonalID != nil && (state.ReadPersonalID == nil || *state.CurrentPersonalID != *state.ReadPersonalID)
 	isUnread := teamUnread || personalUnread

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -58,6 +58,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.GET("/summaries", taskH.ListSummaries)
 		v1.GET("/summaries/:id", taskH.GetSummary)
 		v1.GET("/summaries/:id/stream", streamH.StreamSummary)
+		v1.POST("/summaries/:id/read", taskH.MarkSummaryRead)
 		v1.GET("/summaries/:id/result", taskH.GetResult)
 		v1.POST("/summaries/:id/regenerate", taskH.Regenerate)
 		v1.POST("/summaries/:id/refine", editH.RefineSummary)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -345,6 +345,22 @@ type SummaryEvent struct {
 
 func (SummaryEvent) TableName() string { return "summary_event" }
 
+// SummaryUserRead stores the last team and personal result actually rendered by
+// one user. Team and personal result ids live in different tables, so they must
+// never share a single cursor column.
+type SummaryUserRead struct {
+	ID                        int64      `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID                    int64      `gorm:"column:task_id;not null;uniqueIndex:uk_summary_user_read_task_user" json:"task_id"`
+	UserID                    string     `gorm:"column:user_id;type:varchar(64);not null;uniqueIndex:uk_summary_user_read_task_user" json:"user_id"`
+	LastReadTeamResultID      *int64     `gorm:"column:last_read_team_result_id" json:"last_read_team_result_id"`
+	LastReadPersonalVersionID *int64     `gorm:"column:last_read_personal_version_id" json:"last_read_personal_version_id"`
+	ReadAt                    *time.Time `gorm:"column:read_at" json:"read_at"`
+	CreatedAt                 time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt                 time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+}
+
+func (SummaryUserRead) TableName() string { return "summary_user_read" }
+
 // TaskEvent is the payload for Worker → API HTTP callback.
 type TaskEvent struct {
 	TaskID       int64  `json:"task_id"`

--- a/migrations/sql/20260716-01-summary-user-read.sql
+++ b/migrations/sql/20260716-01-summary-user-read.sql
@@ -1,0 +1,35 @@
+-- +migrate Up
+CREATE TABLE `summary_user_read` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `task_id` bigint NOT NULL,
+  `user_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `last_read_team_result_id` bigint DEFAULT NULL,
+  `last_read_personal_version_id` bigint DEFAULT NULL,
+  `read_at` datetime(3) DEFAULT NULL,
+  `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_summary_user_read_task_user` (`task_id`,`user_id`),
+  KEY `idx_summary_user_read_user` (`user_id`,`task_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Existing visible summaries start as read so rollout does not create a wall
+-- of historical red dots. Creator rows are inserted first; participant rows
+-- then fill the remaining users and carry their own personal version cursor.
+INSERT INTO `summary_user_read`
+  (`task_id`,`user_id`,`last_read_team_result_id`,`last_read_personal_version_id`,`read_at`,`created_at`,`updated_at`)
+SELECT t.`id`, t.`creator_id`, t.`current_result_id`, pr.`current_version_id`, NOW(3), NOW(3), NOW(3)
+FROM `summary_task` t
+LEFT JOIN `summary_personal_result` pr ON pr.`task_id`=t.`id` AND pr.`user_id`=t.`creator_id`
+WHERE t.`deleted_at` IS NULL;
+
+INSERT IGNORE INTO `summary_user_read`
+  (`task_id`,`user_id`,`last_read_team_result_id`,`last_read_personal_version_id`,`read_at`,`created_at`,`updated_at`)
+SELECT t.`id`, p.`user_id`, t.`current_result_id`, pr.`current_version_id`, NOW(3), NOW(3), NOW(3)
+FROM `summary_task` t
+JOIN `summary_participant` p ON p.`task_id`=t.`id`
+LEFT JOIN `summary_personal_result` pr ON pr.`task_id`=t.`id` AND pr.`user_id`=p.`user_id`
+WHERE t.`deleted_at` IS NULL;
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_user_read`;


### PR DESCRIPTION
## Summary

Add per-user read tracking and attention-aware ordering for Smart Summary tasks. Unread team results, unread personal results, collaboration invitations, and scheduled-summary confirmation requests are represented independently and combined into a task-level attention state.

## Related Issue

Closes #149

## Changes

- Add `summary_user_read` to store per-user team and personal result read cursors.
- Backfill existing visible summaries as read during migration so historical content is not marked unread.
- Add `POST /api/v1/summaries/:id/read` to record the exact result versions rendered by the caller.
- Validate that team and personal result IDs belong to the requested task and user.
- Return remaining unread and invitation state after a read update.
- Extend summary list items with unread, invitation, attention, result-version, and activity fields.
- Return task-level attention, unread, and pending-invitation counts.
- Sort folded summary rows by pending invitations, unread results, and latest meaningful summary activity.
- Include scheduled-summary confirmation requests stored in `participant_config`.
- Keep team and personal result read cursors separate.
- Expose the current personal result version ID for accurate read tracking.

## Data Migration

The migration creates `summary_user_read` with a unique `(task_id, user_id)` key. Existing creators and participants are backfilled with their current visible team and personal result versions.

## Behavior

A task requires attention while any of the following is true:

- the caller has a pending collaboration invitation;
- the caller has a pending scheduled-summary confirmation;
- the current team result differs from the last-read team result;
- the current personal result differs from the last-read personal result.

## Testing

- `go test ./internal/api/handler -run 'TestListSummaries_' -count=1`\n- `go test ./internal/db -count=1`\n- `git diff --check`\n\nManual verification covered unread ordering, team and personal result read state, collaboration invitations, scheduled-summary confirmation invitations, historical data migration behavior, and notification-link read updates.\n\n## Compatibility\n\n- Existing list filters and schedule folding remain in place.\n- Attention sorting is applied after schedule folding and before pagination.\n- Processing updates, retries, title changes, and schedule configuration changes do not create unread result state.