### PR TITLE
fix(summary): fail-closed empty X-Space-Id on version-history reads

### DIFF
--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -564,6 +564,15 @@ func (h *EditHandler) ListSummaryVersions(c *gin.Context) {
 		}
 	}
 	spaceID := middleware.GetSpaceID(c)
+	// fail-closed hard gate: GET requests are NOT caught by StrictSpaceMiddleware,
+	// and SummaryTask.SpaceID is `not null default ''`, so rows with space_id=''
+	// may exist; querying `space_id=''` would MATCH them, leaking a cross-space
+	// version-history read. Reject an empty X-Space-Id before any query (mirrors
+	// authorizeTaskAccess / requireTaskInSpace / ListSummaries).
+	if spaceID == "" {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
 	var task model.SummaryTask
 	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
 		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
@@ -618,6 +627,15 @@ func (h *EditHandler) GetSummaryVersion(c *gin.Context) {
 		return
 	}
 	spaceID := middleware.GetSpaceID(c)
+	// fail-closed hard gate: GET requests are NOT caught by StrictSpaceMiddleware,
+	// and SummaryTask.SpaceID is `not null default ''`, so rows with space_id=''
+	// may exist; querying `space_id=''` would MATCH them, leaking a cross-space
+	// version read. Reject an empty X-Space-Id before any query (mirrors
+	// authorizeTaskAccess / requireTaskInSpace / ListSummaries).
+	if spaceID == "" {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
 	var task model.SummaryTask
 	if err := h.db.Where("id = ? AND space_id = ? AND deleted_at IS NULL", taskID, spaceID).First(&task).Error; err != nil {
 		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})

--- a/internal/api/handler/edit_version_space_gate_test.go
+++ b/internal/api/handler/edit_version_space_gate_test.go
@@ -1,0 +1,142 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------------
+// Pentest 4.11 (逻辑漏洞·垂直越权) — empty-X-Space-Id fail-closed gate on the
+// summary version-history reads.
+//
+// GET /summaries/:id/versions and /summaries/:id/versions/:result_id previously
+// queried `id=? AND space_id=?` with NO spaceID=="" short-circuit — the only
+// summary read paths missing the hard gate every sibling has
+// (authorizeTaskAccess / requireTaskInSpace / ListSummaries / ListSchedules).
+// Because SummaryTask.SpaceID is `not null default ''`, an anomalous space_id=''
+// row could be read version-by-version by a header-less request from its
+// creator/participant (the exact "delete the X-Space-Id header" bypass). The
+// handlers now short-circuit spaceID=="" -> 40008/404 before any query.
+//
+// These tests SEED a real space_id='' task (+ result version) so the gate is
+// genuinely exercised: FAIL-before -> the empty-header query `space_id=''`
+// matched the seeded row and returned 200; PASS-after -> 404/40008.
+// ---------------------------------------------------------------------------
+
+func setupVersionGateRouter(h *EditHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.GET("/api/v1/summaries/:id/versions", h.ListSummaryVersions)
+	r.GET("/api/v1/summaries/:id/versions/:result_id", h.GetSummaryVersion)
+	return r
+}
+
+// seedEmptySpaceVersionTask seeds a space_id='' task owned by creator1 with one
+// SummaryResult version. Returns (taskID, resultID).
+func seedEmptySpaceVersionTask(t *testing.T, db *gorm.DB) (int64, int64) {
+	t.Helper()
+	now := time.Now().UTC()
+	task := model.SummaryTask{
+		TaskNo:      "TST-EDIT-EMPTYSPACE-001",
+		SpaceID:     "", // <-- the anomalous space_id='' row the gate must hide
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	db.Create(&task)
+	db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: "creator1", UserName: "Creator", Status: model.ParticipantCompleted,
+	})
+	result := model.SummaryResult{
+		TaskID:      task.ID,
+		Content:     "empty-space version content",
+		Version:     1,
+		GeneratedAt: now,
+	}
+	db.Create(&result)
+	return task.ID, result.ID
+}
+
+func doGetWithSpace(r *gin.Engine, path, userID, spaceID string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if userID != "" {
+		req.Header.Set("Token", userID)
+	}
+	if spaceID != "" {
+		req.Header.Set("X-Space-Id", spaceID)
+	}
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// 4.11: ListSummaryVersions with NO X-Space-Id against a real creator of a
+// space_id='' task must 404/40008 and NOT return the version list.
+// FAIL-before: empty header -> `space_id=''` matched -> 200 with versions.
+func TestListSummaryVersions_EmptySpaceHeader_Returns404(t *testing.T) {
+	db := setupEditDB(t)
+	taskID, _ := seedEmptySpaceVersionTask(t, db)
+	h := NewEditHandler(db)
+	r := setupVersionGateRouter(h)
+
+	w := doGetWithSpace(r, fmt.Sprintf("/api/v1/summaries/%d/versions", taskID), "creator1", "")
+	assertCrossSpace404(t, w)
+
+	var resp struct {
+		Data struct {
+			Versions []interface{} `json:"versions"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data.Versions) != 0 {
+		t.Errorf("empty-space ListSummaryVersions must NOT return versions, got %d; body=%s", len(resp.Data.Versions), w.Body.String())
+	}
+}
+
+// 4.11: GetSummaryVersion with NO X-Space-Id against a real creator of a
+// space_id='' task must 404/40008 and NOT return the version content.
+// FAIL-before: empty header -> `space_id=''` matched -> 200 with the version.
+func TestGetSummaryVersion_EmptySpaceHeader_Returns404(t *testing.T) {
+	db := setupEditDB(t)
+	taskID, resultID := seedEmptySpaceVersionTask(t, db)
+	h := NewEditHandler(db)
+	r := setupVersionGateRouter(h)
+
+	w := doGetWithSpace(r, fmt.Sprintf("/api/v1/summaries/%d/versions/%d", taskID, resultID), "creator1", "")
+	assertCrossSpace404(t, w)
+
+	if strings.Contains(w.Body.String(), "empty-space version content") {
+		t.Errorf("empty-space GetSummaryVersion must NOT return the version content; body=%s", w.Body.String())
+	}
+}
+
+// No-regression inverse: a genuine in-space task read with the CORRECT header
+// still returns the versions (200), proving the new gate did not over-block.
+func TestSummaryVersions_EmptySpaceGate_NoRegressionInSpace(t *testing.T) {
+	db := setupEditDB(t)
+	taskID, resultID, _ := seedEditableTask(t, db) // space1, creator1, one result
+	h := NewEditHandler(db)
+	r := setupVersionGateRouter(h)
+
+	wList := doGetWithSpace(r, fmt.Sprintf("/api/v1/summaries/%d/versions", taskID), "creator1", "space1")
+	if wList.Code != http.StatusOK {
+		t.Fatalf("in-space ListSummaryVersions must be 200, got %d: %s", wList.Code, wList.Body.String())
+	}
+	wGet := doGetWithSpace(r, fmt.Sprintf("/api/v1/summaries/%d/versions/%d", taskID, resultID), "creator1", "space1")
+	if wGet.Code != http.StatusOK {
+		t.Fatalf("in-space GetSummaryVersion must be 200, got %d: %s", wGet.Code, wGet.Body.String())
+	}
+}

--- a/internal/api/handler/list_space_gate_test.go
+++ b/internal/api/handler/list_space_gate_test.go
@@ -1,0 +1,116 @@
+//go:build cgo
+
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------------
+// Pentest 4.11 (逻辑漏洞·垂直越权) regression — ListSummaries empty-X-Space-Id
+// fail-closed hard gate.
+//
+// The report's mechanism: space-level authorization hinges on the X-Space-Id
+// header; when a caller simply REMOVES that header the backend must NOT fall
+// open. summary's SpaceMiddleware deliberately allows an empty space_id
+// (space_id="" => "no isolation") and StrictSpaceMiddleware only enforces the
+// header on WRITE methods, so a GET like /api/v1/summaries reaches the handler
+// with space_id="". SummaryTask.SpaceID is `not null default ''`, so a
+// space_id='' row CAN exist; without an explicit guard the list query
+// `space_id=''` would MATCH such a row and return it (fail-open cross-space
+// read == the 4.11 bypass).
+//
+// ListSummaries (task.go) now short-circuits spaceID=="" -> 40008/404 BEFORE
+// the query. The detail/accept/submit/personal/members read paths already have
+// their own empty-space regressions in members_auth_test.go; this file closes
+// the one remaining summary READ surface — the list endpoint — against the
+// exact "delete the header" PoC.
+// ---------------------------------------------------------------------------
+
+// seedEmptySpaceListTask seeds a task whose SpaceID is the empty string, owned
+// by creator1, into the list test DB. If the empty-space hard gate were absent,
+// a header-less list call would run `space_id='' AND creator_id='creator1'`,
+// match this row, and return total=1 (the fail-open the guard must prevent).
+func seedEmptySpaceListTask(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	task := model.SummaryTask{
+		TaskNo:      "TST-LIST-EMPTYSPACE-001",
+		SpaceID:     "", // <-- the anomalous space_id='' row the gate must hide
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	db.Create(&task)
+	db.Create(&model.SummarySource{TaskID: task.ID, SourceType: model.SourceGroup, SourceID: "grp_abc"})
+	db.Create(&model.SummaryParticipant{TaskID: task.ID, UserID: "participant1", UserName: "P1"})
+}
+
+// 4.11: the creator of a space_id='' task, listing with NO X-Space-Id header,
+// must get 404/40008 and NO task rows — the header-deletion bypass is closed.
+// FAIL-before: empty header -> query `space_id=''` matches the seeded row ->
+// 200 with total=1 (cross-space roster of an anomalous row leaks). PASS-after:
+// the spaceID=="" short-circuit 404s before any query.
+func TestListSummaries_EmptySpaceHeader_Returns404NoLeak(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedEmptySpaceListTask(t, db)
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	// creator1 is a genuine creator of the space_id='' task, but sends no header.
+	w := doRequestWithSpace(r, "GET", "/api/v1/summaries", "creator1", "")
+	assertCrossSpace404(t, w) // 404 + resp.Code == 40008
+
+	// The task must not have leaked through the empty-space request.
+	if bytes.Contains(w.Body.Bytes(), []byte("TST-LIST-EMPTYSPACE-001")) ||
+		bytes.Contains(w.Body.Bytes(), []byte("\"items\"")) {
+		t.Errorf("empty-space ListSummaries must NOT return any task, body=%s", w.Body.String())
+	}
+}
+
+// 4.11 companion (non-empty but wrong space): a creator of a space1 task who
+// lists with a DIFFERENT, non-empty X-Space-Id must NOT see it. The space_id
+// filter scopes the query, so the result is a clean 200 with total=0 — no
+// cross-space enumeration. (Unlike the empty header, a wrong non-empty header
+// is a normal scoped query, not the hard-gate 404.)
+func TestListSummaries_WrongSpaceHeader_SeesNothing(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedListTask(t, db, imDB) // task lives in space1, creator1 + participant1
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	w := doRequestWithSpace(r, "GET", "/api/v1/summaries", "creator1", "other_space")
+	if w.Code != http.StatusOK {
+		t.Fatalf("wrong-space list must be a scoped 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 0 {
+		t.Errorf("wrong-space list must not surface another space's task, got total=%d", resp.Data.Total)
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("TST-LIST-001")) {
+		t.Errorf("wrong-space list must not leak the space1 task, body=%s", w.Body.String())
+	}
+}
+
+// No-regression inverse: the SAME creator with the CORRECT space header still
+// sees their task (200, total=1), proving the empty-space gate did not
+// over-block legitimate in-space list reads.
+func TestListSummaries_EmptySpaceGate_NoRegressionInSpace(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedListTask(t, db, imDB) // space1, creator1 + participant1
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	w := doRequestWithSpace(r, "GET", "/api/v1/summaries", "creator1", "space1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("in-space creator must still get 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 1 {
+		t.Errorf("in-space creator must still see their task, got total=%d", resp.Data.Total)
+	}
+}

--- a/internal/api/handler/schedule_space_gate_test.go
+++ b/internal/api/handler/schedule_space_gate_test.go
@@ -1,0 +1,89 @@
+//go:build cgo
+
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------------
+// Pentest 4.11 — empty-X-Space-Id fail-closed lock-in for the schedule reads.
+//
+// ListSchedules / GetSchedule already short-circuit spaceID=="" -> 40008/404
+// (schedule.go). These tests lock that gate against regression using a genuine
+// space_id='' schedule row: a header-less read must 404, never surface the
+// anomalous row.
+// ---------------------------------------------------------------------------
+
+func setupScheduleReadRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	sh := NewScheduleHandler(db)
+	r.GET("/api/v1/summary-schedules", sh.ListSchedules)
+	r.GET("/api/v1/summary-schedules/:id", sh.GetSchedule)
+	return r
+}
+
+// seedEmptySpaceSchedule creates a schedule whose SpaceID is the empty string.
+func seedEmptySpaceSchedule(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	sched := model.SummarySchedule{
+		SpaceID:   "", // <-- anomalous space_id='' row the gate must hide
+		CreatorID: "creator1",
+		Title:     "empty-space schedule",
+		IsActive:  1,
+	}
+	if err := db.Create(&sched).Error; err != nil {
+		t.Fatalf("seed empty-space schedule: %v", err)
+	}
+	return sched.ID
+}
+
+// 4.11: ListSchedules with NO X-Space-Id must 404/40008, never returning the
+// space_id='' schedule.
+func TestListSchedules_EmptySpaceHeader_Returns404(t *testing.T) {
+	db := newScheduleTestDB(t)
+	seedEmptySpaceSchedule(t, db)
+	r := setupScheduleReadRouter(db)
+
+	w := scheduleReq(t, r, "creator1", "", http.MethodGet, "/api/v1/summary-schedules", nil)
+	assertCrossSpace404(t, w)
+}
+
+// 4.11: GetSchedule with NO X-Space-Id must 404/40008, never returning the
+// space_id='' schedule.
+func TestGetSchedule_EmptySpaceHeader_Returns404(t *testing.T) {
+	db := newScheduleTestDB(t)
+	schedID := seedEmptySpaceSchedule(t, db)
+	r := setupScheduleReadRouter(db)
+
+	w := scheduleReq(t, r, "creator1", "", http.MethodGet, "/api/v1/summary-schedules/"+sid(schedID), nil)
+	assertCrossSpace404(t, w)
+}
+
+// No-regression inverse: the SAME creator reading with the CORRECT space header
+// still gets a 200 (the gate does not over-block in-space schedule reads).
+func TestSchedule_EmptySpaceGate_NoRegressionInSpace(t *testing.T) {
+	db := newScheduleTestDB(t)
+	sched := model.SummarySchedule{SpaceID: "space1", CreatorID: "creator1", Title: "s", IsActive: 1}
+	if err := db.Create(&sched).Error; err != nil {
+		t.Fatalf("seed in-space schedule: %v", err)
+	}
+	r := setupScheduleReadRouter(db)
+
+	wList := scheduleReq(t, r, "creator1", "space1", http.MethodGet, "/api/v1/summary-schedules", nil)
+	if wList.Code != http.StatusOK {
+		t.Fatalf("in-space ListSchedules must be 200, got %d: %s", wList.Code, wList.Body.String())
+	}
+	wGet := scheduleReq(t, r, "creator1", "space1", http.MethodGet, "/api/v1/summary-schedules/"+sid(sched.ID), nil)
+	if wGet.Code != http.StatusOK {
+		t.Fatalf("in-space GetSchedule must be 200, got %d: %s", wGet.Code, wGet.Body.String())
+	}
+}


### PR DESCRIPTION
## 背景

渗透测试报告(复测)4.11「逻辑漏洞·垂直越权」的核心手法:空间级鉴权依赖 `X-Space-Id` 请求头,**删掉该头后后端未做默认拒绝**即可绕过。报告的 PoC 打在主站接口,但同一机制适用于 summary——本 PR 修复 summary 侧最后一处 fail-open 读接口并补齐回归。

## 问题

`ListSummaryVersions` / `GetSummaryVersion` 按 `id=? AND space_id=?` 查询,但**唯独缺少** siblings(`authorizeTaskAccess` / `requireTaskInSpace` / `ListSummaries` / `ListSchedules`)都已具备的 `spaceID=="" → 404` 硬门。由于 `SummaryTask.SpaceID` 为 `not null default ''`,请求方只要**不带 X-Space-Id**,查询就变成 `space_id=''`,会命中任何异常的 `space_id=''` 任务行,并把其版本历史返回给该任务的 creator/participant —— 即报告所述的删头越权。

严重度:低(需存在 `space_id=''` 异常行 + 调用者为其成员),但属于「让空 X-Space-Id 在全读面一律 fail-closed」应堵的一致性缺口。

## 改动

- `edit.go`:`ListSummaryVersions` / `GetSummaryVersion` 在查询前短路 `spaceID=="" → 40008/404`,与其它读路径一致。
- 回归测试(此前该读面无空头测试):
  - `edit_version_space_gate_test.go` —— 两个被修接口的 **FAIL-before/PASS-after**(种真实 `space_id=''` 任务)+ 正确 space 的 no-regression。
  - `list_space_gate_test.go` —— 锁定 `ListSummaries` 空/错 space 门。
  - `schedule_space_gate_test.go` —— 锁定 `ListSchedules` / `GetSchedule` 空 space 门。

## 验证

`golang:1.25-bookworm`(CGO + libtokenizers)内:新增用例 + 既有全套空间隔离用例 + **整个 handler 包**全部通过。

## 审计结论(其余读接口)

`GetSummary/GetResult/Regenerate/Delete/Cancel`、`Accept/Decline/Submit/GetPersonal/Members/Personal-versions`、`ListSchedules/GetSchedule`、`StreamSummary` 均已 fail-closed;`GetTemplates`(空 space 跳过查询)、`InferScope`(不碰 DB)、agent `History`(按 uid)、`ShareHandler.Get`(等值 space + 成员校验)无跨空间泄露面。修复后 summary 全读接口对空 X-Space-Id 一致 fail-closed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)