### PR TITLE
feat: add summary share snapshots and scoped grants

### DIFF
--- a/internal/api/handler/share.go
+++ b/internal/api/handler/share.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"sort"
 	"strconv"
@@ -108,9 +109,12 @@ func (h *ShareHandler) canUseTarget(spaceID, uid string, target shareTarget) boo
 	}
 	switch target.ChannelType {
 	case model.ChannelTypeGroup:
+		if !h.activeSpaceMember(spaceID, uid) {
+			return false
+		}
 		var count int64
 		err := h.imDB.Raw(
-			"SELECT COUNT(*) FROM `group` g INNER JOIN space s ON s.space_id = g.space_id AND s.status = 1 INNER JOIN group_member gm ON gm.group_no = g.group_no WHERE g.group_no = ? AND g.space_id = ? AND g.status = 1 AND gm.uid = ? AND gm.is_deleted = 0",
+			"SELECT COUNT(*) FROM `group` g INNER JOIN space s ON s.space_id = g.space_id AND s.status = 1 INNER JOIN group_member gm ON gm.group_no = g.group_no WHERE g.group_no = ? AND g.space_id = ? AND g.status = 1 AND gm.uid = ? AND gm.status = 1 AND gm.is_deleted = 0",
 			target.ChannelID, spaceID, uid,
 		).Scan(&count).Error
 		return err == nil && count > 0
@@ -211,6 +215,59 @@ func (h *ShareHandler) response(snapshot model.SummaryShareSnapshot, grants []mo
 	return gin.H{"snapshot": snapshot, "grants": items}
 }
 
+func isShareDuplicateKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "duplicate entry") ||
+		strings.Contains(message, "error 1062") ||
+		strings.Contains(message, "unique constraint failed") ||
+		strings.Contains(message, "constraint failed: unique")
+}
+
+func (h *ShareHandler) existingShare(spaceID, userID, idempotencyKey, hash string) (model.SummaryShareSnapshot, []model.SummaryShareGrant, bool, bool, error) {
+	var snapshot model.SummaryShareSnapshot
+	err := h.db.Where(
+		"space_id = ? AND creator_id = ? AND idempotency_key = ?",
+		spaceID, userID, idempotencyKey,
+	).First(&snapshot).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return snapshot, nil, false, false, nil
+	}
+	if err != nil {
+		return snapshot, nil, false, false, err
+	}
+	if snapshot.RequestHash != hash {
+		return snapshot, nil, true, true, nil
+	}
+	var grants []model.SummaryShareGrant
+	if err := h.db.Where("snapshot_id = ? AND status = ?", snapshot.ID, model.ShareGrantActive).Find(&grants).Error; err != nil {
+		return snapshot, nil, true, false, err
+	}
+	return snapshot, grants, true, false, nil
+}
+
+func (h *ShareHandler) respondWithExistingShare(c *gin.Context, spaceID, userID, idempotencyKey, hash string) bool {
+	snapshot, grants, found, conflict, err := h.existingShare(spaceID, userID, idempotencyKey, hash)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "读取分享请求失败"})
+		return true
+	}
+	if conflict {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "幂等键已用于其他分享请求"})
+		return true
+	}
+	if found {
+		ok(c, h.response(snapshot, grants))
+		return true
+	}
+	return false
+}
+
 func (h *ShareHandler) Create(c *gin.Context) {
 	spaceID, userID := middleware.GetSpaceID(c), middleware.GetUserID(c)
 	var req createSharesRequest
@@ -243,15 +300,7 @@ func (h *ShareHandler) Create(c *gin.Context) {
 		}
 	}
 	hash := requestHash(task.ID, targets)
-	var existing model.SummaryShareSnapshot
-	if err := h.db.Where("space_id = ? AND creator_id = ? AND idempotency_key = ?", spaceID, userID, req.IdempotencyKey).First(&existing).Error; err == nil {
-		if existing.RequestHash != hash {
-			c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "幂等键已用于其他分享请求"})
-			return
-		}
-		var grants []model.SummaryShareGrant
-		h.db.Where("snapshot_id = ? AND status = ?", existing.ID, model.ShareGrantActive).Find(&grants)
-		ok(c, h.response(existing, grants))
+	if h.respondWithExistingShare(c, spaceID, userID, req.IdempotencyKey, hash) {
 		return
 	}
 
@@ -266,7 +315,10 @@ func (h *ShareHandler) Create(c *gin.Context) {
 		return
 	}
 	var sources []model.SummarySource
-	h.db.Where("task_id = ?", task.ID).Find(&sources)
+	if err := h.db.Where("task_id = ?", task.ID).Find(&sources).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "读取总结来源失败"})
+		return
+	}
 	names := make([]string, 0, len(sources))
 	for _, source := range sources {
 		if strings.TrimSpace(source.SourceName) != "" {
@@ -274,7 +326,10 @@ func (h *ShareHandler) Create(c *gin.Context) {
 		}
 	}
 	var participantCount int64
-	h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND status <> ?", task.ID, model.ParticipantDeclined).Count(&participantCount)
+	if err := h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND status <> ?", task.ID, model.ParticipantDeclined).Count(&participantCount).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "读取总结参与者失败"})
+		return
+	}
 	now := time.Now()
 	snapshot := model.SummaryShareSnapshot{
 		TaskID: task.ID, TaskNo: task.TaskNo, SpaceID: spaceID, CreatorID: userID,
@@ -303,6 +358,9 @@ func (h *ShareHandler) Create(c *gin.Context) {
 		return nil
 	})
 	if err != nil {
+		if isShareDuplicateKey(err) && h.respondWithExistingShare(c, spaceID, userID, req.IdempotencyKey, hash) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "创建分享失败"})
 		return
 	}
@@ -361,6 +419,10 @@ func (h *ShareHandler) Revoke(c *gin.Context) {
 		return
 	}
 	now := time.Now()
-	h.db.Model(&grant).Updates(map[string]any{"status": model.ShareGrantRevoked, "revoked_at": now, "updated_at": now})
+	result := h.db.Model(&grant).Updates(map[string]any{"status": model.ShareGrantRevoked, "revoked_at": now, "updated_at": now})
+	if result.Error != nil || result.RowsAffected != 1 {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "撤销分享失败"})
+		return
+	}
 	ok(c, gin.H{"share_id": grant.ShareID, "revoked": true})
 }

--- a/internal/api/handler/share.go
+++ b/internal/api/handler/share.go
@@ -1,0 +1,366 @@
+package handler
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+const (
+	maxShareTargets = 30
+	maxPreviewRunes = 220
+)
+
+type ShareHandler struct {
+	db   *gorm.DB
+	imDB *gorm.DB
+}
+
+func NewShareHandler(db, imDB *gorm.DB) *ShareHandler { return &ShareHandler{db: db, imDB: imDB} }
+
+type shareTarget struct {
+	ChannelID   string `json:"channel_id"`
+	ChannelType int    `json:"channel_type"`
+}
+
+type createSharesRequest struct {
+	IdempotencyKey string        `json:"idempotency_key"`
+	Targets        []shareTarget `json:"targets"`
+}
+
+func (h *ShareHandler) resolveTask(param, spaceID string) (model.SummaryTask, error) {
+	var task model.SummaryTask
+	q := h.db.Where("space_id = ? AND deleted_at IS NULL", spaceID)
+	if id, err := strconv.ParseInt(param, 10, 64); err == nil {
+		return task, q.Where("id = ?", id).First(&task).Error
+	}
+	return task, q.Where("task_no = ?", param).First(&task).Error
+}
+
+func normalizeTargets(targets []shareTarget) ([]shareTarget, bool) {
+	seen := make(map[string]struct{}, len(targets))
+	out := make([]shareTarget, 0, len(targets))
+	for _, target := range targets {
+		target.ChannelID = strings.TrimSpace(target.ChannelID)
+		if target.ChannelID == "" || (target.ChannelType != model.ChannelTypeDM && target.ChannelType != model.ChannelTypeGroup) {
+			return nil, false
+		}
+		key := strconv.Itoa(target.ChannelType) + ":" + target.ChannelID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, target)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ChannelType != out[j].ChannelType {
+			return out[i].ChannelType < out[j].ChannelType
+		}
+		return out[i].ChannelID < out[j].ChannelID
+	})
+	return out, len(out) > 0 && len(out) <= maxShareTargets
+}
+
+func requestHash(taskID int64, targets []shareTarget) string {
+	b, _ := json.Marshal(struct {
+		TaskID  int64         `json:"task_id"`
+		Targets []shareTarget `json:"targets"`
+	}{taskID, targets})
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func newShareID() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func (h *ShareHandler) activeSpaceMember(spaceID, uid string) bool {
+	if h.imDB == nil || spaceID == "" || uid == "" {
+		return false
+	}
+	var count int64
+	err := h.imDB.Raw(
+		"SELECT COUNT(*) FROM space_member sm INNER JOIN space s ON s.space_id = sm.space_id AND s.status = 1 WHERE sm.space_id = ? AND sm.uid = ? AND sm.status = 1",
+		spaceID, uid,
+	).Scan(&count).Error
+	return err == nil && count > 0
+}
+
+func (h *ShareHandler) canUseTarget(spaceID, uid string, target shareTarget) bool {
+	if h.imDB == nil {
+		return false
+	}
+	switch target.ChannelType {
+	case model.ChannelTypeGroup:
+		var count int64
+		err := h.imDB.Raw(
+			"SELECT COUNT(*) FROM `group` g INNER JOIN space s ON s.space_id = g.space_id AND s.status = 1 INNER JOIN group_member gm ON gm.group_no = g.group_no WHERE g.group_no = ? AND g.space_id = ? AND g.status = 1 AND gm.uid = ? AND gm.is_deleted = 0",
+			target.ChannelID, spaceID, uid,
+		).Scan(&count).Error
+		return err == nil && count > 0
+	case model.ChannelTypeDM:
+		return target.ChannelID != uid && h.activeSpaceMember(spaceID, uid) && h.activeSpaceMember(spaceID, target.ChannelID)
+	default:
+		return false
+	}
+}
+
+func stripCitationTokens(content string, plain []model.Citation, team []model.TeamCitation) string {
+	plainSet := make(map[int]struct{}, len(plain))
+	teamSet := make(map[int]struct{}, len(team))
+	for _, c := range plain {
+		plainSet[c.Index] = struct{}{}
+	}
+	for _, c := range team {
+		teamSet[c.Index] = struct{}{}
+	}
+
+	var b strings.Builder
+	for i := 0; i < len(content); {
+		if content[i] != '[' {
+			b.WriteByte(content[i])
+			i++
+			continue
+		}
+		end := strings.IndexByte(content[i:], ']')
+		if end < 0 {
+			b.WriteString(content[i:])
+			break
+		}
+		end += i
+		token := content[i+1 : end]
+		isTeam := strings.HasPrefix(token, "P")
+		number := token
+		if isTeam {
+			number = strings.TrimPrefix(token, "P")
+		}
+		idx, err := strconv.Atoi(number)
+		_, knownPlain := plainSet[idx]
+		_, knownTeam := teamSet[idx]
+		// A numeric markdown link such as [1](url) is content, not a citation.
+		isLink := end+1 < len(content) && content[end+1] == '('
+		if err == nil && !isLink && ((!isTeam && knownPlain) || (isTeam && knownTeam)) {
+			i = end + 1
+			continue
+		}
+		b.WriteString(content[i : end+1])
+		i = end + 1
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func sharePreview(content string) string {
+	lines := strings.Split(content, "\n")
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		line = strings.TrimLeft(line, "#>*-+0123456789. ")
+		if line == "" || strings.HasPrefix(line, "|") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		parts = append(parts, line)
+	}
+	text := strings.Join(parts, " ")
+	runes := []rune(text)
+	if len(runes) > maxPreviewRunes {
+		text = string(runes[:maxPreviewRunes]) + "…"
+	}
+	return text
+}
+
+type shareMaterial struct {
+	content        string
+	plainCitations []model.Citation
+	teamCitations  []model.TeamCitation
+	messageCount   int
+	version        int
+}
+
+func (h *ShareHandler) materialFor(task model.SummaryTask, userID string) (shareMaterial, bool) {
+	if result, ok := (&TaskHandler{db: h.db}).pickDisplayResult(task.ID); ok && strings.TrimSpace(result.Content) != "" {
+		return shareMaterial{result.Content, result.GetCitations(), result.GetTeamCitations(), result.TotalMsgCount, result.Version}, true
+	}
+	var personal model.PersonalResult
+	if err := h.db.Where("task_id = ? AND user_id = ?", task.ID, userID).First(&personal).Error; err != nil || strings.TrimSpace(personal.Content) == "" {
+		return shareMaterial{}, false
+	}
+	return shareMaterial{personal.Content, personal.GetCitations(), nil, personal.MsgCount, 1}, true
+}
+
+func (h *ShareHandler) response(snapshot model.SummaryShareSnapshot, grants []model.SummaryShareGrant) gin.H {
+	items := make([]gin.H, 0, len(grants))
+	for _, grant := range grants {
+		items = append(items, gin.H{"share_id": grant.ShareID, "channel_id": grant.ChannelID, "channel_type": grant.ChannelType})
+	}
+	return gin.H{"snapshot": snapshot, "grants": items}
+}
+
+func (h *ShareHandler) Create(c *gin.Context) {
+	spaceID, userID := middleware.GetSpaceID(c), middleware.GetUserID(c)
+	var req createSharesRequest
+	if err := c.ShouldBindJSON(&req); err != nil || len(req.IdempotencyKey) < 8 || len(req.IdempotencyKey) > 64 {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid share request"})
+		return
+	}
+	targets, targetsValid := normalizeTargets(req.Targets)
+	if !targetsValid {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "invalid share targets"})
+		return
+	}
+	task, err := h.resolveTask(c.Param("id"), spaceID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	if !canAccessTaskDB(h.db, userID, task.ID, task.CreatorID) {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权分享此任务"})
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "总结尚未完成"})
+		return
+	}
+	for _, target := range targets {
+		if !h.canUseTarget(spaceID, userID, target) {
+			c.JSON(http.StatusForbidden, apiResponse{Code: 40003, Message: "无权分享到目标会话"})
+			return
+		}
+	}
+	hash := requestHash(task.ID, targets)
+	var existing model.SummaryShareSnapshot
+	if err := h.db.Where("space_id = ? AND creator_id = ? AND idempotency_key = ?", spaceID, userID, req.IdempotencyKey).First(&existing).Error; err == nil {
+		if existing.RequestHash != hash {
+			c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "幂等键已用于其他分享请求"})
+			return
+		}
+		var grants []model.SummaryShareGrant
+		h.db.Where("snapshot_id = ? AND status = ?", existing.ID, model.ShareGrantActive).Find(&grants)
+		ok(c, h.response(existing, grants))
+		return
+	}
+
+	material, found := h.materialFor(task, userID)
+	if !found {
+		c.JSON(http.StatusUnprocessableEntity, apiResponse{Code: 40010, Message: "没有可分享的总结内容"})
+		return
+	}
+	content := stripCitationTokens(material.content, material.plainCitations, material.teamCitations)
+	if !utf8.ValidString(content) || content == "" {
+		c.JSON(http.StatusUnprocessableEntity, apiResponse{Code: 40010, Message: "没有可分享的总结内容"})
+		return
+	}
+	var sources []model.SummarySource
+	h.db.Where("task_id = ?", task.ID).Find(&sources)
+	names := make([]string, 0, len(sources))
+	for _, source := range sources {
+		if strings.TrimSpace(source.SourceName) != "" {
+			names = append(names, source.SourceName)
+		}
+	}
+	var participantCount int64
+	h.db.Model(&model.SummaryParticipant{}).Where("task_id = ? AND status <> ?", task.ID, model.ParticipantDeclined).Count(&participantCount)
+	now := time.Now()
+	snapshot := model.SummaryShareSnapshot{
+		TaskID: task.ID, TaskNo: task.TaskNo, SpaceID: spaceID, CreatorID: userID,
+		IdempotencyKey: req.IdempotencyKey, RequestHash: hash, Title: task.Title,
+		SourceName: strings.Join(names, "、"), SourceCount: len(sources), ParticipantCount: int(participantCount),
+		MessageCount: material.messageCount, TimeRangeStart: task.TimeRangeStart, TimeRangeEnd: task.TimeRangeEnd,
+		SummaryMode: task.SummaryMode, ResultVersion: material.version, Preview: sharePreview(content), Content: content,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	grants := make([]model.SummaryShareGrant, 0, len(targets))
+	err = h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&snapshot).Error; err != nil {
+			return err
+		}
+		for _, target := range targets {
+			shareID, err := newShareID()
+			if err != nil {
+				return err
+			}
+			grant := model.SummaryShareGrant{SnapshotID: snapshot.ID, ShareID: shareID, ChannelID: target.ChannelID, ChannelType: target.ChannelType, Status: model.ShareGrantActive, CreatedAt: now, UpdatedAt: now}
+			if err := tx.Create(&grant).Error; err != nil {
+				return err
+			}
+			grants = append(grants, grant)
+		}
+		return nil
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "创建分享失败"})
+		return
+	}
+	ok(c, h.response(snapshot, grants))
+}
+
+func (h *ShareHandler) canReadGrant(spaceID, userID string, snapshot model.SummaryShareSnapshot, grant model.SummaryShareGrant) bool {
+	if snapshot.SpaceID != spaceID || grant.Status != model.ShareGrantActive {
+		return false
+	}
+	if grant.ChannelType == model.ChannelTypeDM {
+		if userID != snapshot.CreatorID && userID != grant.ChannelID {
+			return false
+		}
+		return h.activeSpaceMember(spaceID, snapshot.CreatorID) && h.activeSpaceMember(spaceID, grant.ChannelID)
+	}
+	return h.canUseTarget(spaceID, userID, shareTarget{ChannelID: grant.ChannelID, ChannelType: grant.ChannelType})
+}
+
+func (h *ShareHandler) sourceAccessible(spaceID, userID string, snapshot model.SummaryShareSnapshot) bool {
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", snapshot.TaskID, spaceID).First(&task).Error; err != nil {
+		return false
+	}
+	return canAccessTaskDB(h.db, userID, task.ID, task.CreatorID)
+}
+
+func (h *ShareHandler) Get(c *gin.Context) {
+	var grant model.SummaryShareGrant
+	if err := h.db.Where("share_id = ?", c.Param("share_id")).First(&grant).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "分享不存在或已失效"})
+		return
+	}
+	var snapshot model.SummaryShareSnapshot
+	if err := h.db.First(&snapshot, grant.SnapshotID).Error; err != nil || !h.canReadGrant(middleware.GetSpaceID(c), middleware.GetUserID(c), snapshot, grant) {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "分享不存在或已失效"})
+		return
+	}
+	spaceID, userID := middleware.GetSpaceID(c), middleware.GetUserID(c)
+	ok(c, gin.H{
+		"share_id":          grant.ShareID,
+		"source_accessible": h.sourceAccessible(spaceID, userID, snapshot),
+		"snapshot":          snapshot,
+	})
+}
+
+func (h *ShareHandler) Revoke(c *gin.Context) {
+	var grant model.SummaryShareGrant
+	if err := h.db.Where("share_id = ?", c.Param("share_id")).First(&grant).Error; err != nil {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "分享不存在"})
+		return
+	}
+	var snapshot model.SummaryShareSnapshot
+	if err := h.db.First(&snapshot, grant.SnapshotID).Error; err != nil || snapshot.SpaceID != middleware.GetSpaceID(c) || snapshot.CreatorID != middleware.GetUserID(c) {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "分享不存在"})
+		return
+	}
+	now := time.Now()
+	h.db.Model(&grant).Updates(map[string]any{"status": model.ShareGrantRevoked, "revoked_at": now, "updated_at": now})
+	ok(c, gin.H{"share_id": grant.ShareID, "revoked": true})
+}

--- a/internal/api/handler/share_test.go
+++ b/internal/api/handler/share_test.go
@@ -5,8 +5,11 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,7 +22,7 @@ import (
 
 func setupShareTest(t *testing.T) (*gorm.DB, *gorm.DB, *gin.Engine, int64) {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "summary.db")+"?_busy_timeout=5000&_journal_mode=WAL"), &gorm.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,18 +33,18 @@ func setupShareTest(t *testing.T) (*gorm.DB, *gorm.DB, *gin.Engine, int64) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	imDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	imDB, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "im.db")+"?_busy_timeout=5000&_journal_mode=WAL"), &gorm.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	imDB.Exec(`CREATE TABLE space (space_id TEXT, status INTEGER)`)
 	imDB.Exec(`CREATE TABLE space_member (space_id TEXT, uid TEXT, status INTEGER)`)
 	imDB.Exec(`CREATE TABLE "group" (group_no TEXT, space_id TEXT, status INTEGER)`)
-	imDB.Exec(`CREATE TABLE group_member (group_no TEXT, uid TEXT, is_deleted INTEGER)`)
+	imDB.Exec(`CREATE TABLE group_member (group_no TEXT, uid TEXT, status INTEGER, is_deleted INTEGER)`)
 	imDB.Exec(`INSERT INTO space VALUES ('space1',1),('space2',1)`)
 	imDB.Exec(`INSERT INTO space_member VALUES ('space1','creator',1),('space1','reader',1),('space1','outsider',1),('space1','peer',1)`)
 	imDB.Exec(`INSERT INTO "group" VALUES ('group1','space1',1)`)
-	imDB.Exec(`INSERT INTO group_member VALUES ('group1','creator',0),('group1','reader',0)`)
+	imDB.Exec(`INSERT INTO group_member VALUES ('group1','creator',1,0),('group1','reader',1,0)`)
 
 	now := time.Now()
 	task := model.SummaryTask{TaskNo: "ST-share-1", SpaceID: "space1", CreatorID: "creator", Title: "Weekly review", SummaryMode: 1, Status: model.StatusCompleted, TimeRangeStart: now.Add(-24 * time.Hour), TimeRangeEnd: now, CreatedAt: now, UpdatedAt: now}
@@ -123,6 +126,11 @@ func TestSummaryShare_GroupGrantAndIdempotency(t *testing.T) {
 	if got := decodeShareID(t, w); got != shareID {
 		t.Fatalf("idempotency changed share id: %s != %s", got, shareID)
 	}
+	conflictBody := gin.H{"idempotency_key": "share-request-1", "targets": []gin.H{{"channel_id": "peer", "channel_type": model.ChannelTypeDM}}}
+	w = shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-1/shares", "creator", "space1", conflictBody)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("idempotency hash mismatch=%d %s", w.Code, w.Body.String())
+	}
 	var snapshots, grants int64
 	db.Model(&model.SummaryShareSnapshot{}).Count(&snapshots)
 	db.Model(&model.SummaryShareGrant{}).Count(&grants)
@@ -169,6 +177,18 @@ func TestSummaryShare_GroupGrantAndIdempotency(t *testing.T) {
 		t.Fatalf("departed reader=%d %s", w.Code, w.Body.String())
 	}
 	imDB.Exec(`UPDATE group_member SET is_deleted=0 WHERE group_no='group1' AND uid='reader'`)
+	imDB.Exec(`UPDATE space_member SET status=0 WHERE space_id='space1' AND uid='reader'`)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("removed space member=%d %s", w.Code, w.Body.String())
+	}
+	imDB.Exec(`UPDATE space_member SET status=1 WHERE space_id='space1' AND uid='reader'`)
+	imDB.Exec(`UPDATE group_member SET status=0 WHERE group_no='group1' AND uid='reader'`)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("inactive group member=%d %s", w.Code, w.Body.String())
+	}
+	imDB.Exec(`UPDATE group_member SET status=1 WHERE group_no='group1' AND uid='reader'`)
 	imDB.Exec(`UPDATE space SET status=0 WHERE space_id='space1'`)
 	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
 	if w.Code != http.StatusNotFound {
@@ -203,5 +223,95 @@ func TestSummaryShare_DirectAndCrossSpace(t *testing.T) {
 	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "peer", "space1", nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("revoked grant=%d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSummaryShare_IdempotencyRecoversWhenConcurrentInsertWins(t *testing.T) {
+	db, _, r, _ := setupShareTest(t)
+	body := gin.H{"idempotency_key": "share-race-winner", "targets": []gin.H{{"channel_id": "group1", "channel_type": model.ChannelTypeGroup}}}
+
+	var once sync.Once
+	err := db.Callback().Create().Before("gorm:create").Register("share_test:concurrent_winner", func(tx *gorm.DB) {
+		snapshot, ok := tx.Statement.Dest.(*model.SummaryShareSnapshot)
+		if !ok {
+			return
+		}
+		once.Do(func() {
+			sqlDB, sqlErr := db.DB()
+			if sqlErr != nil {
+				tx.AddError(sqlErr)
+				return
+			}
+			result, insertErr := sqlDB.Exec(`INSERT INTO summary_share_snapshot
+				(task_id, task_no, space_id, creator_id, idempotency_key, request_hash, title, source_name, source_count, participant_count, message_count, time_range_start, time_range_end, summary_mode, result_version, preview, content, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				snapshot.TaskID, snapshot.TaskNo, snapshot.SpaceID, snapshot.CreatorID, snapshot.IdempotencyKey, snapshot.RequestHash,
+				snapshot.Title, snapshot.SourceName, snapshot.SourceCount, snapshot.ParticipantCount, snapshot.MessageCount,
+				snapshot.TimeRangeStart, snapshot.TimeRangeEnd, snapshot.SummaryMode, snapshot.ResultVersion,
+				snapshot.Preview, snapshot.Content, snapshot.CreatedAt, snapshot.UpdatedAt)
+			if insertErr != nil {
+				tx.AddError(insertErr)
+				return
+			}
+			snapshotID, insertErr := result.LastInsertId()
+			if insertErr == nil {
+				_, insertErr = sqlDB.Exec(`INSERT INTO summary_share_grant
+					(snapshot_id, share_id, channel_id, channel_type, status, created_at, updated_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?)`, snapshotID, "concurrent-share-id", "group1", model.ChannelTypeGroup, model.ShareGrantActive, snapshot.CreatedAt, snapshot.UpdatedAt)
+			}
+			if insertErr != nil {
+				tx.AddError(insertErr)
+				return
+			}
+			tx.AddError(gorm.ErrDuplicatedKey)
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-1/shares", "creator", "space1", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("concurrent idempotent create=%d %s", w.Code, w.Body.String())
+	}
+	if got := decodeShareID(t, w); got != "concurrent-share-id" {
+		t.Fatalf("expected concurrent winner grant, got %s", got)
+	}
+	var snapshots, grants int64
+	db.Model(&model.SummaryShareSnapshot{}).Count(&snapshots)
+	db.Model(&model.SummaryShareGrant{}).Count(&grants)
+	if snapshots != 1 || grants != 1 {
+		t.Fatalf("snapshots=%d grants=%d", snapshots, grants)
+	}
+}
+
+func TestSummaryShare_RevokeDoesNotReportSuccessWhenUpdateFails(t *testing.T) {
+	db, _, r, _ := setupShareTest(t)
+	body := gin.H{"idempotency_key": "share-revoke-failure", "targets": []gin.H{{"channel_id": "peer", "channel_type": model.ChannelTypeDM}}}
+	w := shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-1/shares", "creator", "space1", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create=%d %s", w.Code, w.Body.String())
+	}
+	shareID := decodeShareID(t, w)
+
+	injected := errors.New("injected revoke failure")
+	if err := db.Callback().Update().Before("gorm:update").Register("share_test:revoke_failure", func(tx *gorm.DB) {
+		if tx.Statement.Table == "summary_share_grant" {
+			tx.AddError(injected)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w = shareRequest(t, r, http.MethodDelete, "/api/v1/summary-shares/"+shareID, "creator", "space1", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("revoke failure=%d %s", w.Code, w.Body.String())
+	}
+	var grant model.SummaryShareGrant
+	if err := db.Where("share_id = ?", shareID).First(&grant).Error; err != nil {
+		t.Fatal(err)
+	}
+	if grant.Status != model.ShareGrantActive {
+		t.Fatalf("failed revoke changed status to %d", grant.Status)
 	}
 }

--- a/internal/api/handler/share_test.go
+++ b/internal/api/handler/share_test.go
@@ -1,0 +1,207 @@
+//go:build cgo
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupShareTest(t *testing.T) (*gorm.DB, *gorm.DB, *gin.Engine, int64) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{},
+		&model.SummaryResult{}, &model.PersonalResult{},
+		&model.SummaryShareSnapshot{}, &model.SummaryShareGrant{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	imDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	imDB.Exec(`CREATE TABLE space (space_id TEXT, status INTEGER)`)
+	imDB.Exec(`CREATE TABLE space_member (space_id TEXT, uid TEXT, status INTEGER)`)
+	imDB.Exec(`CREATE TABLE "group" (group_no TEXT, space_id TEXT, status INTEGER)`)
+	imDB.Exec(`CREATE TABLE group_member (group_no TEXT, uid TEXT, is_deleted INTEGER)`)
+	imDB.Exec(`INSERT INTO space VALUES ('space1',1),('space2',1)`)
+	imDB.Exec(`INSERT INTO space_member VALUES ('space1','creator',1),('space1','reader',1),('space1','outsider',1),('space1','peer',1)`)
+	imDB.Exec(`INSERT INTO "group" VALUES ('group1','space1',1)`)
+	imDB.Exec(`INSERT INTO group_member VALUES ('group1','creator',0),('group1','reader',0)`)
+
+	now := time.Now()
+	task := model.SummaryTask{TaskNo: "ST-share-1", SpaceID: "space1", CreatorID: "creator", Title: "Weekly review", SummaryMode: 1, Status: model.StatusCompleted, TimeRangeStart: now.Add(-24 * time.Hour), TimeRangeEnd: now, CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&model.SummarySource{TaskID: task.ID, SourceType: model.SourceGroup, SourceID: "source", SourceName: "Source group", CreatedAt: now})
+	db.Create(&model.SummaryParticipant{TaskID: task.ID, UserID: "creator", UserName: "Creator", Status: model.ParticipantAccepted, CreatedAt: now, UpdatedAt: now})
+	result := model.SummaryResult{TaskID: task.ID, Content: "## Result\nGrowth [1] and [123](https://example.com).", TotalMsgCount: 38, Version: 2, GeneratedAt: now, CreatedAt: now, UpdatedAt: now}
+	result.SetCitations([]model.Citation{{Index: 1}})
+	db.Create(&result)
+
+	h := NewShareHandler(db, imDB)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.POST("/api/v1/summaries/:id/shares", h.Create)
+	r.GET("/api/v1/summary-shares/:share_id", h.Get)
+	r.DELETE("/api/v1/summary-shares/:share_id", h.Revoke)
+	return db, imDB, r, task.ID
+}
+
+func shareRequest(t *testing.T, r *gin.Engine, method, path, uid, space string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Token", uid)
+	req.Header.Set("X-Space-Id", space)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func decodeShareID(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var envelope struct {
+		Data struct {
+			Grants []struct {
+				ShareID string `json:"share_id"`
+			} `json:"grants"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if len(envelope.Data.Grants) != 1 {
+		t.Fatalf("grants=%s", w.Body.String())
+	}
+	return envelope.Data.Grants[0].ShareID
+}
+
+func decodeSourceAccessible(t *testing.T, w *httptest.ResponseRecorder) bool {
+	t.Helper()
+	var envelope struct {
+		Data struct {
+			SourceAccessible bool `json:"source_accessible"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	return envelope.Data.SourceAccessible
+}
+
+func TestSummaryShare_GroupGrantAndIdempotency(t *testing.T) {
+	db, imDB, r, taskID := setupShareTest(t)
+	body := gin.H{"idempotency_key": "share-request-1", "targets": []gin.H{{"channel_id": "group1", "channel_type": model.ChannelTypeGroup}}}
+	w := shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-1/shares", "creator", "space1", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create=%d %s", w.Code, w.Body.String())
+	}
+	shareID := decodeShareID(t, w)
+	w = shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-1/shares", "creator", "space1", body)
+	if got := decodeShareID(t, w); got != shareID {
+		t.Fatalf("idempotency changed share id: %s != %s", got, shareID)
+	}
+	var snapshots, grants int64
+	db.Model(&model.SummaryShareSnapshot{}).Count(&snapshots)
+	db.Model(&model.SummaryShareGrant{}).Count(&grants)
+	if snapshots != 1 || grants != 1 {
+		t.Fatalf("snapshots=%d grants=%d", snapshots, grants)
+	}
+
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reader=%d %s", w.Code, w.Body.String())
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("Growth [1]")) || !bytes.Contains(w.Body.Bytes(), []byte("[123](https://example.com)")) {
+		t.Fatalf("citation cleanup corrupted content: %s", w.Body.String())
+	}
+	if decodeSourceAccessible(t, w) {
+		t.Fatal("non-participant reader must not access the original summary")
+	}
+	now := time.Now()
+	db.Create(&model.SummaryParticipant{TaskID: taskID, UserID: "reader", UserName: "Reader", Status: model.ParticipantAccepted, CreatedAt: now, UpdatedAt: now})
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusOK || !decodeSourceAccessible(t, w) {
+		t.Fatalf("participant reader source_accessible=%v response=%d %s", decodeSourceAccessible(t, w), w.Code, w.Body.String())
+	}
+	deletedAt := time.Now()
+	db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("deleted_at", deletedAt)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusOK || decodeSourceAccessible(t, w) {
+		t.Fatalf("deleted source must fall back to snapshot: %d %s", w.Code, w.Body.String())
+	}
+	db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("deleted_at", nil)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "outsider", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("outsider=%d %s", w.Code, w.Body.String())
+	}
+	imDB.Exec(`UPDATE group_member SET is_deleted=1 WHERE group_no='group1' AND uid='creator'`)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "creator", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("departed creator=%d %s", w.Code, w.Body.String())
+	}
+	imDB.Exec(`UPDATE group_member SET is_deleted=0 WHERE group_no='group1' AND uid='creator'`)
+	imDB.Exec(`UPDATE group_member SET is_deleted=1 WHERE group_no='group1' AND uid='reader'`)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("departed reader=%d %s", w.Code, w.Body.String())
+	}
+	imDB.Exec(`UPDATE group_member SET is_deleted=0 WHERE group_no='group1' AND uid='reader'`)
+	imDB.Exec(`UPDATE space SET status=0 WHERE space_id='space1'`)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "reader", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("deleted space reader=%d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSummaryShare_DirectAndCrossSpace(t *testing.T) {
+	_, _, r, _ := setupShareTest(t)
+	body := gin.H{"idempotency_key": "share-request-dm", "targets": []gin.H{{"channel_id": "peer", "channel_type": model.ChannelTypeDM}}}
+	w := shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-1/shares", "creator", "space1", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create=%d %s", w.Code, w.Body.String())
+	}
+	shareID := decodeShareID(t, w)
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "peer", "space1", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("peer=%d %s", w.Code, w.Body.String())
+	}
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "peer", "space2", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-space=%d %s", w.Code, w.Body.String())
+	}
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "outsider", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("unrelated dm reader=%d %s", w.Code, w.Body.String())
+	}
+	w = shareRequest(t, r, http.MethodDelete, "/api/v1/summary-shares/"+shareID, "creator", "space1", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("revoke=%d %s", w.Code, w.Body.String())
+	}
+	w = shareRequest(t, r, http.MethodGet, "/api/v1/summary-shares/"+shareID, "peer", "space1", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("revoked grant=%d %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -52,6 +52,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	editH := handler.NewEditHandler(db, refineLLM)
 	personalH.SetLLM(refineLLM)
 	streamH := handler.NewStreamHandler(db, streamHub)
+	shareH := handler.NewShareHandler(db, imDB)
 
 	v1 := r.Group("/api/v1")
 	v1.Use(middleware.StrictAuthMiddleware(authResolver), middleware.StrictSpaceMiddleware())
@@ -64,6 +65,9 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		v1.POST("/summaries/batch-status", taskH.BatchStatus)
 		v1.GET("/summaries", taskH.ListSummaries)
 		v1.GET("/summaries/:id", taskH.GetSummary)
+		v1.POST("/summaries/:id/shares", shareH.Create)
+		v1.GET("/summary-shares/:share_id", shareH.Get)
+		v1.DELETE("/summary-shares/:share_id", shareH.Revoke)
 		v1.GET("/summaries/:id/stream", streamH.StreamSummary)
 		v1.POST("/summaries/:id/read", taskH.MarkSummaryRead)
 		v1.GET("/summaries/:id/result", taskH.GetResult)

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -217,6 +217,49 @@ SELECT 1;
 -- +migrate Down
 SELECT 1;
 `)},
+	"20260721-02-summary-share-snapshot.sql": &fstest.MapFile{Data: []byte(`-- +migrate Up
+CREATE TABLE summary_share_snapshot (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id INTEGER NOT NULL,
+  task_no TEXT NOT NULL,
+  space_id TEXT NOT NULL,
+  creator_id TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  source_name TEXT NOT NULL DEFAULT '',
+  source_count INTEGER NOT NULL DEFAULT 0,
+  participant_count INTEGER NOT NULL DEFAULT 0,
+  message_count INTEGER NOT NULL DEFAULT 0,
+  time_range_start TEXT NOT NULL,
+  time_range_end TEXT NOT NULL,
+  summary_mode INTEGER NOT NULL,
+  result_version INTEGER NOT NULL DEFAULT 1,
+  preview TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE UNIQUE INDEX uk_summary_share_idempotency ON summary_share_snapshot (space_id, creator_id, idempotency_key);
+CREATE INDEX idx_summary_share_task ON summary_share_snapshot (task_id);
+CREATE TABLE summary_share_grant (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  snapshot_id INTEGER NOT NULL,
+  share_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  channel_type INTEGER NOT NULL,
+  status INTEGER NOT NULL DEFAULT 1,
+  revoked_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE UNIQUE INDEX uk_summary_share_id ON summary_share_grant (share_id);
+CREATE UNIQUE INDEX uk_summary_share_target ON summary_share_grant (snapshot_id, channel_id, channel_type);
+
+-- +migrate Down
+DROP TABLE IF EXISTS summary_share_grant;
+DROP TABLE IF EXISTS summary_share_snapshot;
+`)},
 }
 
 func testSource() migrate.MigrationSource {
@@ -242,14 +285,15 @@ func TestRunMigrations_NewDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 10 {
-		t.Fatalf("expected 10 migrations applied, got %d", n)
+	if n != 11 {
+		t.Fatalf("expected 11 migrations applied, got %d", n)
 	}
 
 	tables := []string{
 		"summary_chunk", "summary_event", "summary_participant",
 		"summary_personal_result", "summary_result", "summary_schedule",
 		"summary_source", "summary_task", "summary_user_template",
+		"summary_share_snapshot", "summary_share_grant",
 	}
 	for _, tbl := range tables {
 		var name string
@@ -318,8 +362,8 @@ func TestRunMigrations_ExistingDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMigrationsCore: %v", err)
 	}
-	if n != 9 {
-		t.Fatalf("expected 9 migrations applied (006+007+workflow_stage+user_template+template_compat+description_1000+title_1300+task_topic+content_2000), got %d", n)
+	if n != 10 {
+		t.Fatalf("expected 10 migrations applied (including summary share snapshot/grant), got %d", n)
 	}
 }
 
@@ -344,8 +388,8 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first run: %v", err)
 	}
-	if n1 != 10 {
-		t.Fatalf("first run: expected 10, got %d", n1)
+	if n1 != 11 {
+		t.Fatalf("first run: expected 11, got %d", n1)
 	}
 
 	n2, err := runMigrationsCore(db, "sqlite3", testSource())

--- a/internal/model/summary_share.go
+++ b/internal/model/summary_share.go
@@ -1,0 +1,50 @@
+package model
+
+import "time"
+
+const (
+	ShareGrantActive  = 1
+	ShareGrantRevoked = 2
+)
+
+// SummaryShareSnapshot is an immutable, citation-free copy of the summary that
+// was visible when the user shared it. One snapshot may be granted to multiple
+// target conversations without duplicating the full body.
+type SummaryShareSnapshot struct {
+	ID               int64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	TaskID           int64     `gorm:"column:task_id;not null;index:idx_summary_share_task" json:"task_id"`
+	TaskNo           string    `gorm:"column:task_no;type:varchar(32);not null" json:"task_no"`
+	SpaceID          string    `gorm:"column:space_id;type:varchar(64);not null;uniqueIndex:uk_summary_share_idempotency" json:"space_id"`
+	CreatorID        string    `gorm:"column:creator_id;type:varchar(64);not null;uniqueIndex:uk_summary_share_idempotency" json:"-"`
+	IdempotencyKey   string    `gorm:"column:idempotency_key;type:varchar(64);not null;uniqueIndex:uk_summary_share_idempotency" json:"-"`
+	RequestHash      string    `gorm:"column:request_hash;type:char(64);not null" json:"-"`
+	Title            string    `gorm:"column:title;type:varchar(2300);not null" json:"title"`
+	SourceName       string    `gorm:"column:source_name;type:varchar(500);not null" json:"source_name"`
+	SourceCount      int       `gorm:"column:source_count;not null" json:"source_count"`
+	ParticipantCount int       `gorm:"column:participant_count;not null" json:"participant_count"`
+	MessageCount     int       `gorm:"column:message_count;not null" json:"message_count"`
+	TimeRangeStart   time.Time `gorm:"column:time_range_start;not null" json:"time_range_start"`
+	TimeRangeEnd     time.Time `gorm:"column:time_range_end;not null" json:"time_range_end"`
+	SummaryMode      int       `gorm:"column:summary_mode;not null" json:"summary_mode"`
+	ResultVersion    int       `gorm:"column:result_version;not null" json:"result_version"`
+	Preview          string    `gorm:"column:preview;type:text;not null" json:"preview"`
+	Content          string    `gorm:"column:content;type:mediumtext;not null" json:"content"`
+	CreatedAt        time.Time `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"column:updated_at;not null" json:"updated_at"`
+}
+
+func (SummaryShareSnapshot) TableName() string { return "summary_share_snapshot" }
+
+type SummaryShareGrant struct {
+	ID          int64      `gorm:"primaryKey;autoIncrement" json:"id"`
+	SnapshotID  int64      `gorm:"column:snapshot_id;not null;uniqueIndex:uk_summary_share_target" json:"snapshot_id"`
+	ShareID     string     `gorm:"column:share_id;type:varchar(64);not null;uniqueIndex:uk_summary_share_id" json:"share_id"`
+	ChannelID   string     `gorm:"column:channel_id;type:varchar(128);not null;uniqueIndex:uk_summary_share_target" json:"channel_id"`
+	ChannelType int        `gorm:"column:channel_type;not null;uniqueIndex:uk_summary_share_target" json:"channel_type"`
+	Status      int        `gorm:"column:status;not null;default:1" json:"status"`
+	RevokedAt   *time.Time `gorm:"column:revoked_at" json:"revoked_at,omitempty"`
+	CreatedAt   time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	UpdatedAt   time.Time  `gorm:"column:updated_at;not null" json:"updated_at"`
+}
+
+func (SummaryShareGrant) TableName() string { return "summary_share_grant" }

--- a/migrations/sql/20260721-02-summary-share-snapshot.sql
+++ b/migrations/sql/20260721-02-summary-share-snapshot.sql
@@ -1,0 +1,46 @@
+-- +migrate Up
+CREATE TABLE `summary_share_snapshot` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `task_id` BIGINT NOT NULL,
+  `task_no` VARCHAR(32) NOT NULL,
+  `space_id` VARCHAR(64) NOT NULL,
+  `creator_id` VARCHAR(64) NOT NULL,
+  `idempotency_key` VARCHAR(64) NOT NULL,
+  `request_hash` CHAR(64) NOT NULL,
+  `title` VARCHAR(2300) NOT NULL DEFAULT '',
+  `source_name` VARCHAR(500) NOT NULL DEFAULT '',
+  `source_count` INT NOT NULL DEFAULT 0,
+  `participant_count` INT NOT NULL DEFAULT 0,
+  `message_count` INT NOT NULL DEFAULT 0,
+  `time_range_start` DATETIME NOT NULL,
+  `time_range_end` DATETIME NOT NULL,
+  `summary_mode` TINYINT NOT NULL,
+  `result_version` INT NOT NULL DEFAULT 1,
+  `preview` TEXT NOT NULL,
+  `content` MEDIUMTEXT NOT NULL,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_summary_share_idempotency` (`space_id`, `creator_id`, `idempotency_key`),
+  KEY `idx_summary_share_task` (`task_id`)
+);
+
+CREATE TABLE `summary_share_grant` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `snapshot_id` BIGINT NOT NULL,
+  `share_id` VARCHAR(64) NOT NULL,
+  `channel_id` VARCHAR(128) NOT NULL,
+  `channel_type` TINYINT NOT NULL,
+  `status` TINYINT NOT NULL DEFAULT 1,
+  `revoked_at` DATETIME NULL,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_summary_share_id` (`share_id`),
+  UNIQUE KEY `uk_summary_share_target` (`snapshot_id`, `channel_id`, `channel_type`),
+  KEY `idx_summary_share_snapshot` (`snapshot_id`)
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS `summary_share_grant`;
+DROP TABLE IF EXISTS `summary_share_snapshot`;


### PR DESCRIPTION
## Summary

Add immutable summary share snapshots and target-scoped grants for card sharing.

## Related Issue

Fixes #169

## Changes

- add snapshot and grant models with database migration
- add create, read, and revoke endpoints
- enforce active Space and target conversation membership
- return source accessibility for permission-aware navigation
- support race-safe idempotent multi-target share creation
- fail closed on revocation and snapshot metadata database errors
- add handler, concurrency, revocation-failure, and migration coverage

## Testing

- `CGO_ENABLED=0 GOCACHE=/tmp/octo-smart-summary-go-cache go test ./internal/api/handler`
- `GOCACHE=/tmp/octo-smart-summary-go-cache go test ./internal/db`
- `CGO_ENABLED=0 GOCACHE=/tmp/octo-smart-summary-go-cache go vet ./...`
- Docker CGO/race: `go test -race -count=1 ./internal/api/handler -run SummaryShare`
- Docker CGO: `go test -count=1 ./internal/db`