### PR TITLE
feat(notify): server-driven group tip on task completion

### DIFF
--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -8,6 +8,12 @@ import "time"
 const (
 	NotifyKindCompleted = "completed"
 	NotifyKindFailed    = "failed"
+	// NotifyKindGroupTip is the passive grey system tip fanned out to every
+	// group source of a Completed non-by-person task. Server-driven successor
+	// of the abandoned web-only #1234 attempt (see #289). Distinct kind so
+	// its per-(task, kind, source_channel_id) dedup row does not collide with
+	// the creator-DM Completed notification.
+	NotifyKindGroupTip = "group_tip"
 )
 
 // Notification status constants (summary_notification.status).

--- a/internal/notify/group_tip_test.go
+++ b/internal/notify/group_tip_test.go
@@ -1,0 +1,272 @@
+//go:build cgo
+
+package notify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupGroupTipTestDB builds an in-memory sqlite fixture with the tables
+// OnGroupTip touches (notifications for the dedup rows, sources for the fan-out
+// query). Kept separate from setupNotifyTestDB so a schema drift on either
+// side surfaces here rather than silently in existing tests.
+func setupGroupTipTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.SummaryNotification{}, &model.SummarySource{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+func groupTipTask(id int64, mode int, status int) model.SummaryTask {
+	return model.SummaryTask{
+		ID:          id,
+		TaskNo:      "GT-1",
+		Title:       "群聊总结",
+		SpaceID:     "space-9",
+		CreatorID:   "user-creator",
+		SummaryMode: mode,
+		Status:      status,
+	}
+}
+
+// mustAddSources inserts the given (source_type, source_id) pairs against a
+// task so OnGroupTip's fan-out has something to iterate over.
+func mustAddSources(t *testing.T, db *gorm.DB, taskID int64, srcs []model.SummarySource) {
+	t.Helper()
+	for i := range srcs {
+		srcs[i].TaskID = taskID
+		if err := db.Create(&srcs[i]).Error; err != nil {
+			t.Fatalf("create source: %v", err)
+		}
+	}
+}
+
+func TestOnGroupTip_FansOutOneTipPerGroupSource(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	task := groupTipTask(1, model.ModeByPerson-1 /* non-by-person */, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+		{SourceType: model.SourceGroup, SourceID: "group-b"},
+		{SourceType: model.SourceThread, SourceID: "thread-x"}, // must be skipped
+		{SourceType: model.SourceDirect, SourceID: "dm-y"},     // must be skipped
+	})
+
+	n.OnGroupTip(task)
+
+	if len(fake.sendCalls) != 2 {
+		t.Fatalf("expected 2 group sends, got %d", len(fake.sendCalls))
+	}
+	channels := map[string]bool{}
+	for _, msg := range fake.sendCalls {
+		if msg.ChannelType != WireChannelGroup {
+			t.Errorf("expected WireChannelGroup=%d, got %d", WireChannelGroup, msg.ChannelType)
+		}
+		if ct, _ := msg.Payload["content_type"].(int); ct != 21 {
+			t.Errorf("expected payload content_type=21 (summaryNotify), got %v", msg.Payload["content_type"])
+		}
+		if fu, _ := msg.Payload["from_uid"].(string); fu != task.CreatorID {
+			t.Errorf("expected payload from_uid=%s, got %v", task.CreatorID, msg.Payload["from_uid"])
+		}
+		channels[msg.ChannelID] = true
+	}
+	if !channels["group-a"] || !channels["group-b"] {
+		t.Errorf("expected both group-a and group-b to receive tip, got %v", channels)
+	}
+	if channels["thread-x"] || channels["dm-y"] {
+		t.Errorf("thread/dm sources must not receive group tip; got %v", channels)
+	}
+
+	// Each group source should have a Sent dedup row.
+	var count int64
+	db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ?",
+			task.ID, model.NotifyKindGroupTip, model.NotifyStatusSent).
+		Count(&count)
+	if count != 2 {
+		t.Errorf("expected 2 sent notification rows, got %d", count)
+	}
+}
+
+func TestOnGroupTip_IsIdempotentAcrossRetriggers(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	task := groupTipTask(1, 1 /* non-by-person */, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+	})
+
+	// Two triggers of the same completion (status event + fallback poll
+	// pattern) must land at most one delivery per (task, group).
+	n.OnGroupTip(task)
+	n.OnGroupTip(task)
+
+	if len(fake.sendCalls) != 1 {
+		t.Fatalf("idempotency violated: expected exactly 1 send, got %d", len(fake.sendCalls))
+	}
+}
+
+func TestOnGroupTip_SkipsFailedTask(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	// Failed → group tip must NOT fire (would broadcast failure to the group).
+	task := groupTipTask(1, 1 /* non-by-person */, model.StatusFailed)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+	})
+
+	n.OnGroupTip(task)
+	if len(fake.sendCalls) != 0 {
+		t.Errorf("failed task must not emit group tip, got %d sends", len(fake.sendCalls))
+	}
+}
+
+func TestOnGroupTip_SkipsByPersonMode(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	// by-person mode's fan-out already goes to participants via DMs; layering
+	// group tips on top would double-broadcast.
+	task := groupTipTask(1, model.ModeByPerson, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+	})
+
+	n.OnGroupTip(task)
+	if len(fake.sendCalls) != 0 {
+		t.Errorf("by-person task must not emit group tip, got %d sends", len(fake.sendCalls))
+	}
+}
+
+func TestOnGroupTip_SkipsWhenNotEnabled(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: false, MaxAttempts: 3})
+
+	task := groupTipTask(1, 1, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+	})
+
+	n.OnGroupTip(task)
+	if len(fake.sendCalls) != 0 {
+		t.Errorf("disabled notifier must not emit; got %d sends", len(fake.sendCalls))
+	}
+}
+
+func TestOnGroupTip_OneGroupFailureDoesNotBlockOthers(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	// Fail the very first delivery attempt (any group; we assert isolation by
+	// counting total deliveries across both groups).
+	fake := &fakeDeliverer{sendErrOnce: errors.New("transient network")}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	task := groupTipTask(1, 1, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+		{SourceType: model.SourceGroup, SourceID: "group-b"},
+	})
+
+	n.OnGroupTip(task)
+
+	// Both groups must have been attempted (one failed, one succeeded) — one
+	// group's failure never blocks another.
+	if len(fake.sendCalls) != 2 {
+		t.Fatalf("expected 2 delivery attempts across groups, got %d", len(fake.sendCalls))
+	}
+
+	// One row Sent, one row Failed → attempt_count=1, retry-eligible on sweep.
+	var sent, failed int64
+	db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ?",
+			task.ID, model.NotifyKindGroupTip, model.NotifyStatusSent).Count(&sent)
+	db.Model(&model.SummaryNotification{}).
+		Where("task_id = ? AND notify_kind = ? AND status = ?",
+			task.ID, model.NotifyKindGroupTip, model.NotifyStatusFailed).Count(&failed)
+	if sent != 1 || failed != 1 {
+		t.Errorf("expected sent=1 failed=1, got sent=%d failed=%d", sent, failed)
+	}
+}
+
+func TestOnGroupTip_SkipsWhenNoGroupSources(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	// Only DM / thread sources — nothing to fan out to.
+	task := groupTipTask(1, 1, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceDirect, SourceID: "dm-y"},
+		{SourceType: model.SourceThread, SourceID: "thread-x"},
+	})
+
+	n.OnGroupTip(task)
+	if len(fake.sendCalls) != 0 {
+		t.Errorf("no group sources → no sends; got %d", len(fake.sendCalls))
+	}
+}
+
+func TestOnGroupTip_UsesGroupChannelWithoutEnsureFriend(t *testing.T) {
+	db := setupGroupTipTestDB(t)
+	fake := &fakeDeliverer{}
+	n := newTestNotifier(db, fake, Config{Enabled: true, MaxAttempts: 3})
+
+	task := groupTipTask(1, 1, model.StatusCompleted)
+	mustAddSources(t, db, task.ID, []model.SummarySource{
+		{SourceType: model.SourceGroup, SourceID: "group-a"},
+	})
+
+	n.OnGroupTip(task)
+
+	// Group delivery must NOT call EnsureFriend (there is no per-user
+	// relationship for a group destination and octo-server does not require
+	// one). The DM path in OnTaskTerminal is the only caller of EnsureFriend.
+	if len(fake.ensureCalls) != 0 {
+		t.Errorf("group tip must not EnsureFriend, got %d calls", len(fake.ensureCalls))
+	}
+	if len(fake.sendCalls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(fake.sendCalls))
+	}
+	msg := fake.sendCalls[0]
+	if msg.ChannelType != WireChannelGroup {
+		t.Errorf("expected group channel type %d, got %d", WireChannelGroup, msg.ChannelType)
+	}
+	if msg.ChannelID != "group-a" {
+		t.Errorf("expected channel_id=group-a, got %s", msg.ChannelID)
+	}
+	if _, hasCard := any(msg.Card).(*notifyCard); hasCard && msg.Card != nil {
+		t.Errorf("group tip should use Payload not Card; got Card=%+v", msg.Card)
+	}
+	// Sanity: SpaceID is threaded through the deliverer so octo-server can
+	// enforce space membership on the group.
+	if len(fake.sendSpaceID) != 1 || fake.sendSpaceID[0] != task.SpaceID {
+		t.Errorf("expected SpaceID=%s threaded to SendMessage, got %v",
+			task.SpaceID, fake.sendSpaceID)
+	}
+}
+
+// Compile-time assertion: OnGroupTip's implementation must not accidentally
+// take a *context.Context signature — the deliverer receives it internally.
+// This is a smoke test to catch a signature drift during refactors.
+func TestOnGroupTip_MethodSignature(t *testing.T) {
+	var _ func(task model.SummaryTask) = (&Notifier{}).OnGroupTip
+	_ = context.Background // keep the import used
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -197,6 +197,130 @@ func kindForStatus(status int) (string, bool) {
 	}
 }
 
+// OnGroupTip fans out a passive "{creator} 总结了群聊内容" system tip to every
+// group source of a completed non-by-person task. Server-driven successor of
+// the abandoned web-only #1234 attempt — server is now the authoritative
+// exactly-once source for the tip.
+//
+// Scope guards (each an early return, all defensive):
+//   - only Status == Completed (Failed / Cancelled / mid-flight never emit).
+//   - only NON-by-person tasks (by-person's fan-out already goes to
+//     participants via personal DMs; layering a group tip on top is out of
+//     scope for #289).
+//   - only sources with SourceType == SourceGroup (SourceThread / SourceDirect
+//     never receive this tip).
+//   - only tasks with a Creator (empty creator → nothing to render).
+//
+// Idempotency: reuses the summary_notification state machine with
+// notify_kind = NotifyKindGroupTip and recipient_uid = source.ChannelID (the
+// GROUP channel_id), so retries and multiple triggers of the same completion
+// converge on one row per (task, group).
+func (n *Notifier) OnGroupTip(task model.SummaryTask) {
+	if n == nil || !n.cfg.Enabled || n.deliverer == nil || n.db == nil {
+		return
+	}
+	if task.Status != model.StatusCompleted {
+		return
+	}
+	if task.SummaryMode == model.ModeByPerson {
+		// By-person tasks fan out to participants individually — the group
+		// tip is orthogonal to that flow. Keeping this scope guard explicit
+		// so a future by-person change doesn't accidentally start double-
+		// broadcasting.
+		return
+	}
+	if task.CreatorID == "" {
+		return
+	}
+
+	// Resolve group sources. A source resolution error is not fatal — we log
+	// and skip; on the next trigger/sweep the resolution runs again.
+	var sources []model.SummarySource
+	if err := n.db.Where("task_id = ? AND source_type = ?", task.ID, model.SourceGroup).
+		Find(&sources).Error; err != nil {
+		log.Printf("[notify] task=%d kind=%s: resolve group sources failed: %v",
+			task.ID, model.NotifyKindGroupTip, err)
+		return
+	}
+	if len(sources) == 0 {
+		return
+	}
+
+	// Each group source runs the claim/deliver/mark state machine on its own
+	// (task, kind, source_channel_id) row so one group's delivery failure
+	// never blocks the others (matches OnTaskTerminal's fan-out semantics).
+	for _, src := range sources {
+		target := deliveryTarget{
+			ChannelID:   src.SourceID,
+			ChannelType: WireChannelGroup,
+			// TargetUID intentionally empty for group回发: no EnsureFriend
+			// is needed and octo-server does not build a whitelist DM channel
+			// for a group destination.
+			SpaceID: task.SpaceID,
+		}
+		n.deliverGroupTipToSource(task, target, src)
+	}
+}
+
+// deliverGroupTipToSource runs the per-source claim/deliver/mark state machine
+// for one group source. Extracted so OnGroupTip's loop stays flat and each
+// source's failure isolates from the others.
+func (n *Notifier) deliverGroupTipToSource(task model.SummaryTask, target deliveryTarget, src model.SummarySource) {
+	kind := model.NotifyKindGroupTip
+	uid := src.SourceID // recipient_uid slot repurposed for the group channel id
+
+	claimed, _, err := n.claim(task.ID, kind, uid)
+	if err != nil {
+		log.Printf("[notify] task=%d kind=%s group=%s: claim failed: %v", task.ID, kind, uid, err)
+		return
+	}
+	if !claimed {
+		// Already delivered / in-flight / attempts exhausted — dedup row
+		// carries the terminal state.
+		return
+	}
+
+	if err := n.deliverGroupTip(task, target, src); err != nil {
+		n.markFailed(task.ID, kind, uid, err)
+		log.Printf("[notify] task=%d kind=%s group=%s: delivery failed: %v",
+			task.ID, kind, uid, sanitize(err.Error()))
+		return
+	}
+	n.markSent(task.ID, kind, uid)
+	log.Printf("[notify] task=%d kind=%s group=%s: delivered", task.ID, kind, uid)
+}
+
+// deliverGroupTip posts the SummaryNotifyContent (contentType=21) system tip
+// to one group channel. It intentionally does NOT reuse `deliver` because:
+//   - group delivery skips EnsureFriend (no per-user relationship needed).
+//   - the payload is not a card but a raw content-type-21 system message
+//     whose renderer lives in octo-web packages/dmworkbase/Messages/SummaryNotify.
+func (n *Notifier) deliverGroupTip(task model.SummaryTask, target deliveryTarget, src model.SummarySource) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	payload := map[string]any{
+		// content_type=21 mirrors packages/dmworkbase/src/Service/Const.ts
+		// (MessageContentTypeConst.summaryNotify) and is decoded by the
+		// SummaryNotifyContent class in the web/mobile renderer PR.
+		"content_type": 21,
+		"from_uid":     task.CreatorID,
+		"task_id":      task.ID,
+		"task_no":      task.TaskNo,
+		"source_id":    src.SourceID,
+	}
+
+	msg := SendMessageRequest{
+		ChannelID:   target.ChannelID,
+		ChannelType: target.ChannelType,
+		Payload:     payload,
+	}
+	if err := n.deliverer.SendMessage(ctx, target.SpaceID, msg); err != nil {
+		return fmt.Errorf("sendMessage: %w", err)
+	}
+	return nil
+}
+
 // claim attempts the preemptive INSERT. Returns claimed=true when this run won
 // the (task, kind) slot. When the row already exists, claimed=false and the
 // existing row is returned so the caller can decide whether retry budget remains.

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -149,6 +149,13 @@ func (p *Processor) notifyTaskTerminal(taskID int64, status int) {
 		errMsg = *task.ErrorMessage
 	}
 	p.notifier.OnTaskTerminal(task, status, errMsg)
+	// #289 server-driven group tip (successor of the abandoned web-only #1234).
+	// OnGroupTip is scope-guarded: it no-ops for Failed / by-person / non-group-
+	// source tasks, so we can call it unconditionally here on any terminal.
+	// Reusing the summary_notification state machine with kind=group_tip means
+	// each (task, group) is delivered at most once even if this terminal fires
+	// multiple times.
+	p.notifier.OnGroupTip(task)
 }
 
 // TriggerCh returns the channel for worker trigger requests.


### PR DESCRIPTION
## Summary

Server-driven successor of the abandoned web-only [octo-web#1234](https://github.com/Mininglamp-OSS/octo-web/pull/1234) attempt at delivering "{creator} 总结了群聊内容" as a passive grey system tip in every group source of a completed non-by-person task. Client-side best-effort delivery couldn't reach the correctness bar (see #1234 round-6 architecture escalation). This PR moves the tip generation to the server so exactly-once delivery comes from the authoritative source.

## Linked Spec

- **Product requirement**: [octo-web#289](https://github.com/Mininglamp-OSS/octo-web/issues/289)
- **Superseded**: [octo-web#1234](https://github.com/Mininglamp-OSS/octo-web/pull/1234) (closed after round-6)
- **Companion web renderer PR**: [wanyiwang06/octo-web feat/summary-notify-renderer](https://github.com/wanyiwang06/octo-web/tree/feat/summary-notify-renderer) (renderer for `contentType=21` messages; will be opened in Mininglamp-OSS/octo-web separately)

## Behavior

On every terminal-state transition of a summary task, `processor.go` calls `notifier.OnGroupTip(task)` alongside the existing `OnTaskTerminal` fan-out. `OnGroupTip` is scope-guarded and no-ops for anything outside its intent:

- Only `Status == Completed` (`Failed` / `Cancelled` / mid-flight never emit).
- Only **non-by-person** tasks (by-person's fan-out already goes to participants individually via DMs; layering a group broadcast on top is out of scope for #289).
- Only sources with `SourceType == SourceGroup` (`SourceThread` / `SourceDirect` skipped — the tip is a group-scale signal by design).
- Only tasks with a `Creator` (empty creator renders as "someone" and defeats the purpose).

For each eligible group source, the deliverer posts a payload `{content_type: 21, from_uid, task_id, task_no, source_id}` to the group channel via `WireChannelGroup` — no `EnsureFriend` hop (unlike DM), `SpaceID` is threaded through so octo-server can enforce space membership.

## Idempotency

Reuses the existing `summary_notification` state machine with a new kind:

- `model.NotifyKindGroupTip = "group_tip"`
- `recipient_uid` slot is repurposed as the group's `ChannelID`
- unique index `(task_id, kind, recipient_uid)` unchanged, so each `(task, group)` converges on one row; a second/third trigger of the same completion (status event + fallback poll + retry) finds the claim already made and no-ops.

Distinct kind means the `group_tip` row does NOT collide with the existing `completed` / `failed` rows for the same task, so the creator-DM completion notification and the group tips dedup independently.

## Isolation

Each group source runs the claim / deliver / mark state machine on its own `(task, kind, source_id)` row so one group's delivery failure never blocks the others — matches `OnTaskTerminal`'s per-recipient isolation.

## How verified

- `go build ./...` → passes
- `go vet ./...` → clean
- New `internal/notify/group_tip_test.go` (8 cases, CGO-gated to match existing `notify_test.go`):
  - Fan-out to every group source, thread/dm sources filtered out
  - Idempotency across two triggers of the same completion
  - Failed status skipped
  - by-person mode skipped
  - Disabled config skipped
  - One group's failure does not block others (attempt_count reflects retry)
  - No group sources → no delivery attempts
  - Group delivery skips `EnsureFriend` and uses `Payload` not `Card`
- Local `go test` requires `gcc` for the sqlite driver (`//go:build cgo`); CI provides it.

Diff stat: **+409 / -0** across 4 files — fully additive, zero existing code paths modified.

## COMPREHENSION

- 本 PR 让服务器接管「总结完成后向群里发 tip」这一动作,取代 web-only 那条已废弃路径。所有 dedup / retry / space membership 校验都复用现有 `summary_notification` 状态机,只加一个新 kind = `group_tip`。
- 保持向后兼容:`OnTaskTerminal` (creator DM 通知)行为不变,`OnGroupTip` 是独立 method,两者互相独立 dedup,不会重发。
- Failed / by-person / 非 group source 全都显式 short-circuit,任何一条 guard 失效都独立触发相同的 no-op,不会误发。
- Payload 里 `content_type=21` 对应 `octo-web` renderer PR 里 `MessageContentTypeConst.summaryNotify = 21`,contract 是纯 additive。
- 依然 respect 现有 `Config.Enabled` 开关:功能可以在 config 侧灰度关闭而无需回滚代码。
