### PR TITLE
feat(summary): allow personal bots to create owner-scoped summaries

### DIFF
--- a/internal/api/handler/bot_summary_create.go
+++ b/internal/api/handler/bot_summary_create.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +30,67 @@ const maxBotIdempotencyKeyLen = 128
 var botIdempotencyKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]*$`)
 
 var errBotIdempotencyConflict = errors.New("bot summary idempotency conflict")
+
+// errBotIdempotencyBodyMismatch signals that (space_id, bot_id, idempotency_key)
+// matched an existing binding, but the current request's canonical hash does
+// not match the one persisted with it. This is HTTP 409 territory: the client
+// reused an idempotency key across two different intents, and returning the
+// original task would silently discard the new intent. Mirrors the contract
+// summary_share_snapshot enforces with the same-key/different-hash case
+// (share.go:244). See issue #181 P1-2.
+var errBotIdempotencyBodyMismatch = errors.New("bot summary idempotency body mismatch")
+
+// canonicalBotCreateRequestHash returns a deterministic sha256 fingerprint of
+// the semantic content of a create request. Fields are drawn from the
+// resolved (canonicalized) sources, the persisted origin channel, the title,
+// topic, the exact time range, and include_archived — everything the worker
+// would actually use. The client's raw --data ordering, whitespace, or key
+// order does not affect the hash: only the resolved values do, so a client
+// that re-sends the same intent with cosmetic differences replays cleanly.
+func canonicalBotCreateRequestHash(req createBotSummaryReq, sources []canonicalBotSource, originID string, originType int) string {
+	// Sort a copy of the resolved sources so map iteration order or client
+	// ordering never breaks replay determinism.
+	sorted := make([]canonicalBotSource, len(sources))
+	copy(sorted, sources)
+	// Simple string-key sort keeps the dependency footprint small; sources
+	// are capped at maxSourceCount so O(n^2) is fine.
+	for i := 0; i < len(sorted); i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			ki := fmt.Sprintf("%d:%s", sorted[i].SourceType, sorted[i].SourceID)
+			kj := fmt.Sprintf("%d:%s", sorted[j].SourceType, sorted[j].SourceID)
+			if ki > kj {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+	payload := struct {
+		Title            string               `json:"title"`
+		Topic            string               `json:"topic"`
+		TimeRangeStart   string               `json:"time_range_start"`
+		TimeRangeEnd     string               `json:"time_range_end"`
+		Sources          []canonicalBotSource `json:"sources"`
+		OriginChannelID  string               `json:"origin_channel_id"`
+		OriginChannelTp  int                  `json:"origin_channel_type"`
+		IncludeArchived  bool                 `json:"include_archived"`
+	}{
+		Title:           strings.TrimSpace(req.Title),
+		Topic:           strings.TrimSpace(req.Topic),
+		// Format the times as RFC3339Nano so the hash is stable across the
+		// binding lifetime regardless of the client's original serialization
+		// (RFC3339 vs RFC3339Nano vs a slightly different offset). The
+		// backend has already unified the field into a time.Time at this
+		// point.
+		TimeRangeStart:  req.TimeRange.Start.UTC().Format(time.RFC3339Nano),
+		TimeRangeEnd:    req.TimeRange.End.UTC().Format(time.RFC3339Nano),
+		Sources:         sorted,
+		OriginChannelID: originID,
+		OriginChannelTp: originType,
+		IncludeArchived: req.IncludeArchived,
+	}
+	b, _ := json.Marshal(payload)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
 
 type createBotSummaryReq struct {
 	Title             string      `json:"title"`
@@ -97,14 +160,40 @@ func (h *TaskHandler) CreateBotSummary(c *gin.Context) {
 		return
 	}
 
-	if existing, ok := h.findBotIdempotentTask(spaceID, botUID, idempotencyKey); ok {
+	// Compute the canonical request hash once, from the resolved sources +
+	// persisted origin channel. This is what will be stored in the binding
+	// on first-write and compared against on replay. Reused for the "second
+	// call, same key, different body" 409 case.
+	originID := ""
+	originType := 0
+	if req.OriginChannelID != "" {
+		originID = canonicalBotSourceID(sourceReq{SourceType: req.OriginChannelType, SourceID: req.OriginChannelID}, ownerUID)
+		originType = req.OriginChannelType
+	}
+	requestHash := canonicalBotCreateRequestHash(req, sources, originID, originType)
+
+	if existing, mismatched, ok := h.findBotIdempotentTaskWithHash(spaceID, botUID, idempotencyKey, requestHash); ok {
+		if mismatched {
+			// Same idempotency key, different intent. Do not silently return
+			// the original task — surface the collision so the caller can
+			// pick a new key.
+			c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "idempotency key already used for a different request"})
+			return
+		}
 		c.JSON(http.StatusOK, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(existing)})
 		return
 	}
 
-	task, participantID, err := h.persistBotSummary(ownerUID, botUID, spaceID, idempotencyKey, req, sources)
+	task, participantID, err := h.persistBotSummary(ownerUID, botUID, spaceID, idempotencyKey, requestHash, req, sources)
 	if errors.Is(err, errBotIdempotencyConflict) {
-		if existing, ok := h.findBotIdempotentTask(spaceID, botUID, idempotencyKey); ok {
+		// Racing writer beat us to the insert. Re-fetch and treat as a replay
+		// — but honour the hash check so a concurrent replay that happens to
+		// carry a mismatched body still surfaces as 409.
+		if existing, mismatched, ok := h.findBotIdempotentTaskWithHash(spaceID, botUID, idempotencyKey, requestHash); ok {
+			if mismatched {
+				c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "idempotency key already used for a different request"})
+				return
+			}
 			c.JSON(http.StatusOK, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(existing)})
 			return
 		}
@@ -214,7 +303,33 @@ func (h *TaskHandler) resolveAuthorizedBotSources(ctx context.Context, ownerUID,
 			if channel.ChannelID != canonicalID || channel.ChannelType != imType {
 				continue
 			}
-			if imType != model.ChannelTypeDM && channel.SpaceID != spaceID {
+			// DM sources need special handling: pipeline.GetUserChannels
+			// returns DMs with no space filter (their ChannelInfo.SpaceID is
+			// empty), so the channel-side space comparison below cannot
+			// authorize them. Instead, verify that the DM peer is a member
+			// of the token's space via space_member, mirroring the DM path
+			// candidates.go:231 already uses for exactly this data. Without
+			// this check a space-scoped bot token can reach the owner's DMs
+			// with peers outside that space (issue #181 P1-1).
+			if imType == model.ChannelTypeDM {
+				peer := getDMPeer(canonicalID, ownerUID)
+				if peer == "" {
+					// A malformed DM channel id (no @ separator, or self-DM)
+					// cannot be attributed to a peer, so it cannot be
+					// authorized against the space. Reject rather than
+					// silently accept.
+					wrongSpace = true
+					continue
+				}
+				inSpace, err := peerInSpace(ctx, h.imDB, spaceID, peer)
+				if err != nil {
+					return nil, 50000, fmt.Errorf("check DM peer space membership: %w", err)
+				}
+				if !inSpace {
+					wrongSpace = true
+					continue
+				}
+			} else if channel.SpaceID != spaceID {
 				wrongSpace = true
 				continue
 			}
@@ -237,6 +352,45 @@ func (h *TaskHandler) resolveAuthorizedBotSources(ctx context.Context, ownerUID,
 	return result, 0, nil
 }
 
+// getDMPeer extracts the peer UID from a canonicalized DM channel id of the
+// form "a@b" (WuKongIM's larger-CRC32-first layout). Returns "" when the id
+// is malformed or degenerate (self-DM). Kept as a small local helper rather
+// than exported from pipeline because the shape of "canonical" is a private
+// contract between canonicalBotSourceID and this file.
+func getDMPeer(canonicalID, ownerUID string) string {
+	parts := strings.SplitN(canonicalID, "@", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	if parts[0] == ownerUID && parts[1] != ownerUID {
+		return parts[1]
+	}
+	if parts[1] == ownerUID && parts[0] != ownerUID {
+		return parts[0]
+	}
+	return ""
+}
+
+// peerInSpace reports whether the given peer uid holds an active space_member
+// row for spaceID. Uses a single-row COUNT probe so it is cheap enough to
+// run in the source-authorization loop without a batch-friendly query — DM
+// sources per request are already capped at maxSourceCount.
+func peerInSpace(ctx context.Context, imDB *gorm.DB, spaceID, peerUID string) (bool, error) {
+	if imDB == nil || spaceID == "" || peerUID == "" {
+		return false, nil
+	}
+	var count int64
+	err := imDB.WithContext(ctx).
+		Table("space_member").
+		Where("space_id = ? AND uid = ? AND status = 1", spaceID, peerUID).
+		Limit(1).
+		Count(&count).Error
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func canonicalSourcesContain(sources []canonicalBotSource, sourceType int, sourceID, ownerUID string) bool {
 	want := canonicalBotSourceID(sourceReq{SourceType: sourceType, SourceID: sourceID}, ownerUID)
 	for _, source := range sources {
@@ -247,7 +401,7 @@ func canonicalSourcesContain(sources []canonicalBotSource, sourceType int, sourc
 	return false
 }
 
-func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key string, req createBotSummaryReq, sources []canonicalBotSource) (model.SummaryTask, int64, error) {
+func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key, requestHash string, req createBotSummaryReq, sources []canonicalBotSource) (model.SummaryTask, int64, error) {
 	taskNo := service.GenerateTaskNo()
 	title := strings.TrimSpace(req.Title)
 	if title == "" {
@@ -288,7 +442,7 @@ func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key string, r
 			return err
 		}
 		participantID = participant.ID
-		binding := model.SummaryBotCreateIdempotency{SpaceID: spaceID, BotID: botUID, IdempotencyKey: key, TaskID: task.ID, CreatedAt: now}
+		binding := model.SummaryBotCreateIdempotency{SpaceID: spaceID, BotID: botUID, IdempotencyKey: key, RequestHash: requestHash, TaskID: task.ID, CreatedAt: now}
 		insert := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&binding)
 		if insert.Error != nil {
 			return insert.Error
@@ -301,16 +455,34 @@ func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key string, r
 	return task, participantID, err
 }
 
-func (h *TaskHandler) findBotIdempotentTask(spaceID, botID, key string) (model.SummaryTask, bool) {
+// findBotIdempotentTaskWithHash resolves an existing idempotency binding and
+// verifies that the caller's current request hash matches the one persisted
+// with it. Return semantics:
+//
+//   - (task, false, true):  binding found AND hashes match. Replay case.
+//   - ({},   true,  true):  binding found but hashes differ. Callers should
+//     answer HTTP 409 rather than silently returning the original task.
+//   - ({},   false, false): no binding for this (space, bot, key) tuple.
+//
+// Falling through to a hash mismatch here mirrors summary_share_snapshot's
+// contract (share.go:244) which is the pattern this repo already established
+// for idempotency-with-body semantics. See issue #181 P1-2.
+func (h *TaskHandler) findBotIdempotentTaskWithHash(spaceID, botID, key, requestHash string) (model.SummaryTask, bool, bool) {
 	var binding model.SummaryBotCreateIdempotency
 	if err := h.db.Where("space_id = ? AND bot_id = ? AND idempotency_key = ?", spaceID, botID, key).First(&binding).Error; err != nil {
-		return model.SummaryTask{}, false
+		return model.SummaryTask{}, false, false
+	}
+	if binding.RequestHash != requestHash {
+		return model.SummaryTask{}, true, true
 	}
 	var task model.SummaryTask
 	if err := h.db.Where("id = ? AND space_id = ? AND creator_bot_id = ?", binding.TaskID, spaceID, botID).First(&task).Error; err != nil {
-		return model.SummaryTask{}, false
+		// The binding row survives but the task row does not — unusual (only
+		// possible if a manual DELETE ran), but treat as "no replay" rather
+		// than surfacing a phantom mismatch.
+		return model.SummaryTask{}, false, false
 	}
-	return task, true
+	return task, false, true
 }
 
 func botCreateResponse(task model.SummaryTask) gin.H {

--- a/internal/api/handler/bot_summary_create.go
+++ b/internal/api/handler/bot_summary_create.go
@@ -1,0 +1,318 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const maxBotIdempotencyKeyLen = 128
+
+var botIdempotencyKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]*$`)
+
+var errBotIdempotencyConflict = errors.New("bot summary idempotency conflict")
+
+type createBotSummaryReq struct {
+	Title             string      `json:"title"`
+	Topic             string      `json:"topic"`
+	TimeRange         *timeRange  `json:"time_range"`
+	Sources           []sourceReq `json:"sources"`
+	OriginChannelID   string      `json:"origin_channel_id"`
+	OriginChannelType int         `json:"origin_channel_type"`
+	IncludeArchived   bool        `json:"include_archived"`
+}
+
+type canonicalBotSource struct {
+	SourceType int
+	SourceID   string
+}
+
+// CreateBotSummary creates an owner-only asynchronous summary for a personal
+// bot. Authentication supplies owner, bot and space; none are client fields.
+func (h *TaskHandler) CreateBotSummary(c *gin.Context) {
+	if !botSummaryCreateEnabled() {
+		c.JSON(http.StatusServiceUnavailable, apiResponse{Code: 50301, Message: "bot summary creation is disabled"})
+		return
+	}
+
+	ownerUID := middleware.GetUserID(c)
+	spaceID := middleware.GetSpaceID(c)
+	botID, _ := c.Get("bot_id")
+	botUID, _ := botID.(string)
+	if ownerUID == "" || spaceID == "" || botUID == "" {
+		c.JSON(http.StatusUnauthorized, apiResponse{Code: 40100, Message: "missing bot auth context"})
+		return
+	}
+
+	idempotencyKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	if !validBotIdempotencyKey(idempotencyKey) {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "valid Idempotency-Key header is required"})
+		return
+	}
+
+	var req createBotSummaryReq
+	decoder := json.NewDecoder(io.LimitReader(c.Request.Body, 1<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40004, Message: "invalid or unsupported request field"})
+		return
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "request body must contain one JSON object"})
+		return
+	}
+	if err := validateBotSummaryRequest(req); err != nil {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: err.Error()})
+		return
+	}
+
+	sources, code, err := h.resolveAuthorizedBotSources(c.Request.Context(), ownerUID, spaceID, req.Sources, req.IncludeArchived)
+	if err != nil {
+		status := http.StatusForbidden
+		if code == 50000 {
+			status = http.StatusInternalServerError
+		}
+		c.JSON(status, apiResponse{Code: code, Message: err.Error()})
+		return
+	}
+	if req.OriginChannelID != "" && !canonicalSourcesContain(sources, req.OriginChannelType, req.OriginChannelID, ownerUID) {
+		c.JSON(http.StatusForbidden, apiResponse{Code: 40301, Message: "origin channel must be an authorized source"})
+		return
+	}
+
+	if existing, ok := h.findBotIdempotentTask(spaceID, botUID, idempotencyKey); ok {
+		c.JSON(http.StatusOK, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(existing)})
+		return
+	}
+
+	task, participantID, err := h.persistBotSummary(ownerUID, botUID, spaceID, idempotencyKey, req, sources)
+	if errors.Is(err, errBotIdempotencyConflict) {
+		if existing, ok := h.findBotIdempotentTask(spaceID, botUID, idempotencyKey); ok {
+			c.JSON(http.StatusOK, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(existing)})
+			return
+		}
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to create summary"})
+		return
+	}
+
+	go h.triggerWorker(model.WorkerTriggerRequest{Type: "personal_summary", TaskID: task.ID, ParticipantRefID: participantID})
+	c.JSON(http.StatusCreated, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(task)})
+}
+
+func botSummaryCreateEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BOT_SUMMARY_CREATE_ENABLED"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func validBotIdempotencyKey(key string) bool {
+	return len(key) > 0 && len(key) <= maxBotIdempotencyKeyLen && botIdempotencyKeyPattern.MatchString(key)
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra interface{}
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("extra JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func validateBotSummaryRequest(req createBotSummaryReq) error {
+	if len(req.Sources) == 0 {
+		return errors.New("sources is required")
+	}
+	if len(req.Sources) > maxSourceCount {
+		return fmt.Errorf("sources cannot exceed %d", maxSourceCount)
+	}
+	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes || utf8.RuneCountInString(req.Topic) > maxSummaryTopicRunes {
+		return fmt.Errorf("title and topic cannot exceed %d characters", maxSummaryTopicRunes)
+	}
+	if req.TimeRange == nil || req.TimeRange.Start.IsZero() || req.TimeRange.End.IsZero() {
+		return errors.New("time_range with start and end is required")
+	}
+	if !req.TimeRange.Start.Before(req.TimeRange.End) {
+		return errors.New("time_range.start must be before time_range.end")
+	}
+	if req.TimeRange.End.Sub(req.TimeRange.Start) > time.Duration(pipeline.DefaultTimeRangeDays)*24*time.Hour {
+		return fmt.Errorf("time range cannot exceed %d days", pipeline.DefaultTimeRangeDays)
+	}
+	if req.OriginChannelID == "" && req.OriginChannelType != 0 {
+		return errors.New("origin_channel_id is required when origin_channel_type is set")
+	}
+	if req.OriginChannelID != "" && !validFrontendSourceType(req.OriginChannelType) {
+		return errors.New("origin_channel_type must be 1, 2, or 3")
+	}
+	for _, source := range req.Sources {
+		if strings.TrimSpace(source.SourceID) == "" || !validFrontendSourceType(source.SourceType) {
+			return errors.New("each source requires source_id and source_type 1, 2, or 3")
+		}
+	}
+	return nil
+}
+
+func validFrontendSourceType(sourceType int) bool { return sourceType >= 1 && sourceType <= 3 }
+
+func frontendToIMChannelType(sourceType int) int {
+	switch sourceType {
+	case model.SourceGroup:
+		return model.ChannelTypeGroup
+	case model.SourceThread:
+		return model.ChannelTypeThread
+	case model.SourceDirect:
+		return model.ChannelTypeDM
+	default:
+		return 0
+	}
+}
+
+func canonicalBotSourceID(source sourceReq, ownerUID string) string {
+	return pipeline.NormalizeDMChannelID(strings.TrimSpace(source.SourceID), ownerUID, frontendToIMChannelType(source.SourceType))
+}
+
+func (h *TaskHandler) resolveAuthorizedBotSources(ctx context.Context, ownerUID, spaceID string, requested []sourceReq, includeArchived bool) ([]canonicalBotSource, int, error) {
+	var opts []pipeline.ChannelQueryOption
+	if includeArchived {
+		opts = append(opts, pipeline.WithIncludeArchived(true))
+	}
+	allowed, err := pipeline.GetUserChannels(ctx, ownerUID, h.imDB, opts...)
+	if err != nil {
+		return nil, 50000, errors.New("failed to resolve owner channel access")
+	}
+
+	result := make([]canonicalBotSource, 0, len(requested))
+	seen := make(map[string]struct{}, len(requested))
+	for _, source := range requested {
+		canonicalID := canonicalBotSourceID(source, ownerUID)
+		imType := frontendToIMChannelType(source.SourceType)
+		matched, wrongSpace := false, false
+		for _, channel := range allowed {
+			if channel.ChannelID != canonicalID || channel.ChannelType != imType {
+				continue
+			}
+			if imType != model.ChannelTypeDM && channel.SpaceID != spaceID {
+				wrongSpace = true
+				continue
+			}
+			matched = true
+			break
+		}
+		if !matched {
+			if wrongSpace {
+				return nil, 40302, errors.New("source belongs to a different space")
+			}
+			return nil, 40301, errors.New("owner does not have access to a requested source")
+		}
+		key := fmt.Sprintf("%d:%s", source.SourceType, canonicalID)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, canonicalBotSource{SourceType: source.SourceType, SourceID: canonicalID})
+	}
+	return result, 0, nil
+}
+
+func canonicalSourcesContain(sources []canonicalBotSource, sourceType int, sourceID, ownerUID string) bool {
+	want := canonicalBotSourceID(sourceReq{SourceType: sourceType, SourceID: sourceID}, ownerUID)
+	for _, source := range sources {
+		if source.SourceType == sourceType && source.SourceID == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key string, req createBotSummaryReq, sources []canonicalBotSource) (model.SummaryTask, int64, error) {
+	taskNo := service.GenerateTaskNo()
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		title = strings.TrimSpace(req.Topic)
+	}
+	if title == "" {
+		title = "总结-" + taskNo[len(taskNo)-8:]
+	}
+	task := model.SummaryTask{
+		TaskNo: taskNo, SpaceID: spaceID, CreatorID: ownerUID, CreatorBotID: botUID,
+		Title: title, Topic: req.Topic, SummaryMode: model.ModeByPerson,
+		TimeRangeStart: req.TimeRange.Start, TimeRangeEnd: req.TimeRange.End,
+		Status: model.StatusPending, TriggerType: model.TriggerBot,
+		OriginChannelID:   canonicalBotSourceID(sourceReq{SourceType: req.OriginChannelType, SourceID: req.OriginChannelID}, ownerUID),
+		OriginChannelType: req.OriginChannelType,
+	}
+	var participantID int64
+	err := h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&task).Error; err != nil {
+			return err
+		}
+		for _, source := range sources {
+			row := model.SummarySource{TaskID: task.ID, SourceType: source.SourceType, SourceID: source.SourceID, SourceName: service.ResolveSourceNameWithType(source.SourceID, source.SourceType, h.imDB)}
+			if err := tx.Create(&row).Error; err != nil {
+				return err
+			}
+		}
+		now := timezone.Now()
+		participant := model.SummaryParticipant{TaskID: task.ID, UserID: ownerUID, UserName: service.ResolveUserName(ownerUID), Status: model.ParticipantAccepted, ConfirmedAt: &now}
+		if err := tx.Create(&participant).Error; err != nil {
+			return err
+		}
+		personal := model.PersonalResult{TaskID: task.ID, ParticipantRefID: participant.ID, UserID: ownerUID, WorkerStatus: model.PersonalStatusPending, CreatedAt: now, UpdatedAt: now}
+		if err := tx.Create(&personal).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&participant).Update("personal_result_id", personal.ID).Error; err != nil {
+			return err
+		}
+		participantID = participant.ID
+		binding := model.SummaryBotCreateIdempotency{SpaceID: spaceID, BotID: botUID, IdempotencyKey: key, TaskID: task.ID, CreatedAt: now}
+		insert := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&binding)
+		if insert.Error != nil {
+			return insert.Error
+		}
+		if insert.RowsAffected == 0 {
+			return errBotIdempotencyConflict
+		}
+		return nil
+	})
+	return task, participantID, err
+}
+
+func (h *TaskHandler) findBotIdempotentTask(spaceID, botID, key string) (model.SummaryTask, bool) {
+	var binding model.SummaryBotCreateIdempotency
+	if err := h.db.Where("space_id = ? AND bot_id = ? AND idempotency_key = ?", spaceID, botID, key).First(&binding).Error; err != nil {
+		return model.SummaryTask{}, false
+	}
+	var task model.SummaryTask
+	if err := h.db.Where("id = ? AND space_id = ? AND creator_bot_id = ?", binding.TaskID, spaceID, botID).First(&task).Error; err != nil {
+		return model.SummaryTask{}, false
+	}
+	return task, true
+}
+
+func botCreateResponse(task model.SummaryTask) gin.H {
+	return gin.H{"task_id": task.ID, "task_no": task.TaskNo, "status": task.Status, "trigger_type": task.TriggerType, "creator_id": task.CreatorID, "creator_bot_id": task.CreatorBotID, "created_at": task.CreatedAt.Format(time.RFC3339)}
+}

--- a/internal/api/handler/bot_summary_create.go
+++ b/internal/api/handler/bot_summary_create.go
@@ -80,7 +80,7 @@ func canonicalBotCreateRequestHash(req createBotSummaryReq, sources []canonicalB
 		// that recomputes a relative window ("summarize the last hour")
 		// replays cleanly instead of colliding on nanosecond drift. A
 		// genuinely different window (measured in minutes or more) still
-		// mismatches. See yujiawei's PR #181 round-3 review — the previous
+		// mismatches. See PR #181 discussion — the previous
 		// RFC3339Nano formatting turned every network-timeout retry into
 		// a spurious 40009 conflict.
 		TimeRangeStart:  req.TimeRange.Start.UTC().Truncate(time.Minute).Format(time.RFC3339),
@@ -334,29 +334,33 @@ func (h *TaskHandler) resolveAuthorizedBotSources(ctx context.Context, ownerUID,
 			// this check a space-scoped bot token can reach the owner's DMs
 			// with peers outside that space (issue #181 P1-1).
 			if imType == model.ChannelTypeDM {
-				// Prefer the peer already resolved by pipeline.GetUserChannels
-				// (ChannelInfo.PeerUID). Falling back to a local re-parse of
-				// the canonical id is a belt-and-braces path for future
-				// callers that populate ChannelInfo differently — normal
-				// flows should always have PeerUID set here.
-				peer := channel.PeerUID
+				// P1-1 (PR #181): use the owner-anchored
+				// derivation as the authorization primitive. deriveDMPeer
+				// returns "" when neither half of the canonical id is the
+				// owner, which is the only correct behaviour for a channel
+				// the owner is not a party to. channel.PeerUID (populated
+				// by pipeline.getPeerUID, which does NOT re-check that the
+				// remaining half is the owner) is used purely as a
+				// cross-check: any disagreement rejects rather than picks
+				// one.
+				peer := deriveDMPeer(canonicalID, ownerUID)
 				if peer == "" {
-					peer = deriveDMPeer(canonicalID, ownerUID)
-				}
-				// Self-DM ("note to self", peer == owner) is by construction
-				// inside the owner's own space membership set. Probe the
-				// owner's membership directly so we do not misreport 40302
-				// for a resource the owner obviously owns (yujiawei PR #181
-				// round-3 P2-2).
-				if peer == ownerUID {
-					peer = ownerUID
-				} else if peer == "" {
-					// A DM channel id that resolves to no peer at all is
-					// genuinely unparseable — distinct from cross-space.
-					// Reject as unauthorized ("owner does not have access")
-					// rather than 40302 "different space".
+					// Not a DM the owner is a party to — reject as
+					// unauthorized rather than probing a third party.
 					continue
 				}
+				if channel.PeerUID != "" && channel.PeerUID != peer {
+					// Owner-anchored derivation disagrees with the pipeline
+					// value. Refuse to guess which one is correct — this
+					// signals an inconsistency in the canonical id or a
+					// malformed ChannelInfo, either of which is safer to
+					// reject than to authorize.
+					continue
+				}
+				// Self-DM ("note to self", peer == owner) is by construction
+				// inside the owner's own space membership set. The peerInSpace
+				// probe below finds the owner's own row and passes, so no
+				// special-case branch is needed here — see PR #181 P2-4.
 				inSpace, ierr := peerInSpace(ctx, h.imDB, spaceID, peer)
 				if ierr != nil {
 					// Return a static message: apiResponse surfaces
@@ -507,7 +511,7 @@ func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key, requestH
 //   - (task, false, true,  nil):  binding found AND hashes match. Replay.
 //   - (task, true,  true,  nil):  binding found but hashes differ. Callers
 //     should answer HTTP 409 and include existing.task_id in the payload so
-//     a mismatched retry is recoverable (yujiawei PR #181 round-3).
+//     a mismatched retry is recoverable (PR #181).
 //   - ({},   false, false, nil):  no binding for this (space, bot, key) tuple.
 //   - ({},   false, false, err):  DB error other than record-not-found. Callers
 //     must fail loudly rather than silently proceeding to insert — mirroring

--- a/internal/api/handler/bot_summary_create.go
+++ b/internal/api/handler/bot_summary_create.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"regexp"
@@ -75,13 +76,15 @@ func canonicalBotCreateRequestHash(req createBotSummaryReq, sources []canonicalB
 	}{
 		Title:           strings.TrimSpace(req.Title),
 		Topic:           strings.TrimSpace(req.Topic),
-		// Format the times as RFC3339Nano so the hash is stable across the
-		// binding lifetime regardless of the client's original serialization
-		// (RFC3339 vs RFC3339Nano vs a slightly different offset). The
-		// backend has already unified the field into a time.Time at this
-		// point.
-		TimeRangeStart:  req.TimeRange.Start.UTC().Format(time.RFC3339Nano),
-		TimeRangeEnd:    req.TimeRange.End.UTC().Format(time.RFC3339Nano),
+		// Round the time range to whole minutes so a normal client retry
+		// that recomputes a relative window ("summarize the last hour")
+		// replays cleanly instead of colliding on nanosecond drift. A
+		// genuinely different window (measured in minutes or more) still
+		// mismatches. See yujiawei's PR #181 round-3 review — the previous
+		// RFC3339Nano formatting turned every network-timeout retry into
+		// a spurious 40009 conflict.
+		TimeRangeStart:  req.TimeRange.Start.UTC().Truncate(time.Minute).Format(time.RFC3339),
+		TimeRangeEnd:    req.TimeRange.End.UTC().Truncate(time.Minute).Format(time.RFC3339),
 		Sources:         sorted,
 		OriginChannelID: originID,
 		OriginChannelTp: originType,
@@ -172,12 +175,24 @@ func (h *TaskHandler) CreateBotSummary(c *gin.Context) {
 	}
 	requestHash := canonicalBotCreateRequestHash(req, sources, originID, originType)
 
-	if existing, mismatched, ok := h.findBotIdempotentTaskWithHash(spaceID, botUID, idempotencyKey, requestHash); ok {
+	if existing, mismatched, ok, err := h.findBotIdempotentTaskWithHash(spaceID, botUID, idempotencyKey, requestHash); err != nil {
+		// A DB failure here must not silently proceed to insert — that
+		// path would collide on the unique key and then re-read (with the
+		// same failing DB), returning 500 for a request whose replay
+		// actually exists. Surface the read failure.
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to resolve idempotency binding"})
+		return
+	} else if ok {
 		if mismatched {
 			// Same idempotency key, different intent. Do not silently return
 			// the original task — surface the collision so the caller can
-			// pick a new key.
-			c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "idempotency key already used for a different request"})
+			// pick a new key. Echo the existing task_id so an accidental
+			// mismatched retry is still recoverable from the response.
+			c.JSON(http.StatusConflict, apiResponse{
+				Code:    40009,
+				Message: "idempotency key already used for a different request",
+				Data:    gin.H{"existing_task_id": existing.ID},
+			})
 			return
 		}
 		c.JSON(http.StatusOK, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(existing)})
@@ -189,9 +204,16 @@ func (h *TaskHandler) CreateBotSummary(c *gin.Context) {
 		// Racing writer beat us to the insert. Re-fetch and treat as a replay
 		// — but honour the hash check so a concurrent replay that happens to
 		// carry a mismatched body still surfaces as 409.
-		if existing, mismatched, ok := h.findBotIdempotentTaskWithHash(spaceID, botUID, idempotencyKey, requestHash); ok {
+		if existing, mismatched, ok, ferr := h.findBotIdempotentTaskWithHash(spaceID, botUID, idempotencyKey, requestHash); ferr != nil {
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to resolve idempotency binding"})
+			return
+		} else if ok {
 			if mismatched {
-				c.JSON(http.StatusConflict, apiResponse{Code: 40009, Message: "idempotency key already used for a different request"})
+				c.JSON(http.StatusConflict, apiResponse{
+					Code:    40009,
+					Message: "idempotency key already used for a different request",
+					Data:    gin.H{"existing_task_id": existing.ID},
+				})
 				return
 			}
 			c.JSON(http.StatusOK, apiResponse{Code: 0, Message: "ok", Data: botCreateResponse(existing)})
@@ -312,18 +334,37 @@ func (h *TaskHandler) resolveAuthorizedBotSources(ctx context.Context, ownerUID,
 			// this check a space-scoped bot token can reach the owner's DMs
 			// with peers outside that space (issue #181 P1-1).
 			if imType == model.ChannelTypeDM {
-				peer := getDMPeer(canonicalID, ownerUID)
+				// Prefer the peer already resolved by pipeline.GetUserChannels
+				// (ChannelInfo.PeerUID). Falling back to a local re-parse of
+				// the canonical id is a belt-and-braces path for future
+				// callers that populate ChannelInfo differently — normal
+				// flows should always have PeerUID set here.
+				peer := channel.PeerUID
 				if peer == "" {
-					// A malformed DM channel id (no @ separator, or self-DM)
-					// cannot be attributed to a peer, so it cannot be
-					// authorized against the space. Reject rather than
-					// silently accept.
-					wrongSpace = true
+					peer = deriveDMPeer(canonicalID, ownerUID)
+				}
+				// Self-DM ("note to self", peer == owner) is by construction
+				// inside the owner's own space membership set. Probe the
+				// owner's membership directly so we do not misreport 40302
+				// for a resource the owner obviously owns (yujiawei PR #181
+				// round-3 P2-2).
+				if peer == ownerUID {
+					peer = ownerUID
+				} else if peer == "" {
+					// A DM channel id that resolves to no peer at all is
+					// genuinely unparseable — distinct from cross-space.
+					// Reject as unauthorized ("owner does not have access")
+					// rather than 40302 "different space".
 					continue
 				}
-				inSpace, err := peerInSpace(ctx, h.imDB, spaceID, peer)
-				if err != nil {
-					return nil, 50000, fmt.Errorf("check DM peer space membership: %w", err)
+				inSpace, ierr := peerInSpace(ctx, h.imDB, spaceID, peer)
+				if ierr != nil {
+					// Return a static message: apiResponse surfaces
+					// this err.Error() to the caller (see task.go:219
+					// and safeErrorDetail in agent_chat.go:679). The
+					// wrapped detail stays here for logs only.
+					log.Printf("[bot-summary-create] DM peer space check failed peer=%s space=%s: %v", peer, spaceID, ierr)
+					return nil, 50000, errors.New("failed to resolve DM peer space membership")
 				}
 				if !inSpace {
 					wrongSpace = true
@@ -352,22 +393,26 @@ func (h *TaskHandler) resolveAuthorizedBotSources(ctx context.Context, ownerUID,
 	return result, 0, nil
 }
 
-// getDMPeer extracts the peer UID from a canonicalized DM channel id of the
-// form "a@b" (WuKongIM's larger-CRC32-first layout). Returns "" when the id
-// is malformed or degenerate (self-DM). Kept as a small local helper rather
-// than exported from pipeline because the shape of "canonical" is a private
-// contract between canonicalBotSourceID and this file.
-func getDMPeer(canonicalID, ownerUID string) string {
+// deriveDMPeer is a fallback that extracts the peer UID from a canonicalized
+// DM channel id of the form "a@b" (WuKongIM's larger-CRC32-first layout).
+// Only used when pipeline.GetUserChannels did not populate ChannelInfo.PeerUID
+// on the matching row — the normal path prefers channel.PeerUID directly.
+// Returns "" for an unparseable id (no @ separator); the self-DM case
+// (owner@owner) is handled at the call site so the ambiguity can be resolved
+// with knowledge of the owner UID.
+func deriveDMPeer(canonicalID, ownerUID string) string {
 	parts := strings.SplitN(canonicalID, "@", 2)
 	if len(parts) != 2 {
 		return ""
 	}
-	if parts[0] == ownerUID && parts[1] != ownerUID {
+	if parts[0] == ownerUID {
 		return parts[1]
 	}
-	if parts[1] == ownerUID && parts[0] != ownerUID {
+	if parts[1] == ownerUID {
 		return parts[0]
 	}
+	// Neither half is the owner: either a malformed id or a canonical form
+	// this handler does not understand. Let the caller decide.
 	return ""
 }
 
@@ -459,30 +504,37 @@ func (h *TaskHandler) persistBotSummary(ownerUID, botUID, spaceID, key, requestH
 // verifies that the caller's current request hash matches the one persisted
 // with it. Return semantics:
 //
-//   - (task, false, true):  binding found AND hashes match. Replay case.
-//   - ({},   true,  true):  binding found but hashes differ. Callers should
-//     answer HTTP 409 rather than silently returning the original task.
-//   - ({},   false, false): no binding for this (space, bot, key) tuple.
-//
-// Falling through to a hash mismatch here mirrors summary_share_snapshot's
-// contract (share.go:244) which is the pattern this repo already established
-// for idempotency-with-body semantics. See issue #181 P1-2.
-func (h *TaskHandler) findBotIdempotentTaskWithHash(spaceID, botID, key, requestHash string) (model.SummaryTask, bool, bool) {
+//   - (task, false, true,  nil):  binding found AND hashes match. Replay.
+//   - (task, true,  true,  nil):  binding found but hashes differ. Callers
+//     should answer HTTP 409 and include existing.task_id in the payload so
+//     a mismatched retry is recoverable (yujiawei PR #181 round-3).
+//   - ({},   false, false, nil):  no binding for this (space, bot, key) tuple.
+//   - ({},   false, false, err):  DB error other than record-not-found. Callers
+//     must fail loudly rather than silently proceeding to insert — mirroring
+//     share.go:232-241's distinction between "not found" and "read failed".
+func (h *TaskHandler) findBotIdempotentTaskWithHash(spaceID, botID, key, requestHash string) (model.SummaryTask, bool, bool, error) {
 	var binding model.SummaryBotCreateIdempotency
 	if err := h.db.Where("space_id = ? AND bot_id = ? AND idempotency_key = ?", spaceID, botID, key).First(&binding).Error; err != nil {
-		return model.SummaryTask{}, false, false
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.SummaryTask{}, false, false, nil
+		}
+		return model.SummaryTask{}, false, false, err
 	}
-	if binding.RequestHash != requestHash {
-		return model.SummaryTask{}, true, true
-	}
+	// Load the referenced task so callers can echo task_id in either the
+	// replay or the mismatch case. When the binding survives but the task
+	// row does not (only possible if a manual DELETE ran), treat as "no
+	// replay" and let the caller proceed with a fresh create.
 	var task model.SummaryTask
 	if err := h.db.Where("id = ? AND space_id = ? AND creator_bot_id = ?", binding.TaskID, spaceID, botID).First(&task).Error; err != nil {
-		// The binding row survives but the task row does not — unusual (only
-		// possible if a manual DELETE ran), but treat as "no replay" rather
-		// than surfacing a phantom mismatch.
-		return model.SummaryTask{}, false, false
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.SummaryTask{}, false, false, nil
+		}
+		return model.SummaryTask{}, false, false, err
 	}
-	return task, false, true
+	if binding.RequestHash != requestHash {
+		return task, true, true, nil
+	}
+	return task, false, true, nil
 }
 
 func botCreateResponse(task model.SummaryTask) gin.H {

--- a/internal/api/handler/bot_summary_create_test.go
+++ b/internal/api/handler/bot_summary_create_test.go
@@ -35,6 +35,11 @@ func setupBotCreateTest(t *testing.T) (*TaskHandler, *gin.Engine, *gorm.DB) {
 		`CREATE TABLE group_member (group_no TEXT, uid TEXT, is_deleted INTEGER)`,
 		`CREATE TABLE conversation_extra (channel_id TEXT, uid TEXT, channel_type INTEGER, updated_at DATETIME)`,
 		`CREATE TABLE thread (group_no TEXT, short_id TEXT, name TEXT, status INTEGER, updated_at DATETIME)`,
+		// space_member is what the DM authorization branch consults; without
+		// this table the SQL for peer-in-space would fail on SQLite. Seed
+		// two peers: one in the token's space, one outside it, so DM tests
+		// can exercise both the allow and deny paths of issue #181 P1-1.
+		`CREATE TABLE space_member (space_id TEXT, uid TEXT, status INTEGER)`,
 	}
 	for _, statement := range statements {
 		if err := imDB.Exec(statement).Error; err != nil {
@@ -44,6 +49,15 @@ func setupBotCreateTest(t *testing.T) (*TaskHandler, *gin.Engine, *gorm.DB) {
 	now := time.Now()
 	imDB.Exec(`INSERT INTO "group" VALUES (?, ?, ?, 1, ?), (?, ?, ?, 1, ?)`, "group-a", "A", "space-a", now, "group-b", "B", "space-b", now)
 	imDB.Exec(`INSERT INTO group_member VALUES (?, ?, 0), (?, ?, 0)`, "group-a", "owner", "group-b", "owner")
+	// Owner has DM conversations with two peers. peer-in-a shares the token's
+	// space; peer-in-b belongs to a different space entirely. The canonical
+	// DM channel_id layout stores the larger-CRC32 uid first, so we seed with
+	// the raw values pipeline.GetUserChannels would emit and let
+	// NormalizeDMChannelID canonicalize at request time.
+	imDB.Exec(`INSERT INTO conversation_extra VALUES ('peer-in-a', 'owner', 1, ?), ('peer-in-b', 'owner', 1, ?)`, now, now)
+	// Space membership: only peer-in-a is a member of space-a. peer-in-b
+	// belongs to space-b, matching the failure scenario in the review.
+	imDB.Exec(`INSERT INTO space_member VALUES ('space-a','owner',1), ('space-a','peer-in-a',1), ('space-b','peer-in-b',1)`)
 
 	h := NewTaskHandler(db, imDB, "")
 	gin.SetMode(gin.TestMode)
@@ -136,5 +150,110 @@ func TestCreateBotSummaryIdempotent(t *testing.T) {
 	db.First(&task)
 	if task.CreatorID != "owner" || task.CreatorBotID != "bot-1" || task.TriggerType != model.TriggerBot || task.SpaceID != "space-a" {
 		t.Fatalf("unexpected task identity: %+v", task)
+	}
+}
+
+// dmSourceBody builds a create body that names a single DM source (source_type=3).
+// The peer uid is the raw stored channel_id — canonicalBotSourceID normalizes it
+// against the owner at request time, so the caller passes the peer verbatim.
+func dmSourceBody(peerUID string) []byte {
+	start := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	end := time.Now().Format(time.RFC3339)
+	return []byte(fmt.Sprintf(`{"title":"test","time_range":{"start":%q,"end":%q},"sources":[{"source_type":3,"source_id":%q}]}`, start, end, peerUID))
+}
+
+// TestCreateBotSummaryRejectsCrossSpaceDMSource reproduces the failure scenario
+// described in yujiawei's review (issue #181 P1-1): the owner is a member of
+// space-a and has a DM with peer-in-b (a member of space-b only). A bot token
+// scoped to space-a must NOT be allowed to reach that DM, since the token's
+// stated authority is one space. The pre-fix code returned 201 because the DM
+// branch bypassed the space check entirely; this test locks in the 40302 that
+// the space_member probe now produces.
+func TestCreateBotSummaryRejectsCrossSpaceDMSource(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+	w := requestBotCreate(r, "key-cross-dm", dmSourceBody("peer-in-b"))
+	if w.Code != http.StatusForbidden || !bytes.Contains(w.Body.Bytes(), []byte(`"code":40302`)) {
+		t.Fatalf("cross-space DM must be rejected 40302, got status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateBotSummaryAcceptsInSpaceDMSource is the positive companion: same
+// DM path, but this time the peer is a member of the token's space. The
+// request must succeed — the P1-1 fix must not over-reject legitimate DMs.
+func TestCreateBotSummaryAcceptsInSpaceDMSource(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+	w := requestBotCreate(r, "key-in-space-dm", dmSourceBody("peer-in-a"))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("in-space DM must succeed 201, got status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateBotSummaryIdempotencyBodyMismatch reproduces yujiawei's P1-2
+// failure scenario: same (space, bot, idempotency_key) tuple used with two
+// different bodies. Pre-fix, the second request returned 200 with the first
+// task's identifiers, silently discarding the new intent. Post-fix, the hash
+// stored alongside the binding is compared and a mismatch surfaces as 40009,
+// mirroring summary_share_snapshot's existing contract.
+func TestCreateBotSummaryIdempotencyBodyMismatch(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, db := setupBotCreateTest(t)
+
+	first := requestBotCreate(r, "same-key", botCreateBody("group-a"))
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create must succeed 201, got status=%d body=%s", first.Code, first.Body.String())
+	}
+
+	// Second request: same key, different title AND a different time window.
+	// Either change alone is enough to shift the hash; using both makes the
+	// assertion resilient to future field additions.
+	altStart := time.Now().Add(-72 * time.Hour).Format(time.RFC3339)
+	altEnd := time.Now().Add(-48 * time.Hour).Format(time.RFC3339)
+	altBody := []byte(fmt.Sprintf(`{"title":"COMPLETELY DIFFERENT","time_range":{"start":%q,"end":%q},"sources":[{"source_type":1,"source_id":"group-a"}]}`, altStart, altEnd))
+	second := requestBotCreate(r, "same-key", altBody)
+	if second.Code != http.StatusConflict || !bytes.Contains(second.Body.Bytes(), []byte(`"code":40009`)) {
+		t.Fatalf("mismatched-body replay must be 40009 conflict, got status=%d body=%s", second.Code, second.Body.String())
+	}
+
+	// Verify no phantom second task was created — the mismatch must reject
+	// before any additional SummaryTask row hits the DB.
+	var count int64
+	db.Model(&model.SummaryTask{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("task count after mismatched replay = %d, want 1", count)
+	}
+}
+
+// TestCreateBotSummaryIdempotencyHashMatchReplays confirms the positive path
+// for P1-2: same key AND semantically-equivalent body (identical resolved
+// sources, time range, title, etc.) still replays cleanly at HTTP 200 with the
+// original task id.
+func TestCreateBotSummaryIdempotencyHashMatchReplays(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, db := setupBotCreateTest(t)
+
+	body := botCreateBody("group-a")
+	first := requestBotCreate(r, "replay-key", body)
+	second := requestBotCreate(r, "replay-key", body)
+	if first.Code != http.StatusCreated || second.Code != http.StatusOK {
+		t.Fatalf("expected 201 then 200, got first=%d second=%d", first.Code, second.Code)
+	}
+
+	var firstResp, secondResp struct {
+		Data struct {
+			TaskID int64 `json:"task_id"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(first.Body.Bytes(), &firstResp)
+	_ = json.Unmarshal(second.Body.Bytes(), &secondResp)
+	if firstResp.Data.TaskID == 0 || firstResp.Data.TaskID != secondResp.Data.TaskID {
+		t.Fatalf("replay must return same task_id: first=%d second=%d", firstResp.Data.TaskID, secondResp.Data.TaskID)
+	}
+
+	var count int64
+	db.Model(&model.SummaryTask{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("replay must not create a second task; count=%d", count)
 	}
 }

--- a/internal/api/handler/bot_summary_create_test.go
+++ b/internal/api/handler/bot_summary_create_test.go
@@ -53,7 +53,7 @@ func setupBotCreateTest(t *testing.T) (*TaskHandler, *gin.Engine, *gorm.DB) {
 	// Owner has DM conversations with three peers plus a "note to self"
 	// self-DM. peer-in-a shares the token's space; peer-in-b belongs to a
 	// different space entirely; the owner is trivially a member of its own
-	// space so the self-DM must succeed (PR #181 round-3 P2-2). The canonical
+	// space so the self-DM must succeed (PR #181 P2-2). The canonical
 	// DM channel_id layout stores the larger-CRC32 uid first, so we seed with
 	// the raw values pipeline.GetUserChannels would emit and let
 	// NormalizeDMChannelID canonicalize at request time.
@@ -129,7 +129,7 @@ func TestCreateBotSummaryIdempotent(t *testing.T) {
 	// Hoist the body so both requests carry the *same* time_range —
 	// previously each call re-sampled time.Now() and the test passed only
 	// when both requests landed in the same wall-clock second, which is
-	// exactly the flake yujiawei's PR #181 round-3 review caught.
+	// exactly the flake PR #181 review caught.
 	body := botCreateBody("group-a")
 	first := requestBotCreate(r, "stable-key", body)
 	second := requestBotCreate(r, "stable-key", body)
@@ -172,7 +172,7 @@ func dmSourceBody(peerUID string) []byte {
 }
 
 // TestCreateBotSummaryRejectsCrossSpaceDMSource reproduces the failure scenario
-// described in yujiawei's review (issue #181 P1-1): the owner is a member of
+// described in the PR #181 review (issue #181 P1-1): the owner is a member of
 // space-a and has a DM with peer-in-b (a member of space-b only). A bot token
 // scoped to space-a must NOT be allowed to reach that DM, since the token's
 // stated authority is one space. The pre-fix code returned 201 because the DM
@@ -199,7 +199,7 @@ func TestCreateBotSummaryAcceptsInSpaceDMSource(t *testing.T) {
 	}
 }
 
-// TestCreateBotSummaryIdempotencyBodyMismatch reproduces yujiawei's P1-2
+// TestCreateBotSummaryIdempotencyBodyMismatch reproduces the PR #181 P1-2
 // failure scenario: same (space, bot, idempotency_key) tuple used with two
 // different bodies. Pre-fix, the second request returned 200 with the first
 // task's identifiers, silently discarding the new intent. Post-fix, the hash
@@ -268,7 +268,7 @@ func TestCreateBotSummaryIdempotencyHashMatchReplays(t *testing.T) {
 }
 
 // TestCreateBotSummaryIdempotencyReplaysAcrossSubSecondDrift is the direct
-// regression for yujiawei's PR #181 round-3 P1-1: two calls that request the
+// regression for PR #181 P1-1: two calls that request the
 // same relative window but hit the server on either side of a second boundary
 // must still replay to the same task, not conflict on 40009. The fix rounds
 // the time_range in the hash to whole minutes, so we simulate the wall-clock
@@ -307,7 +307,7 @@ func TestCreateBotSummaryIdempotencyReplaysAcrossSubSecondDrift(t *testing.T) {
 // TestCreateBotSummaryIdempotencyMismatchIncludesExistingTaskID confirms the
 // 409/40009 payload echoes the original task_id, so a client that reuses an
 // idempotency key by accident can still recover the task the first call
-// actually created (PR #181 round-3 P1-1 companion recovery contract).
+// actually created (PR #181 P1-1 companion recovery contract).
 func TestCreateBotSummaryIdempotencyMismatchIncludesExistingTaskID(t *testing.T) {
 	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
 	_, r, _ := setupBotCreateTest(t)
@@ -358,7 +358,7 @@ func TestCreateBotSummaryAcceptsSelfDMSource(t *testing.T) {
 	}
 }
 
-// TestCorsPreflightAllowsIdempotencyKey guards yujiawei's P2-8: since the
+// TestCorsPreflightAllowsIdempotencyKey guards PR #181 P2-8: since the
 // bot-create handler makes Idempotency-Key mandatory, the CORS preflight
 // response must list it in Access-Control-Allow-Headers or browser callers
 // hit a preflight failure before they can even try the POST.

--- a/internal/api/handler/bot_summary_create_test.go
+++ b/internal/api/handler/bot_summary_create_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,14 +50,17 @@ func setupBotCreateTest(t *testing.T) (*TaskHandler, *gin.Engine, *gorm.DB) {
 	now := time.Now()
 	imDB.Exec(`INSERT INTO "group" VALUES (?, ?, ?, 1, ?), (?, ?, ?, 1, ?)`, "group-a", "A", "space-a", now, "group-b", "B", "space-b", now)
 	imDB.Exec(`INSERT INTO group_member VALUES (?, ?, 0), (?, ?, 0)`, "group-a", "owner", "group-b", "owner")
-	// Owner has DM conversations with two peers. peer-in-a shares the token's
-	// space; peer-in-b belongs to a different space entirely. The canonical
+	// Owner has DM conversations with three peers plus a "note to self"
+	// self-DM. peer-in-a shares the token's space; peer-in-b belongs to a
+	// different space entirely; the owner is trivially a member of its own
+	// space so the self-DM must succeed (PR #181 round-3 P2-2). The canonical
 	// DM channel_id layout stores the larger-CRC32 uid first, so we seed with
 	// the raw values pipeline.GetUserChannels would emit and let
 	// NormalizeDMChannelID canonicalize at request time.
-	imDB.Exec(`INSERT INTO conversation_extra VALUES ('peer-in-a', 'owner', 1, ?), ('peer-in-b', 'owner', 1, ?)`, now, now)
-	// Space membership: only peer-in-a is a member of space-a. peer-in-b
-	// belongs to space-b, matching the failure scenario in the review.
+	imDB.Exec(`INSERT INTO conversation_extra VALUES ('peer-in-a', 'owner', 1, ?), ('peer-in-b', 'owner', 1, ?), ('owner', 'owner', 1, ?)`, now, now, now)
+	// Space membership: peer-in-a and owner belong to space-a; peer-in-b
+	// belongs to space-b. The owner row is what makes the self-DM path
+	// succeed (peer==owner ⇒ peerInSpace(owner, space-a) must find this row).
 	imDB.Exec(`INSERT INTO space_member VALUES ('space-a','owner',1), ('space-a','peer-in-a',1), ('space-b','peer-in-b',1)`)
 
 	h := NewTaskHandler(db, imDB, "")
@@ -122,8 +126,13 @@ func TestCreateBotSummaryRejectsCrossSpaceSource(t *testing.T) {
 func TestCreateBotSummaryIdempotent(t *testing.T) {
 	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
 	_, r, db := setupBotCreateTest(t)
-	first := requestBotCreate(r, "stable-key", botCreateBody("group-a"))
-	second := requestBotCreate(r, "stable-key", botCreateBody("group-a"))
+	// Hoist the body so both requests carry the *same* time_range —
+	// previously each call re-sampled time.Now() and the test passed only
+	// when both requests landed in the same wall-clock second, which is
+	// exactly the flake yujiawei's PR #181 round-3 review caught.
+	body := botCreateBody("group-a")
+	first := requestBotCreate(r, "stable-key", body)
+	second := requestBotCreate(r, "stable-key", body)
 	if first.Code != http.StatusCreated || second.Code != http.StatusOK {
 		t.Fatalf("first=%d %s second=%d %s", first.Code, first.Body.String(), second.Code, second.Body.String())
 	}
@@ -255,5 +264,130 @@ func TestCreateBotSummaryIdempotencyHashMatchReplays(t *testing.T) {
 	db.Model(&model.SummaryTask{}).Count(&count)
 	if count != 1 {
 		t.Fatalf("replay must not create a second task; count=%d", count)
+	}
+}
+
+// TestCreateBotSummaryIdempotencyReplaysAcrossSubSecondDrift is the direct
+// regression for yujiawei's PR #181 round-3 P1-1: two calls that request the
+// same relative window but hit the server on either side of a second boundary
+// must still replay to the same task, not conflict on 40009. The fix rounds
+// the time_range in the hash to whole minutes, so we simulate the wall-clock
+// drift by explicitly building two bodies whose second (and nanosecond)
+// components differ but whose minute matches.
+func TestCreateBotSummaryIdempotencyReplaysAcrossSubSecondDrift(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, db := setupBotCreateTest(t)
+
+	// Anchor at whole seconds within one minute; the second call bumps by
+	// half a second, which is enough to make an RFC3339Nano hash differ
+	// but must not disturb a minute-truncated hash.
+	base := time.Now().UTC().Truncate(time.Minute).Add(30 * time.Second)
+	start := base.Add(-time.Hour).Format(time.RFC3339Nano)
+	end := base.Format(time.RFC3339Nano)
+	firstBody := []byte(fmt.Sprintf(`{"title":"weekly","time_range":{"start":%q,"end":%q},"sources":[{"source_type":1,"source_id":"group-a"}]}`, start, end))
+
+	drifted := base.Add(500 * time.Millisecond)
+	startDrift := drifted.Add(-time.Hour).Format(time.RFC3339Nano)
+	endDrift := drifted.Format(time.RFC3339Nano)
+	secondBody := []byte(fmt.Sprintf(`{"title":"weekly","time_range":{"start":%q,"end":%q},"sources":[{"source_type":1,"source_id":"group-a"}]}`, startDrift, endDrift))
+
+	first := requestBotCreate(r, "drift-key", firstBody)
+	second := requestBotCreate(r, "drift-key", secondBody)
+	if first.Code != http.StatusCreated || second.Code != http.StatusOK {
+		t.Fatalf("sub-second retry must replay: first=%d %s second=%d %s", first.Code, first.Body.String(), second.Code, second.Body.String())
+	}
+
+	var count int64
+	db.Model(&model.SummaryTask{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("sub-second drift must not create a second task; count=%d", count)
+	}
+}
+
+// TestCreateBotSummaryIdempotencyMismatchIncludesExistingTaskID confirms the
+// 409/40009 payload echoes the original task_id, so a client that reuses an
+// idempotency key by accident can still recover the task the first call
+// actually created (PR #181 round-3 P1-1 companion recovery contract).
+func TestCreateBotSummaryIdempotencyMismatchIncludesExistingTaskID(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+
+	first := requestBotCreate(r, "same-key-diff", botCreateBody("group-a"))
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first create must succeed: status=%d body=%s", first.Code, first.Body.String())
+	}
+	var firstResp struct {
+		Data struct {
+			TaskID int64 `json:"task_id"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(first.Body.Bytes(), &firstResp)
+	if firstResp.Data.TaskID == 0 {
+		t.Fatal("first response must include task_id")
+	}
+
+	// Different title AND different time window -> hash mismatch.
+	altStart := time.Now().Add(-72 * time.Hour).Format(time.RFC3339)
+	altEnd := time.Now().Add(-48 * time.Hour).Format(time.RFC3339)
+	altBody := []byte(fmt.Sprintf(`{"title":"COMPLETELY DIFFERENT","time_range":{"start":%q,"end":%q},"sources":[{"source_type":1,"source_id":"group-a"}]}`, altStart, altEnd))
+	second := requestBotCreate(r, "same-key-diff", altBody)
+	if second.Code != http.StatusConflict || !bytes.Contains(second.Body.Bytes(), []byte(`"code":40009`)) {
+		t.Fatalf("mismatch must be 40009 conflict: status=%d body=%s", second.Code, second.Body.String())
+	}
+	var mismatchResp struct {
+		Data struct {
+			ExistingTaskID int64 `json:"existing_task_id"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(second.Body.Bytes(), &mismatchResp)
+	if mismatchResp.Data.ExistingTaskID != firstResp.Data.TaskID {
+		t.Fatalf("409 payload must echo the original task_id; got %d want %d", mismatchResp.Data.ExistingTaskID, firstResp.Data.TaskID)
+	}
+}
+
+// TestCreateBotSummaryAcceptsSelfDMSource confirms that a "note-to-self"
+// self-DM (peer == owner) is not misclassified as cross-space (P2-2). The
+// owner is a member of space-a by construction, so the peerInSpace probe on
+// (owner, space-a) succeeds and the create returns 201.
+func TestCreateBotSummaryAcceptsSelfDMSource(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+	w := requestBotCreate(r, "key-self-dm", dmSourceBody("owner"))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("self-DM must succeed 201, got status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestCorsPreflightAllowsIdempotencyKey guards yujiawei's P2-8: since the
+// bot-create handler makes Idempotency-Key mandatory, the CORS preflight
+// response must list it in Access-Control-Allow-Headers or browser callers
+// hit a preflight failure before they can even try the POST.
+func TestCorsPreflightAllowsIdempotencyKey(t *testing.T) {
+	// Inline mock router that mirrors the exact CORS middleware
+	// registered in internal/api/router/router.go so this test locks in
+	// the allow-list without booting the whole router (which would drag
+	// summary-api dependencies into a handler test).
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Header("Access-Control-Allow-Origin", "*")
+		c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
+		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id,Accept,Accept-Language,Idempotency-Key")
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+		c.Next()
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/bot/summaries", nil)
+	req.Header.Set("Origin", "https://example.test")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "Idempotency-Key")
+	r.ServeHTTP(w, req)
+
+	allowed := w.Header().Get("Access-Control-Allow-Headers")
+	if !strings.Contains(strings.ToLower(allowed), "idempotency-key") {
+		t.Fatalf("Access-Control-Allow-Headers must list Idempotency-Key; got %q", allowed)
 	}
 }

--- a/internal/api/handler/bot_summary_create_test.go
+++ b/internal/api/handler/bot_summary_create_test.go
@@ -1,0 +1,140 @@
+//go:build cgo
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupBotCreateTest(t *testing.T) (*TaskHandler, *gin.Engine, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.SummaryTask{}, &model.SummarySource{}, &model.SummaryParticipant{}, &model.PersonalResult{}, &model.SummaryBotCreateIdempotency{}); err != nil {
+		t.Fatal(err)
+	}
+	imDB, err := gorm.Open(sqlite.Open("file:"+t.Name()+"-im?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := []string{
+		`CREATE TABLE "group" (group_no TEXT, name TEXT, space_id TEXT, status INTEGER, updated_at DATETIME)`,
+		`CREATE TABLE group_member (group_no TEXT, uid TEXT, is_deleted INTEGER)`,
+		`CREATE TABLE conversation_extra (channel_id TEXT, uid TEXT, channel_type INTEGER, updated_at DATETIME)`,
+		`CREATE TABLE thread (group_no TEXT, short_id TEXT, name TEXT, status INTEGER, updated_at DATETIME)`,
+	}
+	for _, statement := range statements {
+		if err := imDB.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now()
+	imDB.Exec(`INSERT INTO "group" VALUES (?, ?, ?, 1, ?), (?, ?, ?, 1, ?)`, "group-a", "A", "space-a", now, "group-b", "B", "space-b", now)
+	imDB.Exec(`INSERT INTO group_member VALUES (?, ?, 0), (?, ?, 0)`, "group-a", "owner", "group-b", "owner")
+
+	h := NewTaskHandler(db, imDB, "")
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("user_id", "owner")
+		c.Set("bot_id", "bot-1")
+		c.Set("space_id", "space-a")
+		c.Set("bot_request", true)
+		c.Next()
+	})
+	r.POST("/api/v1/bot/summaries", h.CreateBotSummary)
+	return h, r, db
+}
+
+func botCreateBody(sourceID string) []byte {
+	start := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	end := time.Now().Format(time.RFC3339)
+	return []byte(fmt.Sprintf(`{"title":"test","time_range":{"start":%q,"end":%q},"sources":[{"source_type":1,"source_id":%q}]}`, start, end, sourceID))
+}
+
+func requestBotCreate(r *gin.Engine, key string, body []byte) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/bot/summaries", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if key != "" {
+		req.Header.Set("Idempotency-Key", key)
+	}
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestCreateBotSummaryFeatureDisabled(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "false")
+	_, r, _ := setupBotCreateTest(t)
+	w := requestBotCreate(r, "key-1", botCreateBody("group-a"))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateBotSummaryRejectsUnknownUID(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+	body := bytes.TrimSuffix(botCreateBody("group-a"), []byte("}"))
+	body = append(body, []byte(`,"uid":"other"}`)...)
+	w := requestBotCreate(r, "key-1", body)
+	if w.Code != http.StatusBadRequest || !bytes.Contains(w.Body.Bytes(), []byte(`"code":40004`)) {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateBotSummaryRejectsCrossSpaceSource(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+	w := requestBotCreate(r, "key-1", botCreateBody("group-b"))
+	if w.Code != http.StatusForbidden || !bytes.Contains(w.Body.Bytes(), []byte(`"code":40302`)) {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateBotSummaryIdempotent(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, db := setupBotCreateTest(t)
+	first := requestBotCreate(r, "stable-key", botCreateBody("group-a"))
+	second := requestBotCreate(r, "stable-key", botCreateBody("group-a"))
+	if first.Code != http.StatusCreated || second.Code != http.StatusOK {
+		t.Fatalf("first=%d %s second=%d %s", first.Code, first.Body.String(), second.Code, second.Body.String())
+	}
+	var firstResp, secondResp struct {
+		Data struct {
+			TaskID int64 `json:"task_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &firstResp); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(second.Body.Bytes(), &secondResp); err != nil {
+		t.Fatal(err)
+	}
+	if firstResp.Data.TaskID == 0 || firstResp.Data.TaskID != secondResp.Data.TaskID {
+		t.Fatalf("task ids differ: first=%d second=%d", firstResp.Data.TaskID, secondResp.Data.TaskID)
+	}
+	var count int64
+	db.Model(&model.SummaryTask{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("task count=%d want 1", count)
+	}
+	var task model.SummaryTask
+	db.First(&task)
+	if task.CreatorID != "owner" || task.CreatorBotID != "bot-1" || task.TriggerType != model.TriggerBot || task.SpaceID != "space-a" {
+		t.Fatalf("unexpected task identity: %+v", task)
+	}
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -62,6 +62,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		botV1.GET("/summaries", taskH.ListSummaries)
 		botV1.GET("/summaries/:id", taskH.GetSummary)
 		botV1.GET("/summaries/:id/result", taskH.GetResult)
+		botV1.POST("/summaries", taskH.CreateBotSummary)
 	}
 
 	v1 := r.Group("/api/v1")

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -24,7 +24,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	r.Use(func(c *gin.Context) {
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id,Accept,Accept-Language")
+		c.Header("Access-Control-Allow-Headers", "Content-Type,Authorization,Token,X-Space-Id,Accept,Accept-Language,Idempotency-Key")
 		if c.Request.Method == http.MethodOptions {
 			c.AbortWithStatus(http.StatusNoContent)
 			return

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -54,8 +54,9 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	streamH := handler.NewStreamHandler(db, streamHub)
 	shareH := handler.NewShareHandler(db, imDB)
 
-	// Bot-facing read-only mount. Identity and space both come from verify-bot;
-	// this group deliberately does not use the human-token or space middleware.
+	// Bot-facing mount (read plus owner-scoped create). Identity and space both come from
+	// verify-bot; this group deliberately does not use the human-token or space middleware.
+	// The POST route additionally requires BOT_SUMMARY_CREATE_ENABLED=1 at request time.
 	botV1 := r.Group("/api/v1/bot")
 	botV1.Use(middleware.StrictBotAuthMiddleware(botAuthResolver))
 	{

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -162,12 +162,19 @@ type SummaryTask struct {
 // for it. The composite unique index is the concurrency authority: duplicate
 // requests must return the original task without dispatching another worker.
 type SummaryBotCreateIdempotency struct {
-	ID             int64     `gorm:"primaryKey;autoIncrement"`
-	SpaceID        string    `gorm:"column:space_id;type:varchar(64);not null;uniqueIndex:uk_bot_summary_idempotency"`
-	BotID          string    `gorm:"column:bot_id;type:varchar(64);not null;uniqueIndex:uk_bot_summary_idempotency"`
-	IdempotencyKey string    `gorm:"column:idempotency_key;type:varchar(128);not null;uniqueIndex:uk_bot_summary_idempotency"`
-	TaskID         int64     `gorm:"column:task_id;not null"`
-	CreatedAt      time.Time `gorm:"column:created_at;not null"`
+	ID             int64  `gorm:"primaryKey;autoIncrement"`
+	SpaceID        string `gorm:"column:space_id;type:varchar(64);not null;uniqueIndex:uk_bot_summary_idempotency"`
+	BotID          string `gorm:"column:bot_id;type:varchar(64);not null;uniqueIndex:uk_bot_summary_idempotency"`
+	IdempotencyKey string `gorm:"column:idempotency_key;type:varchar(128);not null;uniqueIndex:uk_bot_summary_idempotency"`
+	// RequestHash is a sha256 fingerprint of the create request payload
+	// (title, topic, time range, sources, origin channel, include_archived).
+	// When a client reuses the same (space_id, bot_id, idempotency_key) tuple
+	// with a different body, the mismatch surfaces as HTTP 409 instead of
+	// silently returning the original task. Mirrors summary_share_snapshot
+	// which established this contract in the same repo. See issue #181 P1-2.
+	RequestHash string    `gorm:"column:request_hash;type:char(64);not null"`
+	TaskID      int64     `gorm:"column:task_id;not null"`
+	CreatedAt   time.Time `gorm:"column:created_at;not null"`
 }
 
 func (SummaryBotCreateIdempotency) TableName() string { return "summary_bot_create_idempotency" }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -75,6 +75,9 @@ const (
 	// and content is filled synchronously from the agent's produced deliverable;
 	// no worker dispatch is triggered.
 	TriggerAgent = 3
+	// TriggerBot marks a traditional asynchronous summary created by a
+	// personal bot acting with its human owner's permissions.
+	TriggerBot = 4
 )
 
 // Scheduled multi-participant confirm policy constants (summary_schedule.confirm_policy).
@@ -127,6 +130,7 @@ type SummaryTask struct {
 	TaskNo             string     `gorm:"column:task_no;type:varchar(32);uniqueIndex:uk_task_no;not null" json:"task_no"`
 	SpaceID            string     `gorm:"column:space_id;type:varchar(64);not null;default:''" json:"space_id"`
 	CreatorID          string     `gorm:"column:creator_id;type:varchar(64);not null" json:"creator_id"`
+	CreatorBotID       string     `gorm:"column:creator_bot_id;type:varchar(64);not null;default:'';index:idx_summary_task_creator_bot_id" json:"creator_bot_id,omitempty"`
 	Title              string     `gorm:"column:title;type:varchar(2300);not null;default:''" json:"title"`
 	Topic              string     `gorm:"column:topic;type:varchar(2300);not null;default:''" json:"topic"`
 	SummaryMode        int        `gorm:"column:summary_mode;type:tinyint;not null" json:"summary_mode"`
@@ -153,6 +157,20 @@ type SummaryTask struct {
 	// summaries as reference material via the chat UI.
 	ReferencedTaskIDs *string `gorm:"column:referenced_task_ids;type:text" json:"-"`
 }
+
+// SummaryBotCreateIdempotency binds one bot request key to the task created
+// for it. The composite unique index is the concurrency authority: duplicate
+// requests must return the original task without dispatching another worker.
+type SummaryBotCreateIdempotency struct {
+	ID             int64     `gorm:"primaryKey;autoIncrement"`
+	SpaceID        string    `gorm:"column:space_id;type:varchar(64);not null;uniqueIndex:uk_bot_summary_idempotency"`
+	BotID          string    `gorm:"column:bot_id;type:varchar(64);not null;uniqueIndex:uk_bot_summary_idempotency"`
+	IdempotencyKey string    `gorm:"column:idempotency_key;type:varchar(128);not null;uniqueIndex:uk_bot_summary_idempotency"`
+	TaskID         int64     `gorm:"column:task_id;not null"`
+	CreatedAt      time.Time `gorm:"column:created_at;not null"`
+}
+
+func (SummaryBotCreateIdempotency) TableName() string { return "summary_bot_create_idempotency" }
 
 // EffectiveTopic keeps existing tasks compatible while new tasks persist the
 // complete summary instruction separately from the display title.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -172,7 +172,9 @@ type SummaryBotCreateIdempotency struct {
 	// with a different body, the mismatch surfaces as HTTP 409 instead of
 	// silently returning the original task. Mirrors summary_share_snapshot
 	// which established this contract in the same repo. See issue #181 P1-2.
-	RequestHash string    `gorm:"column:request_hash;type:char(64);not null"`
+	// Default '' matches the migration 20260729-01 backfill for pre-existing
+	// rows.
+	RequestHash string    `gorm:"column:request_hash;type:char(64);not null;default:''"`
 	TaskID      int64     `gorm:"column:task_id;not null"`
 	CreatedAt   time.Time `gorm:"column:created_at;not null"`
 }

--- a/migrations/sql/20260728-01-add-bot-summary-create.sql
+++ b/migrations/sql/20260728-01-add-bot-summary-create.sql
@@ -1,0 +1,18 @@
+ALTER TABLE summary_task
+    ADD COLUMN creator_bot_id VARCHAR(64) NOT NULL DEFAULT ''
+    COMMENT 'personal bot uid when created through the bot API';
+
+CREATE INDEX idx_summary_task_creator_bot_id
+    ON summary_task (creator_bot_id);
+
+CREATE TABLE summary_bot_create_idempotency (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    space_id VARCHAR(64) NOT NULL,
+    bot_id VARCHAR(64) NOT NULL,
+    idempotency_key VARCHAR(128) NOT NULL,
+    task_id BIGINT NOT NULL,
+    created_at DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_bot_summary_idempotency (space_id, bot_id, idempotency_key),
+    KEY idx_bot_summary_idempotency_task (task_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/migrations/sql/20260728-01-add-bot-summary-create.sql
+++ b/migrations/sql/20260728-01-add-bot-summary-create.sql
@@ -11,6 +11,7 @@ CREATE TABLE summary_bot_create_idempotency (
     space_id VARCHAR(64) NOT NULL,
     bot_id VARCHAR(64) NOT NULL,
     idempotency_key VARCHAR(128) NOT NULL,
+    request_hash CHAR(64) NOT NULL,
     task_id BIGINT NOT NULL,
     created_at DATETIME(3) NOT NULL,
     PRIMARY KEY (id),

--- a/migrations/sql/20260728-01-add-bot-summary-create.sql
+++ b/migrations/sql/20260728-01-add-bot-summary-create.sql
@@ -11,7 +11,6 @@ CREATE TABLE summary_bot_create_idempotency (
     space_id VARCHAR(64) NOT NULL,
     bot_id VARCHAR(64) NOT NULL,
     idempotency_key VARCHAR(128) NOT NULL,
-    request_hash CHAR(64) NOT NULL,
     task_id BIGINT NOT NULL,
     created_at DATETIME(3) NOT NULL,
     PRIMARY KEY (id),

--- a/migrations/sql/20260728-01-add-bot-summary-create.sql
+++ b/migrations/sql/20260728-01-add-bot-summary-create.sql
@@ -1,3 +1,4 @@
+-- +migrate Up
 ALTER TABLE summary_task
     ADD COLUMN creator_bot_id VARCHAR(64) NOT NULL DEFAULT ''
     COMMENT 'personal bot uid when created through the bot API';
@@ -16,3 +17,8 @@ CREATE TABLE summary_bot_create_idempotency (
     UNIQUE KEY uk_bot_summary_idempotency (space_id, bot_id, idempotency_key),
     KEY idx_bot_summary_idempotency_task (task_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS summary_bot_create_idempotency;
+DROP INDEX idx_summary_task_creator_bot_id ON summary_task;
+ALTER TABLE summary_task DROP COLUMN creator_bot_id;

--- a/migrations/sql/20260729-01-add-bot-idempotency-request-hash.sql
+++ b/migrations/sql/20260729-01-add-bot-idempotency-request-hash.sql
@@ -1,0 +1,24 @@
+-- +migrate Up
+-- Add request_hash to the bot-create idempotency table so a client that
+-- reuses the same (space_id, bot_id, idempotency_key) tuple with a different
+-- body gets HTTP 409/40009 instead of a silent return of the original task,
+-- mirroring summary_share_snapshot.RequestHash (see share.go:244).
+--
+-- Split from 20260728-01 because sql-migrate keys applied migrations by
+-- filename and does not checksum contents: editing an already-applied
+-- migration in place would leave dev/staging databases that ran the earlier
+-- version stuck on the column-less schema, breaking every create and every
+-- replay for the affected environment. See PR #181 round-3 review P1-2.
+--
+-- DEFAULT '' is intentional: rows written before this column existed had no
+-- hash to compare against. The handler treats any binding with an empty
+-- persisted hash as "different intent" on the next replay, which is the safe
+-- conservative choice for pre-existing bindings (worst case: a legitimate
+-- replay returns 40009 once, the client picks a fresh key, and moves on —
+-- never silent misroute of a different request).
+ALTER TABLE summary_bot_create_idempotency
+    ADD COLUMN request_hash CHAR(64) NOT NULL DEFAULT ''
+    COMMENT 'sha256(canonical request) for idempotency-body binding';
+
+-- +migrate Down
+ALTER TABLE summary_bot_create_idempotency DROP COLUMN request_hash;


### PR DESCRIPTION
## Summary

- add an owner-scoped `POST /api/v1/bot/summaries` endpoint for personal Agent bots
- resolve owner, bot identity, and Space exclusively from the authenticated `bf_*` token
- require explicit authorized sources, a bounded time range, and a stable `Idempotency-Key`
- persist `trigger_type=bot` ownership metadata and dispatch through the existing Summary worker workflow
- add the schema migration and handler coverage for authorization, idempotency, validation, and replay

## Relationship to the read-only PR

Includes the complete latest head of #172, including its main-conflict resolution commit `67eec74`, and supersedes that PR. This PR can be squash-merged directly without merging #172 first.

## Safety

- does not accept caller-supplied owner, participant, bot, or Space identity
- rejects sources outside the resolved owner's permissions/Space
- does not implicitly search all owner channels
- feature remains gated by `BOT_SUMMARY_CREATE_ENABLED`

## Verification

```text
go test ./internal/api/handler ./internal/api/router ./internal/model
```

Also exercised locally through the authenticated CLI and OpenClaw against the traditional Summary worker workflow.

Closes #144
