### PR TITLE
test(share): cover agent (TriggerAgent + PersonalResult) share fallback

### DIFF
--- a/internal/api/handler/share_test.go
+++ b/internal/api/handler/share_test.go
@@ -315,3 +315,51 @@ func TestSummaryShare_RevokeDoesNotReportSuccessWhenUpdateFails(t *testing.T) {
 		t.Fatalf("failed revoke changed status to %d", grant.Status)
 	}
 }
+
+// TestSummaryShare_AgentPersonalResultFallback covers the TriggerAgent path:
+// an agent summary's deliverable is the creator's PersonalResult and NO
+// SummaryResult row is ever written (see agent_summary.go). Create-share must
+// fall back to that PersonalResult instead of failing with "no shareable
+// content", and the snapshot content must come from it.
+func TestSummaryShare_AgentPersonalResultFallback(t *testing.T) {
+	db, _, r, _ := setupShareTest(t)
+	now := time.Now()
+
+	agent := model.SummaryTask{
+		TaskNo: "ST-share-agent", SpaceID: "space1", CreatorID: "creator",
+		Title: "Agent summary", SummaryMode: model.ModeByPerson, TriggerType: model.TriggerAgent,
+		Status: model.StatusCompleted, TimeRangeStart: now.Add(-time.Hour), TimeRangeEnd: now,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&agent).Error; err != nil {
+		t.Fatal(err)
+	}
+	db.Create(&model.SummarySource{TaskID: agent.ID, SourceType: model.SourceGroup, SourceID: "source", SourceName: "Agent source", CreatedAt: now})
+	db.Create(&model.SummaryParticipant{TaskID: agent.ID, UserID: "creator", UserName: "Creator", Status: model.ParticipantAccepted, CreatedAt: now, UpdatedAt: now})
+
+	const agentContent = "## Agent deliverable\nShipped the release [1]."
+	if err := db.Create(&model.PersonalResult{TaskID: agent.ID, UserID: "creator", Content: agentContent, MsgCount: 12, CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// Guard the premise: the agent task has no SummaryResult row.
+	var srCount int64
+	db.Model(&model.SummaryResult{}).Where("task_id = ?", agent.ID).Count(&srCount)
+	if srCount != 0 {
+		t.Fatalf("agent task must have no summary_result, got %d", srCount)
+	}
+
+	body := gin.H{"idempotency_key": "share-agent-1", "targets": []gin.H{{"channel_id": "group1", "channel_type": model.ChannelTypeGroup}}}
+	w := shareRequest(t, r, http.MethodPost, "/api/v1/summaries/ST-share-agent/shares", "creator", "space1", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("agent create-share should succeed via PersonalResult fallback: %d %s", w.Code, w.Body.String())
+	}
+
+	var snap model.SummaryShareSnapshot
+	if err := db.Where("task_id = ?", agent.ID).First(&snap).Error; err != nil {
+		t.Fatalf("snapshot not created for agent task: %v", err)
+	}
+	if snap.Content != agentContent {
+		t.Fatalf("snapshot content = %q, want PersonalResult content %q", snap.Content, agentContent)
+	}
+}


### PR DESCRIPTION
## Summary
#170 引入了分享快照 + scoped grants,`share.Create` 在任务没有 `summary_result` 行时会回退到创建者的 `PersonalResult`。**agent 总结(`TriggerAgent` + `ModeByPerson`,只写 PersonalResult、从不写 SummaryResult)正是依赖这条回退**,但此前没有测试直接覆盖它——只被间接跑到。

本 PR 补一条专项回归测试 `TestSummaryShare_AgentPersonalResultFallback`:
- 构造 `TriggerAgent + ModeByPerson` 任务,仅有创建者 `PersonalResult`(并断言其**没有** `SummaryResult` 行);
- POST 创建分享应成功(走 PersonalResult 回退,而非返回「没有可分享的总结内容」);
- 断言快照 `content` 来自该 `PersonalResult`。

纯新增测试,无生产代码改动。

## How verified
`CGO_ENABLED=1 CGO_LDFLAGS="-L/usr/local/lib" go test ./internal/api/handler/ -run TestSummaryShare -v`(golang:1.25-bookworm + libtokenizers.a,与 CI 一致)全绿:
```
--- PASS: TestSummaryShare_AgentPersonalResultFallback (0.01s)
ok  github.com/Mininglamp-OSS/octo-smart-summary/internal/api/handler
```
日志印证回退路径:`result_select.go record not found`(无 summary_result)→ 命中 PersonalResult → 分享成功。
