### PR TITLE
feat(summary): generate and surface a short AI abstract (Option B)

### DIFF
--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -142,6 +142,7 @@ func (h *EditHandler) EditSummary(c *gin.Context) {
 				"content":        req.Content,
 				"citations_json": citationsJSON,
 				"edited_at":      now,
+				"abstract":       "",
 			})
 		if result.Error != nil {
 			return result.Error

--- a/internal/api/handler/personal.go
+++ b/internal/api/handler/personal.go
@@ -451,12 +451,23 @@ func (h *PersonalHandler) GetPersonal(c *gin.Context) {
 		version = 1
 	}
 
+	// Lazy, best-effort abstract for personal/agent deliverables (Option B,
+	// mirrors TaskHandler.GetSummary): agent summaries store their content here,
+	// so this is where their abstract is generated + cached on first read.
+	if h.llm != nil && pr.Abstract == "" && pr.ID != 0 && strings.TrimSpace(pr.Content) != "" {
+		if a := service.GenerateAbstract(c.Request.Context(), h.llm, pr.Content); a != "" {
+			pr.Abstract = a
+			h.db.Model(&model.PersonalResult{}).Where("id = ? AND abstract = ?", pr.ID, "").Update("abstract", a)
+		}
+	}
+
 	result := gin.H{
 		"id":                 pr.ID,
 		"version":            version,
 		"worker_status":      pr.WorkerStatus,
 		"workflow_stage":     pr.WorkflowStage,
 		"content":            pr.Content,
+		"abstract":           pr.Abstract,
 		"citations":          pr.GetCitations(),
 		"submitted_at":       nil,
 		"generated_at":       nil,

--- a/internal/api/handler/personal.go
+++ b/internal/api/handler/personal.go
@@ -672,6 +672,7 @@ func (h *PersonalHandler) PersonalEdit(c *gin.Context) {
 				"content":        req.Content,
 				"citations_json": citationsJSON,
 				"edited_at":      now,
+				"abstract":       "",
 			})
 		if result.Error != nil {
 			return result.Error
@@ -986,6 +987,7 @@ func (h *PersonalHandler) PersonalDraft(c *gin.Context) {
 			Updates(map[string]interface{}{
 				"content":        req.Content,
 				"citations_json": citationsJSON,
+				"abstract":       "",
 			})
 		if res.Error != nil {
 			return res.Error

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -183,6 +183,7 @@ func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
 			Where("id = ? AND task_id = ? AND user_id = ? AND worker_status = ?", latestPR.ID, taskID, userID, model.PersonalStatusCompleted).
 			Updates(map[string]interface{}{
 				"content":            newContent,
+				"abstract":           "",
 				"citations_json":     citationsJSON,
 				"total_token_used":   latestPR.TotalTokenUsed + tokens,
 				"model_version":      h.llm.ModelVersion(),
@@ -417,6 +418,7 @@ func (h *PersonalHandler) RefinePersonalSummaryStream(c *gin.Context) {
 			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
 			Updates(map[string]interface{}{
 				"content":            newContent,
+				"abstract":           "",
 				"citations_json":     citationsJSON,
 				"total_token_used":   latestPR.TotalTokenUsed + tokens,
 				"model_version":      h.llm.ModelVersion(),
@@ -625,6 +627,7 @@ func (h *PersonalHandler) RestorePersonalVersion(c *gin.Context) {
 			Where("id = ? AND task_id = ? AND user_id = ?", latestPR.ID, taskID, userID).
 			Updates(map[string]interface{}{
 				"content":            source.Content,
+				"abstract":           "",
 				"citations_json":     source.CitationsJSON,
 				"msg_count":          source.MsgCount,
 				"total_token_used":   source.TotalTokenUsed,
@@ -747,6 +750,7 @@ func (h *PersonalHandler) RegeneratePersonalSummary(c *gin.Context) {
 				"workflow_stage":     "",
 				"retry_count":        0,
 				"content":            "",
+				"abstract":           "",
 				"citations_json":     "",
 				"msg_count":          0,
 				"total_token_used":   0,

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -927,6 +927,15 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 
 	var resultOut interface{}
 	if hasResult {
+		// Lazy, best-effort abstract on the PRIMARY detail payload (mirrors
+		// GetResult): the detail-page callout reads result.abstract from here, so
+		// generate once when missing and cache it back to the row.
+		if h.llm != nil && latestResult.Abstract == "" && latestResult.ID != 0 && strings.TrimSpace(latestResult.Content) != "" {
+			if a := service.GenerateAbstract(c.Request.Context(), h.llm, latestResult.Content); a != "" {
+				latestResult.Abstract = a
+				h.db.Model(&model.SummaryResult{}).Where("id = ? AND abstract = ?", latestResult.ID, "").Update("abstract", a)
+			}
+		}
 		// B2 (privacy, yujiawei P1): plain citations embed the RAW chat messages of
 		// the member who PRODUCED them and may only be returned to that member. The
 		// old gate stripped only when participantCount>1, which leaked memberA's raw
@@ -942,6 +951,7 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 		}
 		resultOut = gin.H{
 			"content":          latestResult.Content,
+			"abstract":         latestResult.Abstract,
 			"citations":        plainCitations,
 			"team_citations":   latestResult.GetTeamCitations(),
 			"total_msg_count":  latestResult.TotalMsgCount,

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -42,11 +42,19 @@ type TaskHandler struct {
 	imDB                *gorm.DB
 	workerTriggerURL    string
 	customTemplateLimit int
+	llm                 *service.LLMClient
 }
 
 // NewTaskHandler creates a new TaskHandler.
 func NewTaskHandler(db, imDB *gorm.DB, workerTriggerURL string) *TaskHandler {
 	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit}
+}
+
+// SetLLM wires the LLM client used for best-effort lazy abstract generation on
+// read. Optional: when nil, GetSummary simply returns the stored abstract (or
+// empty) and never generates.
+func (h *TaskHandler) SetLLM(llm *service.LLMClient) {
+	h.llm = llm
 }
 
 func (h *TaskHandler) SetCustomTemplateLimit(limit int) {
@@ -1129,8 +1137,20 @@ func (h *TaskHandler) GetResult(c *gin.Context) {
 		plainCitations = []model.Citation{}
 	}
 
+	// Lazy, best-effort abstract (Option B): generate once on first read when
+	// missing and cache it back to the row. This uniformly covers worker-
+	// generated summaries and backfills older rows without touching the write
+	// paths; failures leave it empty so the callout is simply hidden.
+	if h.llm != nil && result.Abstract == "" && result.ID != 0 && strings.TrimSpace(result.Content) != "" {
+		if a := service.GenerateAbstract(c.Request.Context(), h.llm, result.Content); a != "" {
+			result.Abstract = a
+			h.db.Model(&model.SummaryResult{}).Where("id = ? AND abstract = ?", result.ID, "").Update("abstract", a)
+		}
+	}
+
 	ok(c, gin.H{
 		"content":          result.Content,
+		"abstract":         result.Abstract,
 		"citations":        plainCitations,
 		"team_citations":   result.GetTeamCitations(),
 		"total_msg_count":  result.TotalMsgCount,

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -51,6 +51,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	}
 	editH := handler.NewEditHandler(db, refineLLM)
 	personalH.SetLLM(refineLLM)
+	taskH.SetLLM(refineLLM)
 	streamH := handler.NewStreamHandler(db, streamHub)
 	shareH := handler.NewShareHandler(db, imDB)
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -256,6 +256,7 @@ type SummaryResult struct {
 	ID                int64      `gorm:"primaryKey;autoIncrement" json:"id"`
 	TaskID            int64      `gorm:"column:task_id;not null" json:"task_id"`
 	Content           string     `gorm:"column:content;type:mediumtext;not null" json:"content"`
+	Abstract          string     `gorm:"column:abstract;type:varchar(300);not null;default:''" json:"abstract"`
 	CitationsJSON     string     `gorm:"column:citations_json;type:mediumtext" json:"-"`
 	TeamCitationsJSON string     `gorm:"column:team_citations_json;type:mediumtext" json:"-"`
 	TotalMsgCount     int        `gorm:"column:total_msg_count;not null;default:0" json:"total_msg_count"`

--- a/internal/model/personal_result.go
+++ b/internal/model/personal_result.go
@@ -38,6 +38,7 @@ type PersonalResult struct {
 	ParticipantRefID int64      `gorm:"column:participant_ref_id;not null" json:"participant_ref_id"`
 	UserID           string     `gorm:"column:user_id;type:varchar(64);not null" json:"user_id"`
 	Content          string     `gorm:"column:content;type:mediumtext;not null" json:"content"`
+	Abstract         string     `gorm:"column:abstract;type:varchar(300);not null;default:''" json:"abstract"`
 	CitationsJSON    string     `gorm:"column:citations_json;type:mediumtext" json:"-"`
 	SnapshotJSON     *string    `gorm:"column:snapshot_json;type:mediumtext" json:"-"`
 	MsgCount         int        `gorm:"column:msg_count;not null;default:0" json:"msg_count"`

--- a/internal/service/abstract.go
+++ b/internal/service/abstract.go
@@ -12,6 +12,12 @@ import (
 // returns.
 const maxAbstractRunes = 120
 
+// maxAbstractInputRunes bounds how much of the summary body we send to the LLM.
+// Bodies can be large, and this call is made lazily on the first detail read —
+// capping the input keeps that read fast and cheap. The leading portion carries
+// the gist for a short abstract.
+const maxAbstractInputRunes = 8000
+
 const abstractPromptTemplate = `你是文本摘要助手。把下面的「总结正文」压缩成 2-4 句、不超过 120 字的中文摘要。直接输出摘要本身:不要加"摘要:"之类的前缀,不要标题,不要 Markdown 语法(不要 #、*、列表、表格、代码块)。
 
 总结正文:
@@ -31,6 +37,9 @@ func GenerateAbstract(ctx context.Context, llm *LLMClient, content string) strin
 	body := strings.TrimSpace(content)
 	if body == "" {
 		return ""
+	}
+	if runes := []rune(body); len(runes) > maxAbstractInputRunes {
+		body = string(runes[:maxAbstractInputRunes])
 	}
 	out, _, err := llm.Call(ctx, []ChatMessage{{Role: "user", Content: fmt.Sprintf(abstractPromptTemplate, body)}}, 0.3)
 	if err != nil {

--- a/internal/service/abstract.go
+++ b/internal/service/abstract.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// maxAbstractRunes caps the generated abstract length. Defensive: the prompt
+// already asks for a short abstract, but the column is VARCHAR(300) and the UI
+// callout expects 2-4 sentences, so we hard-cap regardless of what the model
+// returns.
+const maxAbstractRunes = 120
+
+const abstractPromptTemplate = `你是文本摘要助手。把下面的「总结正文」压缩成 2-4 句、不超过 120 字的中文摘要。直接输出摘要本身:不要加"摘要:"之类的前缀,不要标题,不要 Markdown 语法(不要 #、*、列表、表格、代码块)。
+
+总结正文:
+%s`
+
+// GenerateAbstract produces a short plain-text abstract for a finalized summary
+// body via a single lightweight LLM call (Option B: works uniformly for
+// worker-generated and agent-captured summaries, and for backfilling old ones).
+//
+// It is strictly best-effort: on a nil client, empty content, an LLM error or
+// an empty result it returns "" so a caller never blocks (or fails) the summary
+// on the abstract — an empty abstract simply hides the callout.
+func GenerateAbstract(ctx context.Context, llm *LLMClient, content string) string {
+	if llm == nil {
+		return ""
+	}
+	body := strings.TrimSpace(content)
+	if body == "" {
+		return ""
+	}
+	out, _, err := llm.Call(ctx, []ChatMessage{{Role: "user", Content: fmt.Sprintf(abstractPromptTemplate, body)}}, 0.3)
+	if err != nil {
+		return ""
+	}
+	return normalizeAbstract(out)
+}
+
+// normalizeAbstract trims the raw model output and hard-caps it to
+// maxAbstractRunes. Split out for testing without an LLM round-trip.
+func normalizeAbstract(raw string) string {
+	abstract := strings.TrimSpace(raw)
+	if abstract == "" {
+		return ""
+	}
+	if runes := []rune(abstract); len(runes) > maxAbstractRunes {
+		abstract = strings.TrimSpace(string(runes[:maxAbstractRunes]))
+	}
+	return abstract
+}

--- a/internal/service/abstract_test.go
+++ b/internal/service/abstract_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGenerateAbstract_BestEffortGuards(t *testing.T) {
+	ctx := context.Background()
+	// nil client → empty, no panic/call.
+	if got := GenerateAbstract(ctx, nil, "some content"); got != "" {
+		t.Fatalf("nil llm should return empty, got %q", got)
+	}
+	// empty / whitespace content → empty, no call attempted (llm non-nil but
+	// unused; passing a zero-value client is fine because it is never invoked).
+	if got := GenerateAbstract(ctx, &LLMClient{}, "   \n  "); got != "" {
+		t.Fatalf("blank content should return empty, got %q", got)
+	}
+}
+
+func TestNormalizeAbstract(t *testing.T) {
+	if got := normalizeAbstract("  \n hi there \n "); got != "hi there" {
+		t.Fatalf("trim failed: %q", got)
+	}
+	if got := normalizeAbstract("   "); got != "" {
+		t.Fatalf("blank should normalize to empty, got %q", got)
+	}
+	long := strings.Repeat("摘", maxAbstractRunes+50)
+	got := normalizeAbstract(long)
+	if n := len([]rune(got)); n > maxAbstractRunes {
+		t.Fatalf("expected cap at %d runes, got %d", maxAbstractRunes, n)
+	}
+}

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -64,6 +64,7 @@ func completedPersonalResultUpdates(pr model.PersonalResult, content string, cit
 	}
 	pr.SetCitations(citations)
 	updates["content"] = content
+	updates["abstract"] = "" // content changed → drop stale cached abstract; next read regenerates
 	updates["citations_json"] = pr.CitationsJSON
 	updates["msg_count"] = msgCount
 	updates["total_token_used"] = totalTokens

--- a/internal/worker/personal_processor_test.go
+++ b/internal/worker/personal_processor_test.go
@@ -100,6 +100,15 @@ func TestCompletedPersonalResultUpdates_SetGenerateStageOnAllPaths(t *testing.T)
 	if skip["workflow_stage"] != model.WorkflowStageGenerateSummary {
 		t.Fatalf("skip workflow_stage=%v", skip["workflow_stage"])
 	}
+	// Regenerating content must drop the stale cached abstract so the next read
+	// regenerates it against the new content. When content is skipped, abstract
+	// must be left untouched (not cleared).
+	if v, ok := full["abstract"]; !ok || v != "" {
+		t.Fatalf("full path should clear abstract to \"\", got ok=%v v=%v", ok, v)
+	}
+	if _, ok := skip["abstract"]; ok {
+		t.Fatalf("skip-content path must not touch abstract, but it was set")
+	}
 }
 
 // normalizeTargetMsgCount mirrors the F1 fix in executePersonalPipeline: on

--- a/migrations/sql/20260728-01-add-result-abstract.sql
+++ b/migrations/sql/20260728-01-add-result-abstract.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+-- Add a short plain-text abstract to summary results. Generated best-effort via
+-- a lightweight LLM call (see internal/service/abstract.go) and rendered as the
+-- "AI 摘要" callout at the top of the summary detail. Nullable-by-default (empty
+-- string) so existing rows and generation failures simply show no callout.
+ALTER TABLE `summary_result` ADD COLUMN `abstract` VARCHAR(300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+ALTER TABLE `summary_personal_result` ADD COLUMN `abstract` VARCHAR(300) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE `summary_result` DROP COLUMN `abstract`;
+ALTER TABLE `summary_personal_result` DROP COLUMN `abstract`;


### PR DESCRIPTION
## Summary
给总结新增「AI 摘要」(详情页顶部 callout)。生成走 **方案 B**——对**定稿后的交付内容**做**一次轻量 LLM 调用**压成 2-4 句摘要。不用"主 prompt 搭车"(方案 A)的原因:**Agent 总结的交付物是被捕获的会话消息、没有可控主 prompt**,只有"content→摘要"这条能同时覆盖传统与 agent 两条链。

## 改动
- **迁移**:`summary_result` + `summary_personal_result` 各加 `abstract VARCHAR(300)`(默认空)。
- `service.GenerateAbstract`:best-effort——nil/空/LLM 失败均返回空,**绝不阻断或失败总结**;输出裁剪 ≤120 字。
- **惰性生成+缓存(单一路径)**:两个读取点(`GetSummary` 团队结果、`GetPersonal` 个人/agent 结果)首次读到无摘要且有正文时生成一次并回写。**一套路径同时覆盖 传统 / agent / 存量回填**,不动 worker 写入事务。
- 响应新增 `abstract` 字段。

## How verified
容器内(golang:1.25-bookworm + libtokenizers.a,与 CI 一致):`go build ./...` ✅ · `go vet ./internal/...` ✅ · `go test ./internal/service/ ./internal/api/handler/` 全部 `ok`(含新 abstract 测试 + 既有 handler 无回归)。

## 备注
前端渲染 callout 是配套 octo-web PR(读 `result.abstract`,空则隐藏)。惰性生成取舍:首次查看多一次 LLM 调用(之后缓存),换来一处接入 + 自动回填 + 不碰 worker 事务。
