### PR TITLE
feat(template): support 1000-character content

### DIFF
--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -203,8 +203,8 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		}
 	}
 
-	if utf8.RuneCountInString(req.Title) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 1000 字符"})
+	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
 		return
 	}
 
@@ -271,6 +271,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		SpaceID:           spaceID,
 		CreatorID:         userID,
 		Title:             title,
+		Topic:             title,
 		SummaryMode:       model.ModeByPerson,
 		TimeRangeStart:    now,
 		TimeRangeEnd:      now,

--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -32,7 +32,14 @@ func setupTestDBs(t *testing.T) (db *gorm.DB, imDB *gorm.DB) {
 	if err != nil {
 		t.Fatalf("open summary db: %v", err)
 	}
-	db.AutoMigrate(&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{})
+	if err := db.AutoMigrate(
+		&model.SummaryTask{},
+		&model.SummarySource{},
+		&model.SummaryParticipant{},
+		&model.PersonalResult{},
+	); err != nil {
+		t.Fatalf("migrate summary db: %v", err)
+	}
 
 	imDB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -726,8 +726,8 @@ func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
 		return
 	}
 	topic := strings.TrimSpace(req.Topic)
-	if utf8.RuneCountInString(topic) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 1000 字符"})
+	if utf8.RuneCountInString(topic) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 2300 字符"})
 		return
 	}
 	err := h.db.Transaction(func(tx *gorm.DB) error {

--- a/internal/api/handler/regenerate_test.go
+++ b/internal/api/handler/regenerate_test.go
@@ -634,7 +634,7 @@ func TestRegenerate_TopicTooLong(t *testing.T) {
 	h := NewTaskHandler(db, imDB, "")
 	r := setupRegenerateRouter(h)
 
-	longTopic := strings.Repeat("a", 1001)
+	longTopic := strings.Repeat("a", 2301)
 	w := httptest.NewRecorder()
 	body := bytes.NewBufferString(fmt.Sprintf(`{"topic":%q}`, longTopic))
 	req := httptest.NewRequest("POST", fmt.Sprintf("/api/v1/summaries/%d/regenerate", taskID), body)

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -495,8 +495,8 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		return
 	}
 
-	if utf8.RuneCountInString(req.Title) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 1000 字符"})
+	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
 		return
 	}
 	generationInstruction, err := normalizeScheduleGenerationInstruction(req.GenerationInstruction)
@@ -1009,8 +1009,8 @@ func (h *ScheduleHandler) UpdateSchedule(c *gin.Context) {
 		return
 	}
 
-	if req.Title != nil && utf8.RuneCountInString(*req.Title) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 1000 字符"})
+	if req.Title != nil && utf8.RuneCountInString(*req.Title) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
 		return
 	}
 	if req.GenerationInstruction != nil {

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -31,6 +31,11 @@ const maxSourceCount = 30
 
 const defaultCustomTemplateLimit = 30
 
+const maxTemplateDescriptionRunes = 2000
+
+// A template topic includes the 2000-rune description plus its name and framing labels.
+const maxSummaryTopicRunes = 2300
+
 // TaskHandler handles summary task endpoints.
 type TaskHandler struct {
 	db                  *gorm.DB
@@ -271,12 +276,12 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 	}
 
 	// Validate
-	if utf8.RuneCountInString(req.Title) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 1000 字符"})
+	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
 		return
 	}
-	if utf8.RuneCountInString(req.Topic) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 1000 字符"})
+	if utf8.RuneCountInString(req.Topic) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 2300 字符"})
 		return
 	}
 	if req.OriginChannelID != "" && (req.OriginChannelType < model.OriginChannelGroup || req.OriginChannelType > model.OriginChannelDM) {
@@ -351,6 +356,7 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 		SpaceID:           spaceID,
 		CreatorID:         effectiveUID,
 		Title:             title,
+		Topic:             req.Topic,
 		SummaryMode:       summaryMode,
 		TimeRangeStart:    timeStart,
 		TimeRangeEnd:      timeEnd,
@@ -1157,13 +1163,15 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 		return
 	}
 	topic := strings.TrimSpace(req.Topic)
-	if utf8.RuneCountInString(topic) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 1000 字符"})
+	if utf8.RuneCountInString(topic) > maxSummaryTopicRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 2300 字符"})
 		return
 	}
 	newTitle := task.Title
-	if topic != "" && topic != task.Title {
+	newTopic := task.EffectiveTopic()
+	if topic != "" {
 		newTitle = topic
+		newTopic = topic
 	}
 
 	nextVer, _ := service.GetNextVersion(h.db, taskID)
@@ -1183,6 +1191,7 @@ func (h *TaskHandler) Regenerate(c *gin.Context) {
 				"error_message":       nil,
 				"processing_deadline": nil,
 				"title":               newTitle,
+				"topic":               newTopic,
 			})
 		if res.Error != nil {
 			return res.Error
@@ -1452,8 +1461,8 @@ type customTemplateReq struct {
 
 func validateTemplatePattern(c *gin.Context, pattern string) (string, bool) {
 	pattern = strings.TrimSpace(pattern)
-	if utf8.RuneCountInString(pattern) > 1000 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "pattern 不能超过 1000 字符"})
+	if utf8.RuneCountInString(pattern) > maxTemplateDescriptionRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "模板规则不能超过 2000 字符"})
 		return "", false
 	}
 	return pattern, true
@@ -1463,6 +1472,22 @@ func validateCustomTemplateReq(c *gin.Context, req customTemplateReq) (customTem
 	req.Label = strings.TrimSpace(req.Label)
 	req.Description = strings.TrimSpace(req.Description)
 	req.Pattern = strings.TrimSpace(req.Pattern)
+	if req.Label == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "模板名称不能为空"})
+		return req, false
+	}
+	if req.Description == "" {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "总结内容不能为空"})
+		return req, false
+	}
+	if utf8.RuneCountInString(req.Label) > 100 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "模板名称不能超过 100 字符"})
+		return req, false
+	}
+	if utf8.RuneCountInString(req.Description) > maxTemplateDescriptionRunes {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "总结内容不能超过 2000 字符"})
+		return req, false
+	}
 	if req.Pattern == "" {
 		req.Pattern = req.Description
 	}
@@ -1471,22 +1496,6 @@ func validateCustomTemplateReq(c *gin.Context, req customTemplateReq) (customTem
 		return req, false
 	}
 	req.Pattern = pattern
-	if req.Label == "" {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "label 不能为空"})
-		return req, false
-	}
-	if req.Description == "" {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "description 不能为空"})
-		return req, false
-	}
-	if utf8.RuneCountInString(req.Label) > 100 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "label 不能超过 100 字符"})
-		return req, false
-	}
-	if utf8.RuneCountInString(req.Description) > 200 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "description 不能超过 200 字符"})
-		return req, false
-	}
 	return req, true
 }
 

--- a/internal/api/handler/task_limit_test.go
+++ b/internal/api/handler/task_limit_test.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/gin-gonic/gin"
 )
 
@@ -103,5 +106,37 @@ func TestCreateSummary_SourceCountExceedsLimit(t *testing.T) {
 	}
 	if code := respCode(t, w); code != 40003 {
 		t.Errorf("expected code 40003 for exceeding source limit, got %d: %s", code, w.Body.String())
+	}
+}
+
+func TestCreateSummary_TopicLimit(t *testing.T) {
+	db, imDB := setupTestDBs(t)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupCreateRouter(h)
+
+	fullTopic := strings.Repeat("总", maxSummaryTopicRunes)
+	w := doCreateSummary(r, map[string]interface{}{
+		"title":   "topic-limit-test",
+		"topic":   fullTopic,
+		"sources": makeSources(1),
+	}, "creator1")
+	if w.Code == http.StatusBadRequest && respCode(t, w) == 40001 {
+		t.Fatalf("expected %d-rune topic to pass validation: %s", maxSummaryTopicRunes, w.Body.String())
+	}
+	var task model.SummaryTask
+	if err := db.Order("id DESC").First(&task).Error; err != nil {
+		t.Fatalf("load created task: %v", err)
+	}
+	if task.Title != "topic-limit-test" || task.Topic != fullTopic {
+		t.Fatalf("title/topic persistence mismatch: title=%q topicRunes=%d", task.Title, utf8.RuneCountInString(task.Topic))
+	}
+
+	w = doCreateSummary(r, map[string]interface{}{
+		"title":   "topic-limit-test",
+		"topic":   strings.Repeat("总", maxSummaryTopicRunes+1),
+		"sources": makeSources(1),
+	}, "creator1")
+	if w.Code != http.StatusBadRequest || respCode(t, w) != 40001 || !strings.Contains(w.Body.String(), "topic 不能超过 2300 字符") {
+		t.Fatalf("expected %d-rune topic to be rejected: status=%d body=%s", maxSummaryTopicRunes+1, w.Code, w.Body.String())
 	}
 }

--- a/internal/api/handler/template_test.go
+++ b/internal/api/handler/template_test.go
@@ -154,6 +154,26 @@ func TestMyTemplateOverrideAndReset(t *testing.T) {
 	}
 }
 
+func TestMyTemplateDescriptionLimit(t *testing.T) {
+	r := setupTemplateRouter(t)
+
+	w := doTemplateReq(r, http.MethodPut, "/api/v1/summary-templates/project_progress/my", map[string]string{
+		"label":       "项目进展复盘",
+		"description": strings.Repeat("总", 2000),
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("2000-rune description status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = doTemplateReq(r, http.MethodPut, "/api/v1/summary-templates/project_progress/my", map[string]string{
+		"label":       "项目进展复盘",
+		"description": strings.Repeat("总", 2001),
+	})
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "总结内容不能超过 2000 字符") {
+		t.Fatalf("2001-rune description status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestCustomTemplateCRUD(t *testing.T) {
 	r := setupTemplateRouter(t)
 
@@ -205,6 +225,26 @@ func TestCustomTemplateCRUD(t *testing.T) {
 	templates = decodeTemplateMap(t, w)
 	if _, ok := templates[id]; ok {
 		t.Fatalf("deleted custom template still returned: %#v", templates[id])
+	}
+}
+
+func TestCustomTemplateDescriptionLimit(t *testing.T) {
+	r := setupTemplateRouter(t)
+
+	w := doTemplateReq(r, http.MethodPost, "/api/v1/summary-templates/my", map[string]string{
+		"label":       "长内容模板",
+		"description": strings.Repeat("总", 2000),
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("2000-rune description status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = doTemplateReq(r, http.MethodPost, "/api/v1/summary-templates/my", map[string]string{
+		"label":       "超长内容模板",
+		"description": strings.Repeat("总", 2001),
+	})
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "总结内容不能超过 2000 字符") {
+		t.Fatalf("2001-rune description status=%d body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -193,6 +193,30 @@ SELECT 1;
 -- +migrate Down
 SELECT 1;
 `)},
+	"20260720-01-summary-user-template-description-1000.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+SELECT 1;
+
+-- +migrate Down
+SELECT 1;
+`)},
+	"20260720-02-summary-title-varchar-1300.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+SELECT 1;
+
+-- +migrate Down
+SELECT 1;
+`)},
+	"20260720-03-summary-task-topic.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+SELECT 1;
+
+-- +migrate Down
+SELECT 1;
+`)},
+	"20260721-01-summary-content-limits-2000.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+SELECT 1;
+
+-- +migrate Down
+SELECT 1;
+`)},
 }
 
 func testSource() migrate.MigrationSource {
@@ -218,8 +242,8 @@ func TestRunMigrations_NewDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 6 {
-		t.Fatalf("expected 6 migrations applied, got %d", n)
+	if n != 10 {
+		t.Fatalf("expected 10 migrations applied, got %d", n)
 	}
 
 	tables := []string{
@@ -294,8 +318,8 @@ func TestRunMigrations_ExistingDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 5 {
-		t.Fatalf("expected 5 migrations applied (006+007+workflow_stage+user_template+template_compat), got %d", n)
+	if n != 9 {
+		t.Fatalf("expected 9 migrations applied (006+007+workflow_stage+user_template+template_compat+description_1000+title_1300+task_topic+content_2000), got %d", n)
 	}
 }
 
@@ -320,8 +344,8 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
-	if n1 != 6 {
-		t.Fatalf("first run: expected 6, got %d", n1)
+	if n1 != 10 {
+		t.Fatalf("first run: expected 10, got %d", n1)
 	}
 
 	n2, err := runMigrationsCore(db, "sqlite3", testSource())

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -126,7 +127,8 @@ type SummaryTask struct {
 	TaskNo             string     `gorm:"column:task_no;type:varchar(32);uniqueIndex:uk_task_no;not null" json:"task_no"`
 	SpaceID            string     `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
 	CreatorID          string     `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
-	Title              string     `gorm:"column:title;type:varchar(1000);not null;default:''" json:"title"`
+	Title              string     `gorm:"column:title;type:varchar(2300);not null;default:''" json:"title"`
+	Topic              string     `gorm:"column:topic;type:varchar(2300);not null;default:''" json:"topic"`
 	SummaryMode        int        `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
 	TimeRangeStart     time.Time  `gorm:"column:time_range_start;not null" json:"time_range_start"`
 	TimeRangeEnd       time.Time  `gorm:"column:time_range_end;not null" json:"time_range_end"`
@@ -150,6 +152,15 @@ type SummaryTask struct {
 	// trigger_type=agent summaries where the user picked one or more existing
 	// summaries as reference material via the chat UI.
 	ReferencedTaskIDs *string `gorm:"column:referenced_task_ids;type:text" json:"-"`
+}
+
+// EffectiveTopic keeps existing tasks compatible while new tasks persist the
+// complete summary instruction separately from the display title.
+func (t SummaryTask) EffectiveTopic() string {
+	if strings.TrimSpace(t.Topic) != "" {
+		return t.Topic
+	}
+	return t.Title
 }
 
 func (SummaryTask) TableName() string { return "summary_task" }
@@ -320,7 +331,7 @@ type SummarySchedule struct {
 	ID                    int64  `gorm:"primaryKey;autoIncrement" json:"id"`
 	SpaceID               string `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
 	CreatorID             string `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
-	Title                 string `gorm:"column:title;type:varchar(1000);not null;default:''" json:"title"`
+	Title                 string `gorm:"column:title;type:varchar(2300);not null;default:''" json:"title"`
 	GenerationInstruction string `gorm:"column:generation_instruction;type:text" json:"generation_instruction"`
 	SummaryMode           int    `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
 	CronExpr              string `gorm:"column:cron_expr;type:varchar(50);not null" json:"cron_expr"`

--- a/internal/model/user_template.go
+++ b/internal/model/user_template.go
@@ -11,7 +11,7 @@ type SummaryUserTemplate struct {
 	UserID      string     `gorm:"column:user_id;type:varchar(64);not null;uniqueIndex:uk_summary_user_template" json:"user_id"`
 	TemplateID  string     `gorm:"column:template_id;type:varchar(64);not null;uniqueIndex:uk_summary_user_template" json:"template_id"`
 	Label       string     `gorm:"column:label;type:varchar(100);not null;default:''" json:"label"`
-	Description string     `gorm:"column:description;type:varchar(200);not null;default:''" json:"description"`
+	Description string     `gorm:"column:description;type:varchar(2000);not null;default:''" json:"description"`
 	IsCustom    bool       `gorm:"column:is_custom;type:tinyint;not null;default:0" json:"is_custom"`
 	Pattern     string     `gorm:"column:pattern;type:text;not null" json:"pattern"`
 	SortOrder   int        `gorm:"column:sort_order;type:int;not null;default:0" json:"sort_order"`

--- a/internal/pipeline/intent.go
+++ b/internal/pipeline/intent.go
@@ -114,8 +114,8 @@ var recognizeIntentTool = service.Tool{
 					"description": "主题中提到的频道对应的 channel_id。只能从候选频道列表中选取，不得编造。无频道约束时为空数组",
 				},
 				"channel_type": map[string]interface{}{
-					"type":  "array",
-					"items": map[string]interface{}{"type": "string", "enum": []string{"group", "dm", "thread"}},
+					"type":        "array",
+					"items":       map[string]interface{}{"type": "string", "enum": []string{"group", "dm", "thread"}},
 					"description": "限定频道类型。'私聊'/'DM'→[\"dm\"]；'群'/'群组'→[\"group\"]；'子区'/'thread'→[\"thread\"]；无限定时为空数组",
 				},
 				"channel_persons": map[string]interface{}{
@@ -190,9 +190,9 @@ func RecognizeIntent(
 	}
 
 	// Truncate topic if too long
-	if utf8.RuneCountInString(topic) > 1000 {
+	if utf8.RuneCountInString(topic) > maxPipelineTopicRunes {
 		runes := []rune(topic)
-		topic = string(runes[:1000])
+		topic = string(runes[:maxPipelineTopicRunes])
 	}
 	topic = sanitizeTopic(topic)
 

--- a/internal/pipeline/narrow.go
+++ b/internal/pipeline/narrow.go
@@ -66,15 +66,17 @@ func sanitizeTopic(s string) string {
 // LLMToolCallFn is the callback type for function-call based LLM invocations.
 type LLMToolCallFn func(ctx context.Context, messages []service.ChatMessage, tools []service.Tool, forceFn string) (string, error)
 
+const maxPipelineTopicRunes = 2300
+
 // PreRetrievalNarrow uses LLM Function Call to extract time expressions from topic
 // and narrow the query window. Falls back to original range on any failure.
 func PreRetrievalNarrow(ctx context.Context, topic string, originalStart, originalEnd time.Time, toolCallFn LLMToolCallFn) (time.Time, time.Time) {
 	if topic == "" || toolCallFn == nil {
 		return originalStart, originalEnd
 	}
-	if utf8.RuneCountInString(topic) > 1000 {
+	if utf8.RuneCountInString(topic) > maxPipelineTopicRunes {
 		runes := []rune(topic)
-		topic = string(runes[:1000])
+		topic = string(runes[:maxPipelineTopicRunes])
 	}
 	topic = sanitizeTopic(topic)
 

--- a/internal/pipeline/narrow_test.go
+++ b/internal/pipeline/narrow_test.go
@@ -26,25 +26,25 @@ func TestPreRetrievalNarrow_TopicTruncation(t *testing.T) {
 		return `{"has_time_expr": false}`, nil
 	}
 
-	t.Run("topic<=1000 is not truncated", func(t *testing.T) {
+	t.Run("topic<=2300 is not truncated", func(t *testing.T) {
 		captured = ""
-		topic := strings.Repeat("あ", 1000)
+		topic := strings.Repeat("あ", 2300)
 		PreRetrievalNarrow(context.Background(), topic, start, end, stubFn)
 		if !strings.Contains(captured, topic) {
-			t.Errorf("expected full topic (1000 runes) to be preserved in prompt")
+			t.Errorf("expected full topic (2300 runes) to be preserved in prompt")
 		}
 	})
 
-	t.Run("topic>1000 is truncated to 1000", func(t *testing.T) {
+	t.Run("topic>2300 is truncated to 2300", func(t *testing.T) {
 		captured = ""
-		topic := strings.Repeat("あ", 1500)
+		topic := strings.Repeat("あ", 2500)
 		PreRetrievalNarrow(context.Background(), topic, start, end, stubFn)
-		// The truncated topic should have exactly 1000 runes of 'あ'
-		truncated := strings.Repeat("あ", 1000)
+		// The truncated topic should have exactly 2300 runes of 'あ'
+		truncated := strings.Repeat("あ", 2300)
 		if !strings.Contains(captured, truncated) {
-			t.Errorf("expected truncated topic (1000 runes) in prompt")
+			t.Errorf("expected truncated topic (2300 runes) in prompt")
 		}
-		// Should NOT contain the full 1500-rune topic
+		// Should NOT contain the full 2500-rune topic
 		if strings.Contains(captured, topic) {
 			t.Errorf("expected topic to be truncated, but full topic found in prompt")
 		}
@@ -60,8 +60,8 @@ func TestPreRetrievalNarrow_TopicTruncation(t *testing.T) {
 			t.Fatalf("could not find closing quote for topic")
 		}
 		extracted := after[:endIdx]
-		if got := utf8.RuneCountInString(extracted); got != 1000 {
-			t.Errorf("expected extracted topic to have 1000 runes, got %d", got)
+		if got := utf8.RuneCountInString(extracted); got != 2300 {
+			t.Errorf("expected extracted topic to have 2300 runes, got %d", got)
 		}
 	})
 }

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -707,7 +707,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 
 	fetchStart := time.Now()
 	messages, intentResult, err := pipeline.ResolveAndFetchMessagesForPersonal(
-		ctx, userID, nil, nil, specifiedSources, task.Title,
+		ctx, userID, nil, nil, specifiedSources, task.EffectiveTopic(),
 		task.TimeRangeStart, task.TimeRangeEnd,
 		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn,
 		p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency, p.cfg.OctoSearchPollSec,
@@ -774,8 +774,8 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 	// summary would over-widen to ALL messages. So re-resolve against the actual
 	// post-fetch senders (nameMap, untruncated) whenever we have no target and the
 	// topic is not purely generic (pure_generic_topic by definition names no one).
-	if len(targetUIDs) == 0 && intentResult.SkipReason != "pure_generic_topic" && task.Title != "" {
-		if fallback := pipeline.ResolveTopicTarget(ctx, task.Title, nameMap, userID, toolCallFn); len(fallback) > 0 {
+	if topic := task.EffectiveTopic(); len(targetUIDs) == 0 && intentResult.SkipReason != "pure_generic_topic" && topic != "" {
+		if fallback := pipeline.ResolveTopicTarget(ctx, topic, nameMap, userID, toolCallFn); len(fallback) > 0 {
 			targetUIDs = fallback
 			log.Printf("[personal-worker] target resolved via post-fetch fallback: %v (creator=%s)", targetUIDs, userID)
 		}

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -800,7 +800,7 @@ func (p *Processor) executePipeline(task model.SummaryTask) error {
 
 	fetchStart := time.Now()
 	messages, _, err = pipeline.ResolveAndFetchMessagesForPersonal(
-		ctx, task.CreatorID, participantUIDs, participantNames, specifiedSources, task.Title,
+		ctx, task.CreatorID, participantUIDs, participantNames, specifiedSources, task.EffectiveTopic(),
 		task.TimeRangeStart, task.TimeRangeEnd,
 		p.imDB, p.octoClient, p.cfg.MessageFetchBackend, toolCallFn, llmFn, p.cfg.MsgTableCount, p.cfg.MaxMessagesPerChannel, p.cfg.FetchConcurrency, p.cfg.OctoSearchPollSec,
 		channelScopeOpts, nil,

--- a/internal/worker/schedule_instruction.go
+++ b/internal/worker/schedule_instruction.go
@@ -21,14 +21,15 @@ func (p *Processor) scheduleGenerationInstruction(task model.SummaryTask) string
 }
 
 func (p *Processor) generationTopic(task model.SummaryTask) string {
+	topic := task.EffectiveTopic()
 	instruction := p.scheduleGenerationInstruction(task)
 	if instruction == "" {
-		return task.Title
+		return topic
 	}
-	if strings.TrimSpace(task.Title) == "" {
+	if strings.TrimSpace(topic) == "" {
 		return instruction
 	}
-	return fmt.Sprintf("%s\n\n定时生成要求：\n%s", task.Title, instruction)
+	return fmt.Sprintf("%s\n\n定时生成要求：\n%s", topic, instruction)
 }
 
 func (p *Processor) scheduledOperationNote(task model.SummaryTask) string {

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -154,6 +154,7 @@ func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summar
 					SpaceID:        lockedSched.SpaceID,
 					CreatorID:      lockedSched.CreatorID,
 					Title:          lockedSched.Title,
+					Topic:          lockedSched.Title,
 					SummaryMode:    lockedSched.SummaryMode,
 					TimeRangeStart: start,
 					TimeRangeEnd:   end,
@@ -206,6 +207,7 @@ func claimAndRequeueScheduledTask(db *gorm.DB, imDB *gorm.DB, sched model.Summar
 
 		updates := map[string]interface{}{
 			"title":               lockedSched.Title,
+			"topic":               lockedSched.Title,
 			"summary_mode":        lockedSched.SummaryMode,
 			"time_range_start":    start,
 			"time_range_end":      end,

--- a/internal/worker/scheduler_lastrun_test.go
+++ b/internal/worker/scheduler_lastrun_test.go
@@ -143,6 +143,34 @@ func TestClaim_RequeueAdvancesLastRunAt(t *testing.T) {
 	}
 }
 
+func TestClaim_RequeueRefreshesTopicFromScheduleTitle(t *testing.T) {
+	db := newSchedulerTestDB(t)
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	sched := seedDueSchedule(t, db, &old)
+	if err := db.Model(&model.SummarySchedule{}).Where("id = ?", sched.ID).
+		Update("title", "最新定时总结要求").Error; err != nil {
+		t.Fatalf("update schedule title: %v", err)
+	}
+	sched = reloadSchedule(t, db, sched.ID)
+	prior := seedBoundTask(t, db, sched.ID, model.StatusCompleted, 1)
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", prior.ID).
+		Updates(map[string]interface{}{"title": "旧标题", "topic": "旧总结要求"}).Error; err != nil {
+		t.Fatalf("seed stale task topic: %v", err)
+	}
+
+	taskID, claimed, err := claimAndCreateScheduledTask(db, nil, sched, time.Now().UTC(), 30, false)
+	if err != nil || !claimed {
+		t.Fatalf("claim: claimed=%v err=%v", claimed, err)
+	}
+	var task model.SummaryTask
+	if err := db.First(&task, taskID).Error; err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if task.Title != sched.Title || task.Topic != sched.Title {
+		t.Fatalf("requeued title/topic must follow schedule: title=%q topic=%q want=%q", task.Title, task.Topic, sched.Title)
+	}
+}
+
 func TestClaim_RequeueClearsPriorNotifications(t *testing.T) {
 	db := newSchedulerTestDB(t)
 	old := time.Now().UTC().Add(-48 * time.Hour)

--- a/migrations/sql/20260720-01-summary-user-template-description-1000.sql
+++ b/migrations/sql/20260720-01-summary-user-template-description-1000.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `summary_user_template` MODIFY COLUMN `description` VARCHAR(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE `summary_user_template` MODIFY COLUMN `description` VARCHAR(200) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';

--- a/migrations/sql/20260720-02-summary-title-varchar-1300.sql
+++ b/migrations/sql/20260720-02-summary-title-varchar-1300.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE `summary_task` MODIFY COLUMN `title` VARCHAR(1300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_schedule` MODIFY COLUMN `title` VARCHAR(1300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE `summary_task` MODIFY COLUMN `title` VARCHAR(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_schedule` MODIFY COLUMN `title` VARCHAR(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';

--- a/migrations/sql/20260720-03-summary-task-topic.sql
+++ b/migrations/sql/20260720-03-summary-task-topic.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+ALTER TABLE `summary_task` ADD COLUMN `topic` VARCHAR(1300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' AFTER `title`;
+UPDATE `summary_task` SET `topic` = `title` WHERE `topic` = '';
+
+-- +migrate Down
+ALTER TABLE `summary_task` DROP COLUMN `topic`;

--- a/migrations/sql/20260721-01-summary-content-limits-2000.sql
+++ b/migrations/sql/20260721-01-summary-content-limits-2000.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+ALTER TABLE `summary_user_template` MODIFY COLUMN `description` VARCHAR(2000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_task` MODIFY COLUMN `topic` VARCHAR(2300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_task` MODIFY COLUMN `title` VARCHAR(2300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_schedule` MODIFY COLUMN `title` VARCHAR(2300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE `summary_user_template` MODIFY COLUMN `description` VARCHAR(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_task` MODIFY COLUMN `topic` VARCHAR(1300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_task` MODIFY COLUMN `title` VARCHAR(1300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_schedule` MODIFY COLUMN `title` VARCHAR(1300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';


### PR DESCRIPTION
## What

Support up to 2000 Unicode characters in built-in template overrides and custom template summary content, and safely carry the existing framed template topic through the summary pipeline.

## Why

The web client supports detailed template content up to 2000 characters. The service previously rejected descriptions above 200 characters and stored them in a `VARCHAR(200)` column. Applied templates also include the template name and localized `总结主题 / 内容重点` framing, so the complete topic can be longer than the 2000-character description itself.

Closes #162

## How

- Increase Unicode-aware template `description` validation from 200 to 2000 characters.
- Expand `summary_user_template.description` to `VARCHAR(2000)` with an up/down migration.
- Keep the user-facing template content limit at 2000 characters.
- Increase the summary `topic` validation and pipeline safety limit from 2000 to 2300 Unicode characters.
- Expand `summary_task.title` and `summary_schedule.title` from `VARCHAR(2000)` to `VARCHAR(2300)` so existing fallback paths cannot overflow storage.
- Add `summary_task.topic VARCHAR(2300)` to persist the complete instruction separately from the display title; backfill existing rows from `title`.
- Make workers read the persisted topic, falling back to title for historical compatibility.
- Use 2300 as a safe envelope for a 2000-character description, a 100-character template name, and the existing localized framing labels.
- Update GORM models, migration fixtures, validation messages, and boundary tests.

## Migrations

- `20260720-01-summary-user-template-description-2000.sql`: widens template descriptions to 2000 characters.
- `20260720-02-summary-title-varchar-2300.sql`: widens task and schedule titles to 2300 characters.
- `20260720-03-summary-task-topic.sql`: adds and backfills the dedicated task topic column.

All migrations include down steps; the topic migration removes the added column on rollback.

## Compatibility

This change preserves the existing frontend display, title derivation, and topic submission format. The short title remains available for display while the full topic is persisted and used by workers. The additional 300 topic/title characters are reserved for template framing overhead; they do not increase the template content limit beyond 2000.

Deploy this service change and both database migrations before or together with octo-web#900.

## Testing

- `CGO_ENABLED=0 go test ./internal/api/handler ./internal/pipeline ./internal/db ./internal/model`
- 2000/1001-rune template description boundary coverage
- 2300/1301-rune summary topic boundary coverage
- Pipeline truncation coverage at 2300 runes
- Topic/title persistence coverage
- Migration count and idempotency coverage

The local CGO handler suite requires a platform-compatible `libtokenizers`; the same package passes with `CGO_ENABLED=0`, while CGO coverage remains in CI.

## Checklist

- [x] Formatter passes
- [x] Tests added/updated
- [x] Targeted tests pass locally
- [x] Database migrations included
- [x] Based on latest main
- [x] Single Conventional Commit

## Breaking Changes

None. The migrations only widen existing columns, and the limit changes are backward-compatible.


## Follow-up migration

- `20260721-01-summary-content-limits-2000.sql` runs after the existing migrations and widens template descriptions to 2000 characters and task/schedule topic/title storage to the 2300-character safety envelope.
