### PR TITLE
fix(summary): require space membership for member-candidates (close full-user leak)

### DIFF
--- a/internal/api/handler/candidates.go
+++ b/internal/api/handler/candidates.go
@@ -36,23 +36,51 @@ func (imUser) TableName() string { return "user" }
 
 // SearchCandidates handles GET /api/v1/summary-member-candidates
 // Returns human members of the current Space only (excludes bots).
-// Falls back to all human users if no space_id is available.
+//
+// Security (summary member-candidates full-user leak, pentest 高危): the space
+// scope is REQUIRED and the caller MUST be an active member of that space.
+// Previously an empty space_id fell back to querying ALL human users (org-wide
+// roster leak) and a client-supplied space_id was trusted without a membership
+// check (cross-space enumeration). Both are closed here — mirrors the docs /
+// Matter space-membership authorization.
 func (h *CandidateHandler) SearchCandidates(c *gin.Context) {
 	if h.imDB == nil {
 		c.JSON(http.StatusOK, gin.H{"code": 0, "data": []interface{}{}})
 		return
 	}
 	keyword := c.Query("keyword")
-	// Space ID: prefer explicit query param (sent by frontend), fallback to middleware context.
+
+	// Resolve current user (set by AuthMiddleware via token).
+	currentUID, _ := c.Get("user_id")
+	currentUIDStr, _ := currentUID.(string)
+	if currentUIDStr == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"code": 40100, "message": "authentication required"})
+		return
+	}
+
+	// Space ID: prefer explicit query param (sent by frontend), fallback to
+	// middleware context (X-Space-Id).
 	spaceIDStr := c.Query("space_id")
 	if spaceIDStr == "" {
 		v, _ := c.Get("space_id")
 		spaceIDStr, _ = v.(string)
 	}
-
-	// Resolve current user (set by AuthMiddleware via token)
-	currentUID, _ := c.Get("user_id")
-	currentUIDStr, _ := currentUID.(string)
+	// Never fall back to "all users": without a resolvable space we cannot scope
+	// the roster, so deny instead of leaking every user.
+	if spaceIDStr == "" {
+		c.JSON(http.StatusForbidden, gin.H{"code": 40300, "message": "space membership required"})
+		return
+	}
+	// The caller must be an active member of the target space; otherwise a
+	// non-member could enumerate that space's roster by supplying its space_id.
+	var memberCnt int64
+	h.imDB.Table("space_member").
+		Where("space_id = ? AND uid = ? AND status = 1", spaceIDStr, currentUIDStr).
+		Count(&memberCnt)
+	if memberCnt == 0 {
+		c.JSON(http.StatusForbidden, gin.H{"code": 40300, "message": "not a member of this space"})
+		return
+	}
 
 	var users []imUser
 
@@ -60,22 +88,16 @@ func (h *CandidateHandler) SearchCandidates(c *gin.Context) {
 	// 1. user.robot = 1 (flag on user row)
 	// 2. uid in robot table (some system bots have robot=0, e.g. BotFather)
 	// 3. uid is not a 32-char hex string (system accounts like fileHelper/botfather)
+	//
+	// The space_member join is now UNCONDITIONAL (space is guaranteed non-empty
+	// and the caller is a verified member), so results are always space-scoped.
 	q := h.imDB.Table("user u").Select("u.uid, u.name").
 		Where("u.robot = 0").
 		Where("u.uid NOT IN (SELECT robot_id FROM robot)").
-		Where("LENGTH(u.uid) = 32")
-
-	if spaceIDStr != "" {
-		// Filter by Space members
-		q = q.
-			Joins("INNER JOIN space_member sm ON sm.uid = u.uid").
-			Where("sm.space_id = ? AND sm.status = 1", spaceIDStr)
-	}
-
-	// Exclude the currently logged-in user (task creator doesn't add themselves)
-	if currentUIDStr != "" {
-		q = q.Where("u.uid != ?", currentUIDStr)
-	}
+		Where("LENGTH(u.uid) = 32").
+		Joins("INNER JOIN space_member sm ON sm.uid = u.uid").
+		Where("sm.space_id = ? AND sm.status = 1", spaceIDStr).
+		Where("u.uid != ?", currentUIDStr)
 
 	if keyword != "" {
 		q = q.Where("u.name LIKE ? OR u.username LIKE ?", "%"+keyword+"%", "%"+keyword+"%")
@@ -187,7 +209,7 @@ func (h *CandidateHandler) SearchChatCandidates(c *gin.Context) {
 		if currentUIDStr != "" {
 			// Use group_member instead of thread_member so that all threads in the
 			// user's groups are returned, not just threads the user has posted in.
-			q = q.Joins("INNER JOIN group_member gm ON gm.group_no" + h.collate + " = t.group_no").
+			q = q.Joins("INNER JOIN group_member gm ON gm.group_no"+h.collate+" = t.group_no").
 				Where("gm.uid = ? AND gm.is_deleted = 0", currentUIDStr)
 		}
 		if spaceIDStr != "" {

--- a/internal/api/handler/candidates_test.go
+++ b/internal/api/handler/candidates_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
@@ -23,6 +24,10 @@ func setupCandidateImDB(t *testing.T) *gorm.DB {
 	imDB.Exec(`CREATE TABLE "group" (group_no TEXT NOT NULL, name TEXT, space_id TEXT, status INTEGER DEFAULT 1)`)
 	imDB.Exec(`CREATE TABLE thread (id INTEGER PRIMARY KEY, short_id TEXT, name TEXT, group_no TEXT, status INTEGER DEFAULT 1, message_count INTEGER DEFAULT 0)`)
 	imDB.Exec(`CREATE TABLE group_member (group_no TEXT NOT NULL, uid TEXT NOT NULL, is_deleted INTEGER DEFAULT 0)`)
+	// Tables for SearchCandidates (member-candidates) space-membership authz.
+	imDB.Exec(`CREATE TABLE user (uid TEXT, name TEXT, username TEXT, robot INTEGER DEFAULT 0)`)
+	imDB.Exec(`CREATE TABLE robot (robot_id TEXT)`)
+	imDB.Exec(`CREATE TABLE space_member (space_id TEXT, uid TEXT, status INTEGER DEFAULT 1)`)
 	return imDB
 }
 
@@ -356,5 +361,93 @@ func TestSearchChatCandidates_GroupAndDirectHaveIsArchivedFalse(t *testing.T) {
 	}
 	if v != false {
 		t.Errorf("group is_archived should be false, got %v", v)
+	}
+}
+
+// --- SearchCandidates (member-candidates) space-membership authorization ---
+
+func setupMemberRouter(h *CandidateHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.GET("/api/v1/summary-member-candidates", h.SearchCandidates)
+	return r
+}
+
+// doMemberRequest issues a member-candidates request. When spaceHeader is empty
+// the X-Space-Id header is omitted (simulating a request with no space scope).
+func doMemberRequest(r *gin.Engine, userID, spaceHeader string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/summary-member-candidates", nil)
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	if spaceHeader != "" {
+		req.Header.Set("X-Space-Id", spaceHeader)
+	}
+	r.ServeHTTP(w, req)
+	return w
+}
+
+const (
+	memCaller   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 32-hex; space1 member
+	memPeer     = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" // 32-hex; space1 member
+	memOutsider = "cccccccccccccccccccccccccccccccc" // 32-hex; NOT in space1
+)
+
+func seedMemberSpace(imDB *gorm.DB) {
+	imDB.Exec(`INSERT INTO user (uid, name, username, robot) VALUES (?, 'Caller', 'caller', 0)`, memCaller)
+	imDB.Exec(`INSERT INTO user (uid, name, username, robot) VALUES (?, 'Peer', 'peer', 0)`, memPeer)
+	imDB.Exec(`INSERT INTO user (uid, name, username, robot) VALUES (?, 'Outsider', 'outsider', 0)`, memOutsider)
+	// space1 members: caller + peer (outsider intentionally absent).
+	imDB.Exec(`INSERT INTO space_member (space_id, uid, status) VALUES ('space1', ?, 1)`, memCaller)
+	imDB.Exec(`INSERT INTO space_member (space_id, uid, status) VALUES ('space1', ?, 1)`, memPeer)
+}
+
+func TestSearchCandidates_MemberGetsSpaceRoster(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	seedMemberSpace(imDB)
+	r := setupMemberRouter(NewCandidateHandler(imDB, -1))
+
+	w := doMemberRequest(r, memCaller, "space1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("member should get 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, memPeer) {
+		t.Fatalf("expected peer in roster, body=%s", body)
+	}
+	if strings.Contains(body, memCaller) {
+		t.Fatalf("caller should be excluded from own roster, body=%s", body)
+	}
+}
+
+func TestSearchCandidates_NonMemberForbidden(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	seedMemberSpace(imDB)
+	r := setupMemberRouter(NewCandidateHandler(imDB, -1))
+
+	// Outsider is authenticated but not a member of space1 → 403, no roster.
+	w := doMemberRequest(r, memOutsider, "space1")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("non-member should get 403, got %d body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), memPeer) {
+		t.Fatalf("non-member must not see any roster, body=%s", w.Body.String())
+	}
+}
+
+func TestSearchCandidates_NoSpaceNoFullDump(t *testing.T) {
+	imDB := setupCandidateImDB(t)
+	seedMemberSpace(imDB)
+	r := setupMemberRouter(NewCandidateHandler(imDB, -1))
+
+	// No X-Space-Id header and no space_id query → must NOT fall back to all users.
+	w := doMemberRequest(r, memCaller, "")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("missing space must be 403 (no full-user dump), got %d body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), memPeer) || strings.Contains(w.Body.String(), memOutsider) {
+		t.Fatalf("no users must be leaked without a space, body=%s", w.Body.String())
 	}
 }


### PR DESCRIPTION
## 背景(渗透测试 高危)
`GET /api/v1/summary-member-candidates` 泄露**全量组织架构**:`SearchCandidates` 从客户端 query 取 `space_id`,**为空时兜底查询全部真人用户**;且**从不校验调用者是否为该空间成员**(传任意 `space_id` 即可跨空间枚举成员)。

## 修复(照抄 docs / Matter 的空间成员鉴权)
- **必须有可解析的空间**(query `space_id` 或 `X-Space-Id` 头);解析不出 → **403**,不再回退全量;
- **调用者必须是目标空间的在册成员**(`space_member.status=1`),非成员 → **403**;
- `space_member` INNER JOIN 改为**恒定生效**,结果始终按空间收窄。

`SearchChatCandidates` **无需改**:它本就按调用者自己的 `group_member`(`gm.uid = 调用者`)收窄,只返回你所在的群/子区,不会泄露全量、也无跨空间枚举。

## 零回归(已按前端代码验证)
前端 `getMemberCandidates` 只传 `keyword`、从不传 `space_id`,空间靠请求层注入的 `X-Space-Id`(= `currentSpaceId`)带;合法 UI 调用**必带 X-Space-Id 且用户必是本空间成员** → 两道校验自然通过,选参与者功能照旧。全量兜底从来不是给前端用的。

## 测试
`candidates_test.go` 新增(cgo/sqlite):
- 成员 → 200,返回本空间名单(排除自己);
- 非成员 → 403;
- 无空间(无 X-Space-Id / 无 query)→ 403,且不泄露任何用户。

本地 `go build ./internal/api/handler/` ✅、`gofmt` ✅;cgo 单测本机无 gcc,交 CI 运行。

涉及文件:`internal/api/handler/candidates.go`、`internal/api/handler/candidates_test.go`。