### PR TITLE
refactor(pipeline): use model.Source* and model.ChannelType* constants in fetch.go

### DIFF
--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -254,11 +254,13 @@ func getPeerUID(channelID, selfUID string) string {
 	return parts[0]
 }
 
-// NormalizeDMChannelID converts a logical DM channel id (peerUID or peer@self)
-// into the WuKongIM storage format: the UID with the larger CRC32 hash comes first.
-// For non-DM channels (channelType != 1), returns input unchanged.
+// NormalizeDMChannelID canonicalises the WuKongIM DM channel_id ("uid_a@uid_b")
+// into the WuKongIM storage format: the UID with the larger CRC32 hash comes
+// first. For non-DM channels (channelType != model.ChannelTypeDM), returns
+// input unchanged. The channel id may be logical (peerUID or peer@self) on
+// input.
 func NormalizeDMChannelID(channelID string, selfUID string, channelType int) string {
-	if channelType != 1 {
+	if channelType != model.ChannelTypeDM {
 		return channelID
 	}
 	var a, b string
@@ -275,16 +277,20 @@ func NormalizeDMChannelID(channelID string, selfUID string, channelType int) str
 	return b + "@" + a
 }
 
-// mapFrontendSourceType maps frontend source_type to backend channelType.
-// Frontend: 1=group, 3=DM; Backend IM server: 1=DM, 2=group
+// mapFrontendSourceType maps smart-summary's frontend source_type
+// (see model.SourceGroup / SourceThread / SourceDirect) to octo-server's
+// WuKongIM channel_type (see model.ChannelTypeDM / ChannelTypeGroup /
+// ChannelTypeThread). The two enums intentionally use different numbers
+// — see the discussion in each const block in model/model.go and the
+// PR that introduced these constants (#181).
 func mapFrontendSourceType(frontendType int) int {
 	switch frontendType {
-	case 1: // frontend group -> backend group
-		return 2
-	case 2: // frontend thread -> backend thread
-		return 5
-	case 3: // frontend DM -> backend DM
-		return 1
+	case model.SourceGroup:
+		return model.ChannelTypeGroup
+	case model.SourceThread:
+		return model.ChannelTypeThread
+	case model.SourceDirect:
+		return model.ChannelTypeDM
 	default:
 		return frontendType
 	}
@@ -303,14 +309,14 @@ func sourceType(s map[string]interface{}) int {
 }
 
 // selectedThreadChannelIDs returns the channel ids of explicitly-selected thread
-// sources (frontend source_type=2). These scope the archived-thread relaxation in
-// GetUserChannels so that only threads the user actually picked can be archived;
-// auto/background summaries (no explicit sources) get an empty slice and never
-// surface archived threads.
+// sources (frontend source_type == model.SourceThread). These scope the
+// archived-thread relaxation in GetUserChannels so that only threads the user
+// actually picked can be archived; auto/background summaries (no explicit
+// sources) get an empty slice and never surface archived threads.
 func selectedThreadChannelIDs(specifiedSources []map[string]interface{}) []string {
 	var ids []string
 	for _, s := range specifiedSources {
-		if mapFrontendSourceType(sourceType(s)) != 5 {
+		if mapFrontendSourceType(sourceType(s)) != model.ChannelTypeThread {
 			continue
 		}
 		if id, ok := s["source_id"].(string); ok && id != "" {


### PR DESCRIPTION
## Summary

`#181` introduced the two source-side and IM-side enums as named constants
in `internal/model/model.go`:

```go
const (
    SourceGroup  = 1  // smart-summary API frontend
    SourceThread = 2
    SourceDirect = 3
)

const (
    ChannelTypeDM     = 1  // WuKongIM storage
    ChannelTypeGroup  = 2
    ChannelTypeThread = 5  // WuKongIM reserves 3/4 so thread jumps to 5
)
```

The bot-summary-create handler adopted these constants consistently, but
the older helpers in `internal/pipeline/fetch.go` still spelled the numeric
values inline. This PR finishes the migration inside that one file so a
reader never has to flip between "which numeric enum am I looking at right
now".

## Changes

- `mapFrontendSourceType`: `case 1/2/3` → `case model.SourceGroup/SourceThread/SourceDirect`;
  returns switched from bare 1/2/5 to `model.ChannelTypeGroup/Thread/DM`.
- `NormalizeDMChannelID`: `if channelType != 1` → `if channelType != model.ChannelTypeDM`.
- `selectedThreadChannelIDs`: `!= 5` → `!= model.ChannelTypeThread`.
- Comment cleanup in the three affected functions so the doc names the
  constants each parameter carries instead of restating the digits.

## Why this is safe — and why there is no DB migration

The constant values are unchanged. The compiled instructions are the same
switch on the same integer values. In particular:

1. **DB records are untouched.** `summary_task_sources.source_type` still
   holds `1 / 2 / 3` for group / thread / DM. Every existing row in every
   deployment (local dev, alex-test, prod) is byte-identical after this PR.
2. **API contract is untouched.** Bot POST / GET request bodies and
   responses continue to send `source_type: 1 / 2 / 3`. `octo-cli`
   summary spec and the octo-summary SKILL.md still document `1=group,
   2=thread, 3=DM` — no client update needed.
3. **octo-server side is not involved.** The WuKongIM `channel_type` enum
   `1=DM, 2=Group, 5=Thread` was already the target of the mapper; we now
   name it via `ChannelTypeDM / ChannelTypeGroup / ChannelTypeThread`
   instead of the digits, but the wire values octo-server receives are the
   same as before.
4. **Behaviour is verified byte-identical** locally with
   `go test ./internal/pipeline/... ./internal/api/handler/...`.

Migrating the DB (i.e. renumbering `source_type` in existing rows to align
with WuKongIM's `channel_type`) was explicitly considered and rejected for
this PR: it would be a breaking API change requiring coordinated updates
to `octo-web`, `octo-cli`, the `octo-summary` SKILL.md, and a data
migration across every environment, none of which delivers new user-facing
value. If we ever decide to run that unification, this PR makes the code
side considerably simpler — only the constant values change; every call
site already reads through them.

## How verified

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./internal/pipeline/... ./internal/api/handler/...` all pass
- Diff limited to `internal/pipeline/fetch.go` (+23 / -17)

## Linked Spec

N/A — pure refactor, no spec or handler surface changes.

## Comprehension

The gap this closes surfaced when reading `bot_summary_create.go` (post-#181)
side-by-side with `fetch.go`: the handler used named constants, and the
pipeline helpers used bare digits, so any reader spent time confirming
"is this 1 the smart-summary group, or the WuKongIM DM?" every time.
With this PR, `fetch.go` reads exactly like the handler.
