### PR TITLE
fix(summary): align waiting-state filtering

### DIFF
--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -1069,3 +1069,78 @@ func TestGetResult_SingleConfirmLeak_ProducerSeesOwn(t *testing.T) {
 		t.Errorf("producer memberA must KEEP their own plain citations via GetResult; got none. body=%s", w.Body.String())
 	}
 }
+
+func TestListSummaries_WaitingFilterExcludesSinglePersonCompletedResult(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	task := model.SummaryTask{
+		TaskNo: "TST-SINGLE-COMPLETED", SpaceID: "space1", CreatorID: "creator1",
+		SummaryMode: model.ModeByPerson, Status: model.StatusCompleted,
+	}
+	db.Create(&task)
+	db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: "creator1", Status: model.ParticipantCompleted,
+	})
+	db.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: "creator1", WorkerStatus: model.PersonalStatusCompleted,
+	})
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, "GET", "/api/v1/summaries?status=0", "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 0 || len(resp.Data.Items) != 0 {
+		t.Fatalf("single-person completed result must not be treated as waiting for submission, got total=%d items=%d", resp.Data.Total, len(resp.Data.Items))
+	}
+}
+
+func TestListSummaries_WaitingFilterIncludesMyPendingInvitation(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	task := model.SummaryTask{
+		TaskNo:      "TST-WAITING-INVITE",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusProcessing,
+	}
+	db.Create(&task)
+	db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: "creator1", UserName: "Creator", Status: model.ParticipantAccepted,
+	})
+	db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: "participant1", UserName: "P1", Status: model.ParticipantPending,
+	})
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, "GET", "/api/v1/summaries?status=0", "participant1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 1 || len(resp.Data.Items) != 1 {
+		t.Fatalf("waiting filter must include my pending invitation on a processing task, got total=%d items=%d", resp.Data.Total, len(resp.Data.Items))
+	}
+
+	db.Model(&model.SummaryParticipant{}).
+		Where("task_id = ? AND user_id = ?", task.ID, "participant1").
+		Update("status", model.ParticipantAccepted)
+	db.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: "participant1", WorkerStatus: model.PersonalStatusCompleted,
+	})
+	w = doRequest(r, "GET", "/api/v1/summaries?status=0", "participant1")
+	resp = parseListResponse(t, w)
+	if resp.Data.Total != 1 || len(resp.Data.Items) != 1 {
+		t.Fatalf("waiting filter must include my completed but unsubmitted personal summary, got total=%d items=%d", resp.Data.Total, len(resp.Data.Items))
+	}
+
+	now := timezone.Now()
+	db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", task.ID, "participant1").
+		Update("submitted_at", now)
+	w = doRequest(r, "GET", "/api/v1/summaries?status=0", "participant1")
+	resp = parseListResponse(t, w)
+	if resp.Data.Total != 0 || len(resp.Data.Items) != 0 {
+		t.Fatalf("waiting filter must exclude a processing task after personal summary submission, got total=%d items=%d", resp.Data.Total, len(resp.Data.Items))
+	}
+}

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -506,8 +506,20 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 
 	if s := c.Query("status"); s != "" {
 		if v, err := strconv.Atoi(s); err == nil {
-			whereSQL += " AND status = ?"
-			args = append(args, v)
+			if v == model.StatusPending {
+				// Waiting is a caller-specific aggregate state that includes tasks not
+				// yet started, pending task invitations, and pending schedule invitations.
+				// Apply it before pagination to keep totals and pages accurate.
+				statusPendingExpr := h.schedulePendingInvitationExpr("summary_task")
+				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1) OR " + statusPendingExpr + ")"
+				args = append(args, v, userID, model.ParticipantPending, userID, model.PersonalStatusCompleted)
+				if h.db.Dialector.Name() == "mysql" {
+					args = append(args, userID)
+				}
+			} else {
+				whereSQL += " AND status = ?"
+				args = append(args, v)
+			}
 		}
 	}
 	if s := c.Query("trigger_type"); s != "" {
@@ -583,6 +595,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
 	attentionSelect := `,
  CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1 THEN 1 ELSE 0 END AS has_pending_submission,
  CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
         OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id <> pr.current_version_id))
       THEN 1 ELSE 0 END AS is_unread,
@@ -597,12 +610,14 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	if h.db.Dialector.Name() == "mysql" {
 		pageArgs = append(pageArgs, userID)
 	}
+	pageArgs = append(pageArgs, model.PersonalStatusCompleted)
 	pageArgs = append(pageArgs, args...)
 	pageArgs = append(pageArgs, userID, userID, userID, userID, pageSize, (page-1)*pageSize)
 
 	type listTaskRow struct {
 		model.SummaryTask        `gorm:"embedded"`
 		HasPendingInvitation     bool   `gorm:"column:has_pending_invitation"`
+		HasPendingSubmission     bool   `gorm:"column:has_pending_submission"`
 		IsUnread                 bool   `gorm:"column:is_unread"`
 		ListCurrentResultID      *int64 `gorm:"column:list_current_result_id"`
 		CurrentPersonalVersionID *int64 `gorm:"column:current_personal_version_id"`
@@ -707,6 +722,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"task_id":                     t.ID,
 			"task_no":                     t.TaskNo,
 			"title":                       t.Title,
+			"topic":                       t.EffectiveTopic(),
 			"summary_mode":                t.SummaryMode,
 			"status":                      t.Status,
 			"trigger_type":                t.TriggerType,
@@ -726,6 +742,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"result_edited_at":            resultEditedAt,
 			"is_unread":                   attention.IsUnread,
 			"has_pending_invitation":      attention.HasPendingInvitation,
+			"has_pending_submission":      attention.HasPendingSubmission,
 			"needs_attention":             attention.IsUnread || attention.HasPendingInvitation,
 			"current_result_id":           attention.ListCurrentResultID,
 			"current_personal_version_id": attention.CurrentPersonalVersionID,
@@ -925,6 +942,7 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 		"task_id":             task.ID,
 		"task_no":             task.TaskNo,
 		"title":               task.Title,
+		"topic":               task.EffectiveTopic(),
 		"summary_mode":        task.SummaryMode,
 		"status":              task.Status,
 		"creator_id":          task.CreatorID,


### PR DESCRIPTION
## Summary

Align summary waiting-state filtering and expose topic data for consistent presentation.

## Related Issue

Closes #166

## Changes

- Include pending invitations and unsubmitted multi-person reports in Waiting.
- Exclude completed single-person summaries from pending submission.
- Apply waiting conditions before pagination.
- Return `has_pending_submission` and complete `topic` data.

## Testing

- Added focused handler coverage for waiting-state filtering.
- Ran `gofmt` and `git diff --check`.