### PR TITLE
feat(summary): expose creator_bot_id + creator_bot_name on list/detail/create

### DIFF
--- a/internal/api/handler/bot_summary_create.go
+++ b/internal/api/handler/bot_summary_create.go
@@ -65,17 +65,17 @@ func canonicalBotCreateRequestHash(req createBotSummaryReq, sources []canonicalB
 		}
 	}
 	payload := struct {
-		Title            string               `json:"title"`
-		Topic            string               `json:"topic"`
-		TimeRangeStart   string               `json:"time_range_start"`
-		TimeRangeEnd     string               `json:"time_range_end"`
-		Sources          []canonicalBotSource `json:"sources"`
-		OriginChannelID  string               `json:"origin_channel_id"`
-		OriginChannelTp  int                  `json:"origin_channel_type"`
-		IncludeArchived  bool                 `json:"include_archived"`
+		Title           string               `json:"title"`
+		Topic           string               `json:"topic"`
+		TimeRangeStart  string               `json:"time_range_start"`
+		TimeRangeEnd    string               `json:"time_range_end"`
+		Sources         []canonicalBotSource `json:"sources"`
+		OriginChannelID string               `json:"origin_channel_id"`
+		OriginChannelTp int                  `json:"origin_channel_type"`
+		IncludeArchived bool                 `json:"include_archived"`
 	}{
-		Title:           strings.TrimSpace(req.Title),
-		Topic:           strings.TrimSpace(req.Topic),
+		Title: strings.TrimSpace(req.Title),
+		Topic: strings.TrimSpace(req.Topic),
 		// Round the time range to whole minutes so a normal client retry
 		// that recomputes a relative window ("summarize the last hour")
 		// replays cleanly instead of colliding on nanosecond drift. A
@@ -542,5 +542,9 @@ func (h *TaskHandler) findBotIdempotentTaskWithHash(spaceID, botID, key, request
 }
 
 func botCreateResponse(task model.SummaryTask) gin.H {
-	return gin.H{"task_id": task.ID, "task_no": task.TaskNo, "status": task.Status, "trigger_type": task.TriggerType, "creator_id": task.CreatorID, "creator_bot_id": task.CreatorBotID, "created_at": task.CreatedAt.Format(time.RFC3339)}
+	creatorBotName := ""
+	if task.CreatorBotID != "" {
+		creatorBotName = service.ResolveUserName(task.CreatorBotID)
+	}
+	return gin.H{"task_id": task.ID, "task_no": task.TaskNo, "status": task.Status, "trigger_type": task.TriggerType, "creator_id": task.CreatorID, "creator_bot_id": task.CreatorBotID, "creator_bot_name": creatorBotName, "created_at": task.CreatedAt.Format(time.RFC3339)}
 }

--- a/internal/api/handler/bot_summary_create_test.go
+++ b/internal/api/handler/bot_summary_create_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -97,8 +98,24 @@ func requestBotCreate(r *gin.Engine, key string, body []byte) *httptest.Response
 func TestCreateBotSummaryResponseIncludesBotIdentity(t *testing.T) {
 	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
 	_, r, _ := setupBotCreateTest(t)
+	// Install a temporary name resolver and restore the default (identity)
+	// afterwards. Under test no main() runs, so without this the stub
+	// resolver echoes the uid and the creator_bot_name assertion below
+	// could never fail (review P2-3).
+	service.SetUserNameResolver(func(uid string) string {
+		if uid == "bot-1" {
+			return "Bot Display Name"
+		}
+		return uid
+	})
+	t.Cleanup(func() {
+		service.SetUserNameResolver(func(uid string) string { return uid })
+	})
 	w := requestBotCreate(r, "botname-key", botCreateBody("group-a"))
-	if w.Code != http.StatusOK {
+	// A fresh create returns 201 Created; 200 OK is reserved for idempotent
+	// replays (bot_summary_create.go:198/:219). Every sibling test in this
+	// file already expects StatusCreated for a fresh create (review P0-1).
+	if w.Code != http.StatusCreated {
 		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
 	}
 	var resp struct {
@@ -117,11 +134,37 @@ func TestCreateBotSummaryResponseIncludesBotIdentity(t *testing.T) {
 	if resp.Data.CreatorBotID != "bot-1" {
 		t.Fatalf("creator_bot_id=%q, want bot-1", resp.Data.CreatorBotID)
 	}
-	if resp.Data.CreatorBotName == "" {
-		t.Fatalf("creator_bot_name is empty; want resolved bot name")
+	// Assert the exact resolved display name, not just non-empty: with the
+	// resolver installed above this fails if the handler stops resolving or
+	// resolves the wrong uid.
+	if resp.Data.CreatorBotName != "Bot Display Name" {
+		t.Fatalf("creator_bot_name=%q, want %q", resp.Data.CreatorBotName, "Bot Display Name")
 	}
 	if resp.Data.CreatorID != "owner" {
 		t.Fatalf("creator_id=%q, want owner (the human on whose behalf the bot acts)", resp.Data.CreatorID)
+	}
+}
+
+func TestBotCreateResponseNonBotTaskHasEmptyBotName(t *testing.T) {
+	// Non-bot tasks must not carry a bot label: the CreatorBotID guard keeps
+	// creator_bot_name empty instead of resolving a bogus name for uid ""
+	// (review P2-3 non-bot case). Install a resolver that would poison an
+	// empty uid so the assertion can actually fail if the guard is removed.
+	service.SetUserNameResolver(func(uid string) string {
+		if uid == "" {
+			return "BOGUS"
+		}
+		return uid
+	})
+	t.Cleanup(func() {
+		service.SetUserNameResolver(func(uid string) string { return uid })
+	})
+	resp := botCreateResponse(model.SummaryTask{ID: 1, TaskNo: "T-NONBOT", CreatorID: "owner"})
+	if got, _ := resp["creator_bot_id"].(string); got != "" {
+		t.Fatalf("creator_bot_id=%q, want empty for non-bot task", got)
+	}
+	if got, _ := resp["creator_bot_name"].(string); got != "" {
+		t.Fatalf("creator_bot_name=%q, want empty for non-bot task", got)
 	}
 }
 

--- a/internal/api/handler/bot_summary_create_test.go
+++ b/internal/api/handler/bot_summary_create_test.go
@@ -94,6 +94,37 @@ func requestBotCreate(r *gin.Engine, key string, body []byte) *httptest.Response
 	return w
 }
 
+func TestCreateBotSummaryResponseIncludesBotIdentity(t *testing.T) {
+	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "true")
+	_, r, _ := setupBotCreateTest(t)
+	w := requestBotCreate(r, "botname-key", botCreateBody("group-a"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			TriggerType    int    `json:"trigger_type"`
+			CreatorID      string `json:"creator_id"`
+			CreatorBotID   string `json:"creator_bot_id"`
+			CreatorBotName string `json:"creator_bot_name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, w.Body.String())
+	}
+	// Bot-created summaries must expose the acting bot so the frontend can mark
+	// the card as "由 <bot> 创建".
+	if resp.Data.CreatorBotID != "bot-1" {
+		t.Fatalf("creator_bot_id=%q, want bot-1", resp.Data.CreatorBotID)
+	}
+	if resp.Data.CreatorBotName == "" {
+		t.Fatalf("creator_bot_name is empty; want resolved bot name")
+	}
+	if resp.Data.CreatorID != "owner" {
+		t.Fatalf("creator_id=%q, want owner (the human on whose behalf the bot acts)", resp.Data.CreatorID)
+	}
+}
+
 func TestCreateBotSummaryFeatureDisabled(t *testing.T) {
 	t.Setenv("BOT_SUMMARY_CREATE_ENABLED", "false")
 	_, r, _ := setupBotCreateTest(t)

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -803,6 +803,14 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			creatorName = service.ResolveUserName(t.CreatorID)
 		}
 
+		// Bot-created summaries (trigger_type=TriggerBot) carry the acting bot's
+		// uid in creator_bot_id; resolve its display name so the frontend can
+		// mark the card as "由 <bot> 创建".
+		creatorBotName := ""
+		if t.CreatorBotID != "" {
+			creatorBotName = service.ResolveUserName(t.CreatorBotID)
+		}
+
 		// Expose schedule_id on list items so the frontend can detect a scheduled
 		// task by its bound schedule (the authoritative signal) instead of relying
 		// on trigger_type. A manual task that later gets a scheduled-update added
@@ -856,6 +864,8 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"trigger_type":     t.TriggerType,
 			"schedule_id":      scheduleIDOut,
 			"creator_id":       t.CreatorID,
+			"creator_bot_id":   t.CreatorBotID,
+			"creator_bot_name": creatorBotName,
 			"participants":     parts,
 			"time_range_start": t.TimeRangeStart.Format(time.RFC3339),
 			"time_range_end":   t.TimeRangeEnd.Format(time.RFC3339),
@@ -1081,6 +1091,14 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 		}
 	}
 
+	// Owner + acting-bot display names, so the detail page can show
+	// "由 <bot> 代 <owner> 创建" for bot-created summaries (trigger_type=TriggerBot).
+	creatorName := service.ResolveUserName(task.CreatorID)
+	creatorBotName := ""
+	if task.CreatorBotID != "" {
+		creatorBotName = service.ResolveUserName(task.CreatorBotID)
+	}
+
 	resp := gin.H{
 		"task_id":          task.ID,
 		"task_no":          task.TaskNo,
@@ -1089,6 +1107,9 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 		"summary_mode":     task.SummaryMode,
 		"status":           task.Status,
 		"creator_id":       task.CreatorID,
+		"creator_name":     creatorName,
+		"creator_bot_id":   task.CreatorBotID,
+		"creator_bot_name": creatorBotName,
 		"trigger_type":     task.TriggerType,
 		"time_range_start": task.TimeRangeStart.Format(time.RFC3339),
 		"time_range_end":   task.TimeRangeEnd.Format(time.RFC3339),


### PR DESCRIPTION
## 目的
bot 创建的总结在数据层已可区分(`trigger_type=TriggerBot` + `creator_bot_id`,`creator_id`=owner),但 API 响应没透出 bot 身份,前端无法标注"由 <bot> 创建"。本 PR 把 bot 身份透出。

## 改动
- `GetSummaries`(列表)与 `GetSummary`(详情)用 `service.ResolveUserName(creator_bot_id)` 解析 bot 显示名,响应新增 `creator_bot_id` + `creator_bot_name`;详情另加 `creator_name`(owner),供前端展示"由 <bot> 代 <owner> 创建"。
- `botCreateResponse` 增加 `creator_bot_name`,便于刚建完即时展示。
- 无迁移;worker/生成链不动。

## 测试
`bot_summary_create_test.go` 新增 `TestCreateBotSummaryResponseIncludesBotIdentity`:bot 创建响应含非空 `creator_bot_id`/`creator_bot_name`,且 `creator_id=owner`。

本地 `go build ./internal/api/handler/` ✅、`gofmt` ✅;cgo 单测交 CI。

配套前端 PR:octo-web 卡片"由 <bot> 创建"+ Bot 小标、详情"由 <bot> 代 <owner> 创建"。