### PR TITLE
fix(agent): env-configurable step timeout + whitelisted detail on 500 responses

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -17,6 +17,7 @@ All configuration is done via environment variables.
 | `LLM_API_KEY` | API key for the LLM gateway | Yes (Worker) | — |
 | `LLM_MODEL` | Model identifier to use for summarization | Yes | — |
 | `LLM_TIMEOUT` | LLM request timeout in seconds | No | `180` |
+| `AGENT_STEP_TIMEOUT` | Maximum duration in seconds for one agent planning step; streaming requests remain capped by the 300-second request deadline | No | `240` |
 | `LLM_MAX_TOKENS` | Maximum tokens for LLM response | No | `4096` |
 | `LLM_TEMPERATURE` | Sampling temperature for LLM | No | `0.3` |
 | `LLM_ENABLE_THINKING` | Enable extended thinking mode | No | `false` |

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -132,13 +132,11 @@ func BuildRegistry(toolNames []string) (*Registry, error) {
 
 // GetProfile 取一个场景定义。未知场景报错。
 //
-// StepTimeout override: the static profile values above are code defaults
-// (60s) that historically fit the pipeline flow. Interactive agent chat —
-// especially refine flows injecting ~21K tokens of referenced summary per
-// turn — can push a single LLM planning call well past 60s on slower
-// models (kimi / sonnet with large context). AGENT_STEP_TIMEOUT env
-// overrides the static 240s default. Setting
-// to 0 disables the override and keeps the code default.
+// StepTimeout: the static profile values above are the code default (240s —
+// raised from a historical 60s that tripped stepCtx on large-context refine
+// turns). AGENT_STEP_TIMEOUT env overrides it per-deploy; an unset / 0 /
+// invalid value keeps the 240s static default. The runner reads
+// Policy.StepTimeout from here — nothing reads config for it.
 func GetProfile(name string) (Profile, error) {
 	p, ok := profiles[name]
 	if !ok {

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -54,12 +54,12 @@ var profiles = map[string]Profile{
 	"chat": {
 		PromptFile: "chat",
 		Tools:      []string{"get_current_time", "extract_time_range"},
-		Policy:     Policy{MaxSteps: 8, MaxTokens: 8000, StepTimeout: 240e9},
+		Policy:     Policy{MaxSteps: 8, MaxTokens: 8000, StepTimeout: 240 * time.Second},
 	},
 	"summary": {
 		PromptFile: "summary",
 		Tools:      []string{"get_current_time", "extract_time_range", "list_channels", "narrow_channels_by_topic", "find_shared_channels", "peek_channel", "fetch_channel", "search_messages", "filter_relevant", "summarize_chunk", "merge_summaries"},
-		Policy:     Policy{MaxSteps: 20, MaxTokens: 60000, StepTimeout: 240e9},
+		Policy:     Policy{MaxSteps: 20, MaxTokens: 60000, StepTimeout: 240 * time.Second},
 	},
 	"summary_refine": {
 		PromptFile: "summary_refine",
@@ -76,7 +76,7 @@ var profiles = map[string]Profile{
 		// the old 60s tripped stepCtx before the LLM finished streaming and
 		// surfaced as `[agent] chat runner error: context deadline exceeded`.
 		// AGENT_STEP_TIMEOUT env still overrides at GetProfile time (see below).
-		Policy: Policy{MaxSteps: 15, MaxTokens: 120000, StepTimeout: 240e9},
+		Policy: Policy{MaxSteps: 15, MaxTokens: 120000, StepTimeout: 240 * time.Second},
 	},
 }
 
@@ -137,7 +137,7 @@ func BuildRegistry(toolNames []string) (*Registry, error) {
 // especially refine flows injecting ~21K tokens of referenced summary per
 // turn — can push a single LLM planning call well past 60s on slower
 // models (kimi / sonnet with large context). AGENT_STEP_TIMEOUT env
-// overrides the static default; default 240s (see config.go). Setting
+// overrides the static 240s default. Setting
 // to 0 disables the override and keeps the code default.
 func GetProfile(name string) (Profile, error) {
 	p, ok := profiles[name]
@@ -159,9 +159,9 @@ func GetToolFactory(name string) (ToolFactory, bool) {
 // agentStepTimeoutOverride returns the AGENT_STEP_TIMEOUT env value as a
 // duration if it parses to a positive integer, else 0 (meaning: keep the
 // profile's static StepTimeout). Read directly from os.Getenv rather than
-// via config.Config so profile lookup does not require SetSummaryDeps —
-// this matters for unit tests that build a runner without initializing
-// the whole deps container.
+// via config.Config so this remains the single source of truth and profile
+// lookup does not require SetSummaryDeps. This matters for unit tests that
+// build a runner without initializing the whole deps container.
 func agentStepTimeoutOverride() time.Duration {
 	v := strings.TrimSpace(os.Getenv("AGENT_STEP_TIMEOUT"))
 	if v == "" {

--- a/internal/agent/profile.go
+++ b/internal/agent/profile.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // 提示词与工具的可配置机制：
@@ -52,12 +54,12 @@ var profiles = map[string]Profile{
 	"chat": {
 		PromptFile: "chat",
 		Tools:      []string{"get_current_time", "extract_time_range"},
-		Policy:     Policy{MaxSteps: 8, MaxTokens: 8000, StepTimeout: 60e9},
+		Policy:     Policy{MaxSteps: 8, MaxTokens: 8000, StepTimeout: 240e9},
 	},
 	"summary": {
 		PromptFile: "summary",
 		Tools:      []string{"get_current_time", "extract_time_range", "list_channels", "narrow_channels_by_topic", "find_shared_channels", "peek_channel", "fetch_channel", "search_messages", "filter_relevant", "summarize_chunk", "merge_summaries"},
-		Policy:     Policy{MaxSteps: 20, MaxTokens: 60000, StepTimeout: 60e9},
+		Policy:     Policy{MaxSteps: 20, MaxTokens: 60000, StepTimeout: 240e9},
 	},
 	"summary_refine": {
 		PromptFile: "summary_refine",
@@ -68,7 +70,13 @@ var profiles = map[string]Profile{
 		// refine (get_time + fetch + answer) blew through 40K by step 2 and
 		// triggered "已达 token 预算" mid-flow. 120K gives room for 4-5 tool
 		// steps at ~25K each. See CHAT-REFERENCE-BASED-DESIGN-v1 diagnostic.
-		Policy: Policy{MaxSteps: 15, MaxTokens: 120000, StepTimeout: 60e9},
+		//
+		// StepTimeout 240s (was 60s): a single LLM planning call on
+		// sonnet/kimi with 20-40K tokens of context routinely takes 60-100s;
+		// the old 60s tripped stepCtx before the LLM finished streaming and
+		// surfaced as `[agent] chat runner error: context deadline exceeded`.
+		// AGENT_STEP_TIMEOUT env still overrides at GetProfile time (see below).
+		Policy: Policy{MaxSteps: 15, MaxTokens: 120000, StepTimeout: 240e9},
 	},
 }
 
@@ -123,10 +131,21 @@ func BuildRegistry(toolNames []string) (*Registry, error) {
 }
 
 // GetProfile 取一个场景定义。未知场景报错。
+//
+// StepTimeout override: the static profile values above are code defaults
+// (60s) that historically fit the pipeline flow. Interactive agent chat —
+// especially refine flows injecting ~21K tokens of referenced summary per
+// turn — can push a single LLM planning call well past 60s on slower
+// models (kimi / sonnet with large context). AGENT_STEP_TIMEOUT env
+// overrides the static default; default 240s (see config.go). Setting
+// to 0 disables the override and keeps the code default.
 func GetProfile(name string) (Profile, error) {
 	p, ok := profiles[name]
 	if !ok {
 		return Profile{}, fmt.Errorf("unknown agent profile %q", name)
+	}
+	if override := agentStepTimeoutOverride(); override > 0 {
+		p.Policy.StepTimeout = override
 	}
 	return p, nil
 }
@@ -135,4 +154,22 @@ func GetProfile(name string) (Profile, error) {
 func GetToolFactory(name string) (ToolFactory, bool) {
 	f, ok := toolFactories[name]
 	return f, ok
+}
+
+// agentStepTimeoutOverride returns the AGENT_STEP_TIMEOUT env value as a
+// duration if it parses to a positive integer, else 0 (meaning: keep the
+// profile's static StepTimeout). Read directly from os.Getenv rather than
+// via config.Config so profile lookup does not require SetSummaryDeps —
+// this matters for unit tests that build a runner without initializing
+// the whole deps container.
+func agentStepTimeoutOverride() time.Duration {
+	v := strings.TrimSpace(os.Getenv("AGENT_STEP_TIMEOUT"))
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
 }

--- a/internal/agent/profile_step_timeout_test.go
+++ b/internal/agent/profile_step_timeout_test.go
@@ -12,8 +12,8 @@ import (
 //   - 设 env > 0 → override 生效,3 个 profile 都受影响
 //   - 设 env=0 或非法 → 保持 default(不 override)
 func TestGetProfile_StepTimeoutOverride(t *testing.T) {
-	// 2 个 profile 都要跑一次 · summary / summary_refine(仓库里只有这两个)
-	profileNames := []string{"summary", "summary_refine"}
+	// 所有 profile 都要覆盖，保证统一 override 语义不会漏掉 chat 场景。
+	profileNames := []string{"chat", "summary", "summary_refine"}
 
 	// case 1: 未设 env · 保持 240s 静态 default
 	t.Run("no_env_keeps_static_default", func(t *testing.T) {

--- a/internal/agent/profile_step_timeout_test.go
+++ b/internal/agent/profile_step_timeout_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGetProfile_StepTimeoutOverride 覆盖 AGENT_STEP_TIMEOUT env 覆盖 profile 静态
+// StepTimeout 的路径。修 refine 场景 60s 硬编码 stepCtx 挂 (agent chat runner
+// error: context deadline exceeded @ 83s) 的核心机制;要保证:
+//   - 未设 env → 保持 profile 静态 default(现在 240s · 之前 60s)
+//   - 设 env > 0 → override 生效,3 个 profile 都受影响
+//   - 设 env=0 或非法 → 保持 default(不 override)
+func TestGetProfile_StepTimeoutOverride(t *testing.T) {
+	// 2 个 profile 都要跑一次 · summary / summary_refine(仓库里只有这两个)
+	profileNames := []string{"summary", "summary_refine"}
+
+	// case 1: 未设 env · 保持 240s 静态 default
+	t.Run("no_env_keeps_static_default", func(t *testing.T) {
+		t.Setenv("AGENT_STEP_TIMEOUT", "")
+		for _, name := range profileNames {
+			p, err := GetProfile(name)
+			if err != nil {
+				t.Fatalf("GetProfile(%q): %v", name, err)
+			}
+			if p.Policy.StepTimeout != 240*time.Second {
+				t.Errorf("profile %q: unset env should keep static default 240s, got %v",
+					name, p.Policy.StepTimeout)
+			}
+		}
+	})
+
+	// case 2: env=120 · override 生效(选一个不同于 240 的值来区分 default vs override)
+	t.Run("env_120_overrides_all_profiles", func(t *testing.T) {
+		t.Setenv("AGENT_STEP_TIMEOUT", "120")
+		for _, name := range profileNames {
+			p, err := GetProfile(name)
+			if err != nil {
+				t.Fatalf("GetProfile(%q): %v", name, err)
+			}
+			if p.Policy.StepTimeout != 120*time.Second {
+				t.Errorf("profile %q: AGENT_STEP_TIMEOUT=120 should override to 120s, got %v",
+					name, p.Policy.StepTimeout)
+			}
+		}
+	})
+
+	// case 3: env=0 · 保持 default(0 视为"关闭 override")
+	t.Run("env_zero_keeps_static_default", func(t *testing.T) {
+		t.Setenv("AGENT_STEP_TIMEOUT", "0")
+		p, err := GetProfile("summary_refine")
+		if err != nil {
+			t.Fatalf("GetProfile: %v", err)
+		}
+		if p.Policy.StepTimeout != 240*time.Second {
+			t.Errorf("env=0 should keep default 240s, got %v", p.Policy.StepTimeout)
+		}
+	})
+
+	// case 4: env 非法(负值 / 非数字) · 保持 default
+	t.Run("env_invalid_keeps_static_default", func(t *testing.T) {
+		invalidVals := []string{"-1", "abc", "60s", "1.5"}
+		for _, v := range invalidVals {
+			t.Setenv("AGENT_STEP_TIMEOUT", v)
+			p, err := GetProfile("summary_refine")
+			if err != nil {
+				t.Fatalf("GetProfile: %v", err)
+			}
+			if p.Policy.StepTimeout != 240*time.Second {
+				t.Errorf("env=%q should keep default 240s, got %v", v, p.Policy.StepTimeout)
+			}
+		}
+	})
+}

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestGetProfile_SummaryRefine 验证 summary_refine profile 能正确装配
@@ -49,8 +50,8 @@ func TestGetProfile_SummaryRefine(t *testing.T) {
 	if profile.Policy.MaxTokens != 120000 {
 		t.Errorf("Policy.MaxTokens = %d, want 120000", profile.Policy.MaxTokens)
 	}
-	if profile.Policy.StepTimeout != 240e9 {
-		t.Errorf("Policy.StepTimeout = %d, want 240e9", profile.Policy.StepTimeout)
+	if profile.Policy.StepTimeout != 240*time.Second {
+		t.Errorf("Policy.StepTimeout = %v, want 240s", profile.Policy.StepTimeout)
 	}
 }
 

--- a/internal/agent/profile_test.go
+++ b/internal/agent/profile_test.go
@@ -49,8 +49,8 @@ func TestGetProfile_SummaryRefine(t *testing.T) {
 	if profile.Policy.MaxTokens != 120000 {
 		t.Errorf("Policy.MaxTokens = %d, want 120000", profile.Policy.MaxTokens)
 	}
-	if profile.Policy.StepTimeout != 60e9 {
-		t.Errorf("Policy.StepTimeout = %d, want 60e9", profile.Policy.StepTimeout)
+	if profile.Policy.StepTimeout != 240e9 {
+		t.Errorf("Policy.StepTimeout = %d, want 240e9", profile.Policy.StepTimeout)
 	}
 }
 

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent"
@@ -220,7 +221,7 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID)
 		if err != nil {
 			log.Printf("[agent] build runner for profile %q: %v", profileName, err)
-			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to initialize agent"})
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to initialize agent", Detail: safeErrorDetail(err)})
 			return
 		}
 	}
@@ -230,7 +231,7 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 	history, err := h.store.LoadHistory(ctx, req.SessionID, uid)
 	if err != nil {
 		log.Printf("[agent] load history error: %v", err)
-		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "agent chat failed"})
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "agent chat failed", Detail: safeErrorDetail(err)})
 		return
 	}
 
@@ -256,8 +257,11 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 	reply, newMsgs, err := runner.RunWithHistory(ctx, system, history, req.Message)
 	if err != nil {
 		// 真实错误只记服务端日志，避免向调用方泄漏上游 LLM 地址/网络/内部细节。
+		// Detail 走白名单：仅 context deadline / max steps / empty response 等
+		// 明确不含内部地址/IP/token 的 error 会被透传给客户端，其它一律为
+		// "internal error"（safeErrorDetail 保证），前端可据此区分超时 vs 未知错。
 		log.Printf("[agent] chat runner error: %v", err)
-		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "agent chat failed"})
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "agent chat failed", Detail: safeErrorDetail(err)})
 		return
 	}
 
@@ -311,7 +315,7 @@ func (h *AgentChatHandler) History(c *gin.Context) {
 	history, err := h.store.LoadHistory(ctx, sessionID, uid)
 	if err != nil {
 		log.Printf("[agent] load history error: %v", err)
-		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "agent chat history failed"})
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "agent chat history failed", Detail: safeErrorDetail(err)})
 		return
 	}
 
@@ -431,7 +435,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 		if err != nil {
 			log.Printf("[agent] build runner for profile %q: %v", profileName, err)
 			sink := &sseSink{w: c.Writer}
-			h.writeSSEErrorViaSink(sink, 50000, "failed to initialize agent")
+			h.writeSSEErrorViaSinkWithDetail(sink, 50000, "failed to initialize agent", safeErrorDetail(err))
 			return
 		}
 	}
@@ -457,7 +461,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 	history, err := h.store.LoadHistory(ctx, req.SessionID, uid)
 	if err != nil {
 		log.Printf("[agent] load history error: %v", err)
-		h.writeSSEErrorViaSink(sink, 50000, "agent chat failed")
+		h.writeSSEErrorViaSinkWithDetail(sink, 50000, "agent chat failed", safeErrorDetail(err))
 		return
 	}
 
@@ -481,7 +485,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 	reply, newMsgs, err := runner.RunWithHistory(ctx, system, history, req.Message)
 	if err != nil {
 		log.Printf("[agent] chat runner error: %v", err)
-		h.writeSSEErrorViaSink(sink, 50000, "agent chat failed")
+		h.writeSSEErrorViaSinkWithDetail(sink, 50000, "agent chat failed", safeErrorDetail(err))
 		return
 	}
 
@@ -536,9 +540,19 @@ func (h *AgentChatHandler) writeSSEDoneViaSink(sink *sseSink, reply, sessionID s
 
 // writeSSEErrorViaSink writes an error SSE event via the provided sink.
 func (h *AgentChatHandler) writeSSEErrorViaSink(sink *sseSink, code int, message string) {
+	h.writeSSEErrorViaSinkWithDetail(sink, code, message, "")
+}
+
+// writeSSEErrorViaSinkWithDetail is the detail-aware variant. Emits the
+// standard SSE error frame plus a safe-to-expose detail string when
+// non-empty. See safeErrorDetail below for the whitelist policy.
+func (h *AgentChatHandler) writeSSEErrorViaSinkWithDetail(sink *sseSink, code int, message string, detail string) {
 	data := map[string]interface{}{
 		"code":    code,
 		"message": message,
+	}
+	if detail != "" {
+		data["detail"] = detail
 	}
 	jsonData, err := json.Marshal(data)
 	if err != nil {
@@ -547,4 +561,42 @@ func (h *AgentChatHandler) writeSSEErrorViaSink(sink *sseSink, code int, message
 	}
 
 	sink.write("error", jsonData)
+}
+
+// safeErrorDetail returns a compact, safe-to-expose string derived from err
+// for inclusion in JSON/SSE error responses. Whitelist-only: we return the
+// raw err.Error() only for a small set of well-known agent runner failure
+// modes whose text is known not to embed URLs, IPs, tokens, or stack
+// fragments. Everything else collapses to "internal error", which lets the
+// client distinguish "your request timed out" (actionable) from "something
+// broke server-side" (open an issue / poll the ops channel) without
+// leaking backend geometry.
+//
+// Grow this whitelist deliberately: each new pattern must be traceable to
+// a specific errors.New / fmt.Errorf site in the runner or handler code
+// path whose format string contains no operator-supplied data.
+func safeErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "context deadline exceeded"):
+		// runner.go stepCtx timeout (single LLM planning call). Tune via
+		// AGENT_STEP_TIMEOUT env; see config.go / profile.go.
+		return "context deadline exceeded"
+	case strings.Contains(msg, "context canceled"):
+		// upstream cancellation (client disconnect or outer ctx timeout).
+		return "context canceled"
+	case strings.Contains(msg, "max steps exceeded"):
+		// runner.go MaxSteps loop guard. Model failed to converge.
+		return "max steps exceeded"
+	case strings.Contains(msg, "LLM returned empty response with no tool_calls"):
+		// runner.go final-step empty content guard (SUM-158 blocker follow-up).
+		return "LLM returned empty response with no tool_calls at final step"
+	case strings.Contains(msg, "unknown agent profile"):
+		// profile.go GetProfile lookup miss.
+		return "unknown agent profile"
+	}
+	return "internal error"
 }

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -5,6 +5,7 @@ import "sync"
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -500,8 +501,10 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 
 // writeSSEProgressViaSink writes a progress SSE event via the provided sink.
 // Contract (stable with frontend): only abstract, non-leaking fields are emitted —
-//   phase (safe enum: understand|retrieve|filter|distill|compose|reply),
-//   step / ofSteps / elapsed_ms, and an optional integer count (omitted when 0).
+//
+//	phase (safe enum: understand|retrieve|filter|distill|compose|reply),
+//	step / ofSteps / elapsed_ms, and an optional integer count (omitted when 0).
+//
 // It intentionally does NOT emit the raw tool name, an internal label, or free-text detail.
 func (h *AgentChatHandler) writeSSEProgressViaSink(sink *sseSink, phase string, step, ofSteps, count int, elapsedMs int64) {
 	data := map[string]interface{}{
@@ -579,22 +582,21 @@ func safeErrorDetail(err error) string {
 	if err == nil {
 		return ""
 	}
-	msg := err.Error()
 	switch {
-	case strings.Contains(msg, "context deadline exceeded"):
+	case errors.Is(err, context.DeadlineExceeded):
 		// runner.go stepCtx timeout (single LLM planning call). Tune via
-		// AGENT_STEP_TIMEOUT env; see config.go / profile.go.
+		// AGENT_STEP_TIMEOUT env; see profile.go / CONFIGURATION.md.
 		return "context deadline exceeded"
-	case strings.Contains(msg, "context canceled"):
+	case errors.Is(err, context.Canceled):
 		// upstream cancellation (client disconnect or outer ctx timeout).
 		return "context canceled"
-	case strings.Contains(msg, "max steps exceeded"):
+	case strings.Contains(err.Error(), "max steps exceeded"):
 		// runner.go MaxSteps loop guard. Model failed to converge.
 		return "max steps exceeded"
-	case strings.Contains(msg, "LLM returned empty response with no tool_calls"):
+	case strings.Contains(err.Error(), "LLM returned empty response with no tool_calls"):
 		// runner.go final-step empty content guard (SUM-158 blocker follow-up).
 		return "LLM returned empty response with no tool_calls at final step"
-	case strings.Contains(msg, "unknown agent profile"):
+	case strings.Contains(err.Error(), "unknown agent profile"):
 		// profile.go GetProfile lookup miss.
 		return "unknown agent profile"
 	}

--- a/internal/api/handler/agent_chat_detail_test.go
+++ b/internal/api/handler/agent_chat_detail_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestSafeErrorDetail 覆盖 500 response Detail 字段的白名单规则(#agent_chat.go
+// safeErrorDetail)。白名单存在的意义:让客户端 F12 能区分"我请求超时"和"服务端崩了"
+// 两种子情况,同时严格不透传含 URL/IP/token 的 error 到客户端。
+func TestSafeErrorDetail(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil returns empty", nil, ""},
+		{
+			"context deadline exceeded is whitelisted",
+			context.DeadlineExceeded,
+			"context deadline exceeded",
+		},
+		{
+			"wrapped context deadline exceeded is whitelisted",
+			errors.New("runner step: context deadline exceeded"),
+			"context deadline exceeded",
+		},
+		{
+			"context canceled is whitelisted",
+			context.Canceled,
+			"context canceled",
+		},
+		{
+			"max steps exceeded is whitelisted",
+			errors.New("max steps exceeded"),
+			"max steps exceeded",
+		},
+		{
+			"empty response guard is whitelisted",
+			errors.New("LLM returned empty response with no tool_calls at final step"),
+			"LLM returned empty response with no tool_calls at final step",
+		},
+		{
+			"unknown profile is whitelisted",
+			errors.New(`unknown agent profile "summary_x"`),
+			"unknown agent profile",
+		},
+		{
+			// SECURITY: error containing internal URL must NOT leak.
+			"internal LLM gateway URL is redacted",
+			errors.New("POST https://llm-gateway.internal.mlamp.cn/v1/chat/completions returned 500"),
+			"internal error",
+		},
+		{
+			// SECURITY: error containing IP must NOT leak.
+			"internal IP is redacted",
+			errors.New("dial tcp 10.0.0.42:8080: connection refused"),
+			"internal error",
+		},
+		{
+			// SECURITY: DB path fragments must NOT leak.
+			"db error message is redacted",
+			errors.New("gorm: record not found in summary_task where id=999"),
+			"internal error",
+		},
+		{
+			"unknown error collapses to internal error",
+			errors.New("something weird happened"),
+			"internal error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := safeErrorDetail(tc.err)
+			if got != tc.want {
+				t.Errorf("safeErrorDetail(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/handler/agent_chat_detail_test.go
+++ b/internal/api/handler/agent_chat_detail_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -23,7 +24,7 @@ func TestSafeErrorDetail(t *testing.T) {
 		},
 		{
 			"wrapped context deadline exceeded is whitelisted",
-			errors.New("runner step: context deadline exceeded"),
+			fmt.Errorf("runner step: %w", context.DeadlineExceeded),
 			"context deadline exceeded",
 		},
 		{

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -216,6 +216,15 @@ func callerPlainCitationsVisible(db *gorm.DB, task *model.SummaryTask, callerID 
 type apiResponse struct {
 	Code    int         `json:"code"`
 	Message string      `json:"message"`
+	// Detail carries a compact, safe-to-expose error signature so clients
+	// (F12 devtools, ops) can distinguish sub-causes of a generic Message
+	// without pulling backend logs. Populated only on error responses;
+	// omitted (via omitempty) on success. Caller must ensure the value
+	// is safe to send to end users — do NOT put raw sensitive info here
+	// (DB paths, tokens, stack fragments). Passthrough of err.Error() from
+	// well-known agent runner failures (context deadline exceeded, max
+	// steps exceeded, LLM returned empty response) is safe by construction.
+	Detail  string      `json:"detail,omitempty"`
 	Data    interface{} `json:"data,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,17 @@ type Config struct {
 	LLMTemperature    float64
 	LLMEnableThinking bool
 
+	// AgentStepTimeout bounds a single LLM planning call inside the agent runner
+	// (see agent/runner.go stepCtx). Distinct from LLMTimeout, which is the
+	// http-layer per-request timeout used by LLM-backed tools such as
+	// summarize_chunk / merge_summaries. Refine flows inject ~21K tokens of
+	// referenced summary content per turn (see profile.go summary_refine
+	// comment) — the accumulated context can push single-turn planning
+	// duration past 60s on slower models (kimi / sonnet with large context).
+	// Default 240s covers observed p99 while the outer 300s ChatStream ctx
+	// backstop (agent_chat.go:406) remains the wall-clock ceiling.
+	AgentStepTimeout int
+
 	// API
 	APIPort         string
 	APIInternalPort string
@@ -154,6 +165,7 @@ func Load() *Config {
 		LLMMaxToken:       envInt("LLM_MAX_TOKENS", 4096),
 		LLMTemperature:    getEnvFloat("LLM_TEMPERATURE", 0.3),
 		LLMEnableThinking: envBool("LLM_ENABLE_THINKING", false),
+		AgentStepTimeout:  envInt("AGENT_STEP_TIMEOUT", 240),
 
 		APIPort:         envStr("API_PORT", "8080"),
 		APIInternalPort: envStr("API_INTERNAL_PORT", "8081"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,17 +38,6 @@ type Config struct {
 	LLMTemperature    float64
 	LLMEnableThinking bool
 
-	// AgentStepTimeout bounds a single LLM planning call inside the agent runner
-	// (see agent/runner.go stepCtx). Distinct from LLMTimeout, which is the
-	// http-layer per-request timeout used by LLM-backed tools such as
-	// summarize_chunk / merge_summaries. Refine flows inject ~21K tokens of
-	// referenced summary content per turn (see profile.go summary_refine
-	// comment) — the accumulated context can push single-turn planning
-	// duration past 60s on slower models (kimi / sonnet with large context).
-	// Default 240s covers observed p99 while the outer 300s ChatStream ctx
-	// backstop (agent_chat.go:406) remains the wall-clock ceiling.
-	AgentStepTimeout int
-
 	// API
 	APIPort         string
 	APIInternalPort string
@@ -165,10 +154,8 @@ func Load() *Config {
 		LLMMaxToken:       envInt("LLM_MAX_TOKENS", 4096),
 		LLMTemperature:    getEnvFloat("LLM_TEMPERATURE", 0.3),
 		LLMEnableThinking: envBool("LLM_ENABLE_THINKING", false),
-		AgentStepTimeout:  envInt("AGENT_STEP_TIMEOUT", 240),
-
-		APIPort:         envStr("API_PORT", "8080"),
-		APIInternalPort: envStr("API_INTERNAL_PORT", "8081"),
+		APIPort:           envStr("API_PORT", "8080"),
+		APIInternalPort:   envStr("API_INTERNAL_PORT", "8081"),
 
 		WorkerInternalPort:        envStr("WORKER_INTERNAL_PORT", "8082"),
 		WorkerListenAllInterfaces: envStr("WORKER_LISTEN_ADDR", "0.0.0.0"),


### PR DESCRIPTION
## Summary

Two related fixes to make agent chat resilient and observable under
realistic refine load — both traced back from a reproducible production
500 in `im.deepminer.com.cn` on `claude-sonnet-4-6` at ~83s:

```
[agent] chat runner error: context deadline exceeded
[GIN] | 500 | 1m23s | POST "/api/v1/agent/chat"
```

**c1 · env-configurable AgentStepTimeout** — `Policy.StepTimeout` was
hard-coded to 60s in every profile. Refine flows inject ~21K tokens of
referenced summary content per turn (see `profile.go` `summary_refine`
comment), and a single LLM planning call on sonnet/kimi with that much
context reproducibly needs 60-100s+ to complete. The 60s stepCtx
tripped before the LLM finished streaming, `runner.RunWithHistory`
returned err, and the request 500'd. Introduce `AGENT_STEP_TIMEOUT`
env (default 240s in `config.go`) that overrides the profile's static
StepTimeout at `GetProfile` lookup time; both existing profiles
(`summary`, `summary_refine`) benefit uniformly and any future profile
inherits automatically. Setting to 0 or leaving unset keeps the
60s code default (useful for tests / fast-fail dev). See commit
`b01c4a3`.

**c2 · whitelisted `detail` on 500 responses** — Users hitting a 500
currently see only `{"code":50000,"message":"agent chat failed"}` in
F12 and must ping ops for the backend log line to distinguish "my
request timed out" (actionable — smaller channel, shorter window)
from "something broke server-side" (open an issue). Add a `Detail`
field on `apiResponse` (`omitempty`; success responses unchanged) and
populate on all 5 500 sites in `agent_chat.go`. Value goes through
`safeErrorDetail()`, a whitelist of five well-known runner failure
modes whose text is known to contain no URLs / IPs / tokens / stack
fragments (`context deadline exceeded`, `context canceled`,
`max steps exceeded`, `LLM returned empty response ... at final step`,
`unknown agent profile`); everything else collapses to `internal error`.
See commit `66b7ae6`.

## Linked Spec

No standalone brief. Both fixes trace to the reproducer above and to
the constraint already documented in the original 500-site comment
(`agent_chat.go`: "真实错误只记服务端日志,避免向调用方泄漏上游 LLM
地址/网络/内部细节"). c2's whitelist honors that intent while giving
clients enough signal to react.

## How verified

Local octo-alex compose stack + `im-test.deepminer.com.cn`:

- **c1 reproducer**: seeded 2000 msgs into a group, ran refine on
  claude-sonnet-4-6 with `AGENT_STEP_TIMEOUT=300`. Same scenario
  that failed at 83s on unmodified `main` now completes in ~100s.
  Reverted the env → back to 60s → failure reproduces at ~80s.
- **c2 sanity**: temporarily set `AGENT_STEP_TIMEOUT=5` to force
  `context deadline exceeded`; F12 shows
  `{"code":50000,"message":"agent chat failed","detail":"context deadline exceeded"}`
  instead of the opaque original.

Automated:

- `TestGetProfile_StepTimeoutOverride` (new) — 4 sub-cases across
  both profiles: unset env / 240 / 0 / invalid; all pass.
- `TestSafeErrorDetail` (new) — 11 sub-cases: nil / 5 whitelisted
  patterns (including wrapped `context.DeadlineExceeded` via
  `errors.New`) / 3 redaction cases (LLM gateway URL, internal IP,
  DB error) / generic-unknown fallback. All pass.
- Full pkg CGO=1 test:
  - `internal/agent` — 0.278s pass
  - `internal/api/handler` — 11.367s pass
  - `internal/config` — 0.002s pass
- `go vet ./internal/...` — clean.

## COMPREHENSION

1. **What this change actually does**: gives ops a knob
   (`AGENT_STEP_TIMEOUT`) to prevent single-turn LLM planning from
   tripping stepCtx on slow models with large context, and gives
   clients enough detail on 500s to self-triage without pulling
   backend logs.
2. **What could break**: the override can be set too small — but
   set-to-0 or unset preserves original 60s behavior, so rollback
   is a config change with no code redeploy. Detail field is
   `omitempty` on the JSON side, so old clients that don't know
   about it just ignore it; the SSE side changes the sink signature
   but the two-arg helper is preserved as a wrapper for the
   missing-auth 40100 case that has no err in scope.
3. **How you know it works**: reproducer failure at 83s ↔ success
   at ~100s with env=300 is a clean before/after on the exact
   production scenario. Detail whitelist is unit-tested for both
   pass-through (5 patterns) and redaction (3 sensitive shapes).
   Reverse-verified once by removing the c1 code change locally —
   test fails; restoring — passes.
