### PR TITLE
fix(summary): resolve agent-path source names so chips stop showing raw channel ids

### DIFF
--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -36,6 +36,7 @@ import (
 //     boundary the Chat handler already enforces.
 type AgentSummaryHandler struct {
 	db           *gorm.DB
+	imDB         *gorm.DB
 	llmApiURL    string
 	llmApiKey    string
 	llmModel     string
@@ -60,9 +61,10 @@ type refineRunner interface {
 	RunWithHistory(ctx context.Context, system string, history []agent.Message, userInput string) (string, []agent.Message, error)
 }
 
-func NewAgentSummaryHandler(db *gorm.DB, llmApiURL, llmApiKey, llmModel string, llmTimeout, llmMaxTokens int) *AgentSummaryHandler {
+func NewAgentSummaryHandler(db, imDB *gorm.DB, llmApiURL, llmApiKey, llmModel string, llmTimeout, llmMaxTokens int) *AgentSummaryHandler {
 	return &AgentSummaryHandler{
 		db:           db,
+		imDB:         imDB,
 		llmApiURL:    llmApiURL,
 		llmApiKey:    llmApiKey,
 		llmModel:     llmModel,
@@ -357,10 +359,12 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 
 		// Sources: agent-produced summaries carry their own source list from
 		// the front-end (which knows the origin channel + any additional
-		// referenced channels). We do not currently resolve source names via
-		// IM DB — the deliverable already contains channel names in prose —
-		// so we store source_id only; a future PR can plumb imDB in and call
-		// ResolveSourceNameWithType if the UI wants the resolved display name.
+		// referenced channels). Source names are resolved from the IM DB the
+		// same way the instant path (CreateSummary) does, so the detail chip
+		// shows a human-readable name instead of a raw channel id; the
+		// client-supplied name is deliberately NOT trusted (the instant path
+		// drops it too — see task.go's CreateSummary). ResolveSourceNameWithType
+		// handles a nil imDB with a deterministic "来源-xxxxxxxx" fallback.
 		//
 		// R10: dedup by (source_type, source_id) — uk_summary_source_task_type_id
 		// (migration 20260814-01) would turn duplicate front-end input into a
@@ -379,6 +383,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 				TaskID:     createdTaskID,
 				SourceType: s.SourceType,
 				SourceID:   s.SourceID,
+				SourceName: service.ResolveSourceNameWithType(s.SourceID, s.SourceType, h.imDB),
 			}
 			if err := tx.Create(&src).Error; err != nil {
 				return fmt.Errorf("create summary_source: %w", err)

--- a/internal/api/handler/agent_summary_origin_derive_test.go
+++ b/internal/api/handler/agent_summary_origin_derive_test.go
@@ -92,7 +92,7 @@ func seedPipelineRefTask(t *testing.T, h *AgentSummaryHandler, taskNo string) mo
 // rows → save succeeds with the source channel as origin.
 func TestCreateAgentSummary_DeriveOriginFromSingleSource(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	ref := seedPipelineRefTask(t, h, "ST-PIPE-001")
@@ -142,7 +142,7 @@ func TestCreateAgentSummary_DeriveOriginFromSingleSource(t *testing.T) {
 // precedent.
 func TestCreateAgentSummary_DeriveOriginMultiSourceInheritsFirst(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	ref := seedPipelineRefTask(t, h, "ST-PIPE-002")
@@ -190,7 +190,7 @@ func TestCreateAgentSummary_DeriveOriginMultiSourceInheritsFirst(t *testing.T) {
 // row wins. If nothing usable remains the save still 40001s.
 func TestCreateAgentSummary_DeriveOriginSkipsUnusableRows(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	ref := seedPipelineRefTask(t, h, "ST-PIPE-003")
@@ -240,7 +240,7 @@ func TestCreateAgentSummary_DeriveOriginSkipsUnusableRows(t *testing.T) {
 // the fail-closed contract is unchanged for genuinely origin-less summaries.
 func TestCreateAgentSummary_DeriveOriginNoSourcesStill40001(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	ref := seedPipelineRefTask(t, h, "ST-PIPE-004") // no summary_source rows
@@ -285,7 +285,7 @@ func TestCreateAgentSummary_DeriveOriginNoSourcesStill40001(t *testing.T) {
 // source channels — same authz posture as tier-3.
 func TestCreateAgentSummary_DeriveOriginNoAccessRefused(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	now := time.Now()
@@ -334,7 +334,7 @@ func TestCreateAgentSummary_DeriveOriginNoAccessRefused(t *testing.T) {
 // consulted (regression guard for the pre-existing path).
 func TestCreateAgentSummary_Tier3BorrowStillWins(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	now := time.Now()
@@ -396,7 +396,7 @@ func TestCreateAgentSummary_Tier3BorrowStillWins(t *testing.T) {
 // same as an inaccessible task.
 func TestCreateAgentSummary_OriginBorrowRefusesDeletedReferencedTask(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	now := time.Now()
@@ -449,7 +449,7 @@ func TestCreateAgentSummary_OriginBorrowRefusesDeletedReferencedTask(t *testing.
 
 func TestCreateAgentSummary_OriginBorrowRefusesNonCompletedReferencedTask(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	now := time.Now()
@@ -505,7 +505,7 @@ func TestCreateAgentSummary_OriginBorrowRefusesNonCompletedReferencedTask(t *tes
 // partial lineage.
 func TestCreateAgentSummary_OverCapReferencedTaskIDsRejected400(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	overCap := make([]int64, 0, maxReferencedTaskIDs+3)
@@ -550,7 +550,7 @@ func TestCreateAgentSummary_OverCapReferencedTaskIDsRejected400(t *testing.T) {
 // dedup-then-check posture).
 func TestCreateAgentSummary_DuplicateIDsCollapseBelowCapAccepted(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	ref := seedPipelineRefTask(t, h, "ST-PIPE-DUP-01")
@@ -594,7 +594,7 @@ func TestCreateAgentSummary_DuplicateIDsCollapseBelowCapAccepted(t *testing.T) {
 // borrowable citations the marker dangles and must be stripped before save.
 func TestCreateAgentSummary_DanglingMarkersStrippedWhenBorrowRedacted(t *testing.T) {
 	db := newFileBackedAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	now := time.Now()
@@ -670,7 +670,7 @@ func TestCreateAgentSummary_DanglingMarkersStrippedWhenBorrowRedacted(t *testing
 // happy path.
 func TestCreateAgentSummary_MarkersPreservedWhenBorrowSucceeds(t *testing.T) {
 	db := newFileBackedAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	now := time.Now()

--- a/internal/api/handler/agent_summary_test.go
+++ b/internal/api/handler/agent_summary_test.go
@@ -61,7 +61,7 @@ func setupAgentSummaryRouter(h *AgentSummaryHandler) *gin.Engine {
 // behavior is unchanged (no resolve, direct validation and pass).
 func TestCreateAgentSummary_ProvidedOriginChannelDirectPass(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed: session with assistant message (deliverable content)
@@ -117,7 +117,7 @@ func TestCreateAgentSummary_ProvidedOriginChannelDirectPass(t *testing.T) {
 // and successfully creates the task with the resolved values.
 func TestCreateAgentSummary_NotProvidedResolveSuccess(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed: session with assistant message (deliverable) and fetch_channel tool call
@@ -183,7 +183,7 @@ func TestCreateAgentSummary_NotProvidedResolveSuccess(t *testing.T) {
 // returns 400 40001 with the new error message.
 func TestCreateAgentSummary_NotProvidedResolveFailure(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed: session with only assistant content, no fetch_channel tool call
@@ -233,7 +233,7 @@ func TestCreateAgentSummary_NotProvidedResolveFailure(t *testing.T) {
 // is explicitly provided as an empty string, the handler returns the old error message.
 func TestCreateAgentSummary_ExplicitlyEmptyString(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed: session with assistant content
@@ -280,7 +280,7 @@ func TestCreateAgentSummary_ExplicitlyEmptyString(t *testing.T) {
 // is out of valid range (1-3), the handler returns 400 40001 with the original message.
 func TestCreateAgentSummary_InvalidChannelType(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed: session with assistant content

--- a/internal/api/handler/origin_from_derived_mask_test.go
+++ b/internal/api/handler/origin_from_derived_mask_test.go
@@ -151,7 +151,7 @@ func detailOrigin(t *testing.T, r *gin.Engine, taskID int64) (string, int) {
 // derived source row — the refiner may not be a member of that channel.
 func TestOriginFromDerived_DetailMasksDerivedInheritedOrigin(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, "", "", "", 0, 0))
+	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, nil, "", "", "", 0, 0))
 
 	created := seedDerivedOnlyRefTaskAndRefine(t, db, r, "ST-Q2-DETAIL", "session-q2-detail", "CH-PRIVATE-ALICE")
 
@@ -166,7 +166,7 @@ func TestOriginFromDerived_DetailMasksDerivedInheritedOrigin(t *testing.T) {
 // same mask on the list projection.
 func TestOriginFromDerived_ListMasksDerivedInheritedOrigin(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, "", "", "", 0, 0))
+	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, nil, "", "", "", 0, 0))
 
 	created := seedDerivedOnlyRefTaskAndRefine(t, db, r, "ST-Q2-LIST", "session-q2-list", "CH-PRIVATE-ALICE")
 
@@ -203,7 +203,7 @@ func TestOriginFromDerived_ListMasksDerivedInheritedOrigin(t *testing.T) {
 // carry channel X as its origin?" reveals X's presence without membership).
 func TestOriginFromDerived_ListFilterDoesNotMatchMaskedOrigin(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, "", "", "", 0, 0))
+	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, nil, "", "", "", 0, 0))
 
 	seedDerivedOnlyRefTaskAndRefine(t, db, r, "ST-Q2-FILTER", "session-q2-filter", "CH-PRIVATE-ALICE")
 
@@ -224,7 +224,7 @@ func TestOriginFromDerived_ListFilterDoesNotMatchMaskedOrigin(t *testing.T) {
 // channel either.
 func TestOriginFromDerived_FlagPropagatesThroughTier3Borrow(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, "", "", "", 0, 0))
+	r := setupAgentSummaryRouter(NewAgentSummaryHandler(db, nil, "", "", "", 0, 0))
 
 	first := seedDerivedOnlyRefTaskAndRefine(t, db, r, "ST-Q2-PROP", "session-q2-prop-1", "CH-PRIVATE-ALICE")
 

--- a/internal/api/handler/share.go
+++ b/internal/api/handler/share.go
@@ -405,8 +405,11 @@ func (h *ShareHandler) Create(c *gin.Context) {
 			continue
 		}
 		visibleCount++
-		if strings.TrimSpace(source.SourceName) != "" {
-			names = append(names, source.SourceName)
+		// displaySourceName falls back to a live IM lookup for rows written
+		// before the agent path stored names (see task.go); the share
+		// snapshot is user-visible text, same as the list/detail chips.
+		if name := displaySourceName(source, h.imDB); strings.TrimSpace(name) != "" {
+			names = append(names, name)
 		}
 	}
 	var participantCount int64

--- a/internal/api/handler/source_name_display_test.go
+++ b/internal/api/handler/source_name_display_test.go
@@ -1,0 +1,375 @@
+//go:build cgo
+
+package handler
+
+// Regression tests for the "summary-detail-source-chip 乱码 / 裸 ID" bug
+// (owner report 2026-08-17, live task ST20260811jcw59o84):
+//
+//  1. Write side — POST /api/v1/summaries/agent (CreateAgentSummary) stored
+//     source_id only and left source_name empty (the old code comment said
+//     "a future PR can plumb imDB in"). The front-end chip renders
+//     `source_name || source_id`, so agent-created summaries showed the raw
+//     channel hex id ("来自fef0c26327664232a2fd73ce2fb98ec6"). The agent path
+//     now resolves names exactly like CreateSummary (task.go) does.
+//
+//  2. Read side — rows already persisted with an empty source_name (10 live
+//     rows at report time) are resolved live on list/detail/share via
+//     displaySourceName. A non-empty stored name is a creation-time snapshot
+//     and is NEVER overwritten (a later group rename must not rewrite
+//     history — same semantics as the instant path).
+//
+// Every test below must go RED if its corresponding fix line is reverted.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// setupSourceNameImDB creates an IM DB (sqlite) with the `group` table the
+// group branch of service.ResolveSourceNameWithType reads. Same schema shape
+// as setupBotCreateTest.
+func setupSourceNameImDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	imDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open im db: %v", err)
+	}
+	if err := imDB.Exec(`CREATE TABLE "group" (group_no TEXT, name TEXT, space_id TEXT, status INTEGER, updated_at DATETIME)`).Error; err != nil {
+		t.Fatalf("create group table: %v", err)
+	}
+	return imDB
+}
+
+func seedImGroup(t *testing.T, imDB *gorm.DB, groupNo, name string) {
+	t.Helper()
+	if err := imDB.Exec(`INSERT INTO "group" (group_no, name, space_id, status, updated_at) VALUES (?, ?, ?, 1, ?)`,
+		groupNo, name, "space1", time.Now()).Error; err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+}
+
+// doAgentCreateRequest posts a create-agent-summary request with the given
+// sources array and returns the recorder. Mirrors the request shape used by
+// TestCreateAgentSummary_ProvidedOriginChannelDirectPass.
+func doAgentCreateRequest(t *testing.T, h *AgentSummaryHandler, sessionID string, sources []map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	r := setupAgentSummaryRouter(h)
+	reqBody := map[string]interface{}{
+		"session_id":          sessionID,
+		"origin_channel_id":   "CH-SRCNAME",
+		"origin_channel_type": 1,
+		"title":               "Source name test",
+		"sources":             sources,
+	}
+	bodyBytes, _ := json.Marshal(reqBody)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/summaries/agent", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Token", "test-user")
+	req.Header.Set("X-Space-Id", "test-space")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestCreateAgentSummary_SourceNameResolvedFromIMDB pins the write-side fix:
+// the agent path resolves source names from the IM DB (parity with
+// CreateSummary), so newly created agent summaries never persist an empty
+// source_name. Reverting the ResolveSourceNameWithType call in
+// CreateAgentSummary makes this RED (persisted name becomes "").
+func TestCreateAgentSummary_SourceNameResolvedFromIMDB(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	imDB := setupSourceNameImDB(t)
+	const groupNo = "fef0c26327664232a2fd73ce2fb98ec6"
+	seedImGroup(t, imDB, groupNo, "一个群聊")
+
+	// Seed: session with an assistant deliverable (required by the handler).
+	db.Create(&model.AgentMessage{
+		UserID:    "test-user",
+		SessionID: "session-srcname-001",
+		Role:      "assistant",
+		Content:   "Agent-generated deliverable.",
+	})
+
+	h := NewAgentSummaryHandler(db, imDB, "", "", "", 0, 0)
+	w := doAgentCreateRequest(t, h, "session-srcname-001", []map[string]interface{}{
+		{"source_type": 1, "source_id": groupNo},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var src model.SummarySource
+	if err := db.First(&src).Error; err != nil {
+		t.Fatalf("source row not persisted: %v", err)
+	}
+	if src.SourceID != groupNo {
+		t.Fatalf("source_id = %q, want %q", src.SourceID, groupNo)
+	}
+	if src.SourceName != "一个群聊(群聊)" {
+		t.Errorf("source_name = %q, want %q (resolved from IM DB with type suffix)", src.SourceName, "一个群聊(群聊)")
+	}
+}
+
+// TestCreateAgentSummary_ClientSourceNameNotTrusted pins that a
+// client-supplied source_name is dropped in favour of the canonical IM DB
+// resolution — same contract as the instant path (CreateSummary ignores
+// req source_name; see task.go) and the schedule path
+// (buildScheduledTaskSources: "never trust a client-supplied source_name").
+func TestCreateAgentSummary_ClientSourceNameNotTrusted(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	imDB := setupSourceNameImDB(t)
+	const groupNo = "81f67cec0180463a8bd74117e5582125"
+	seedImGroup(t, imDB, groupNo, "真实群名")
+
+	db.Create(&model.AgentMessage{
+		UserID:    "test-user",
+		SessionID: "session-srcname-002",
+		Role:      "assistant",
+		Content:   "Agent-generated deliverable.",
+	})
+
+	h := NewAgentSummaryHandler(db, imDB, "", "", "", 0, 0)
+	w := doAgentCreateRequest(t, h, "session-srcname-002", []map[string]interface{}{
+		{"source_type": 1, "source_id": groupNo, "source_name": "客户端伪造的名字"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var src model.SummarySource
+	if err := db.First(&src).Error; err != nil {
+		t.Fatalf("source row not persisted: %v", err)
+	}
+	if src.SourceName != "真实群名(群聊)" {
+		t.Errorf("source_name = %q, want %q (client-supplied name must be ignored)", src.SourceName, "真实群名(群聊)")
+	}
+}
+
+// TestCreateAgentSummary_SourceNameNilImDBFallback pins graceful degradation:
+// with no IM DB wired (imDB == nil) the deterministic "来源-xxxxxxxx"
+// fallback is stored instead of an empty string, so the chip never regresses
+// to a raw id.
+func TestCreateAgentSummary_SourceNameNilImDBFallback(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	const groupNo = "fef0c26327664232a2fd73ce2fb98ec6"
+
+	db.Create(&model.AgentMessage{
+		UserID:    "test-user",
+		SessionID: "session-srcname-003",
+		Role:      "assistant",
+		Content:   "Agent-generated deliverable.",
+	})
+
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	w := doAgentCreateRequest(t, h, "session-srcname-003", []map[string]interface{}{
+		{"source_type": 1, "source_id": groupNo},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var src model.SummarySource
+	if err := db.First(&src).Error; err != nil {
+		t.Fatalf("source row not persisted: %v", err)
+	}
+	if src.SourceName != "来源-fef0c263(群聊)" {
+		t.Errorf("source_name = %q, want deterministic fallback %q", src.SourceName, "来源-fef0c263(群聊)")
+	}
+}
+
+// seedEmptyNameSourceTask seeds one completed task whose summary_source row
+// has an EMPTY source_name — the exact shape of the 10 live rows written by
+// the agent path before this fix (e.g. task ST20260811jcw59o84).
+func seedEmptyNameSourceTask(t *testing.T, db *gorm.DB, taskNo, sourceID string) int64 {
+	t.Helper()
+	task := model.SummaryTask{
+		TaskNo:      taskNo,
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := db.Create(&model.SummarySource{
+		TaskID: task.ID, SourceType: model.SourceGroup, SourceID: sourceID, // SourceName left empty on purpose
+	}).Error; err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	return task.ID
+}
+
+// TestGetSummary_EmptySourceNameResolvedLive is the live-bug regression:
+// ST20260811jcw59o84 rendered "来自fef0c26327664232a2fd73ce2fb98ec6" because
+// the stored name was empty and the chip falls back to source_id. The detail
+// endpoint must resolve such rows live from the IM DB. Reverting
+// displaySourceName back to s.SourceName makes this RED.
+func TestGetSummary_EmptySourceNameResolvedLive(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	imDB.Exec(`CREATE TABLE IF NOT EXISTS "group" (group_no TEXT, name TEXT, space_id TEXT, status INTEGER, updated_at DATETIME)`)
+	const groupNo = "fef0c26327664232a2fd73ce2fb98ec6"
+	seedImGroup(t, imDB, groupNo, "一个群聊")
+	taskID := seedEmptyNameSourceTask(t, db, "TST-SRCNAME-DETAIL", groupNo)
+
+	h := NewTaskHandler(db, imDB, "")
+	r := setupRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d", taskID), "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Sources []struct {
+				SourceID   string `json:"source_id"`
+				SourceName string `json:"source_name"`
+			} `json:"sources"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data.Sources) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(resp.Data.Sources))
+	}
+	if resp.Data.Sources[0].SourceName != "一个群聊(群聊)" {
+		t.Errorf("detail source_name = %q, want %q (empty stored name must be resolved live)",
+			resp.Data.Sources[0].SourceName, "一个群聊(群聊)")
+	}
+}
+
+// TestGetSummary_StoredSourceNameNotOverwritten pins snapshot semantics: a
+// non-empty stored name was resolved at creation time and must survive a
+// later group rename. displaySourceName must NOT re-resolve non-empty names.
+func TestGetSummary_StoredSourceNameNotOverwritten(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	imDB.Exec(`CREATE TABLE IF NOT EXISTS "group" (group_no TEXT, name TEXT, space_id TEXT, status INTEGER, updated_at DATETIME)`)
+	const groupNo = "81f67cec0180463a8bd74117e5582125"
+	seedImGroup(t, imDB, groupNo, "改名后的新群名")
+
+	task := model.SummaryTask{
+		TaskNo:      "TST-SRCNAME-SNAPSHOT",
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusCompleted,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := db.Create(&model.SummarySource{
+		TaskID: task.ID, SourceType: model.SourceGroup, SourceID: groupNo,
+		SourceName: "创建时的旧群名(群聊)", // snapshot taken before the rename
+	}).Error; err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+
+	h := NewTaskHandler(db, imDB, "")
+	r := setupRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d", task.ID), "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Sources []struct {
+				SourceName string `json:"source_name"`
+			} `json:"sources"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data.Sources) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(resp.Data.Sources))
+	}
+	if resp.Data.Sources[0].SourceName != "创建时的旧群名(群聊)" {
+		t.Errorf("detail source_name = %q, want stored snapshot %q (a live rename must not rewrite history)",
+			resp.Data.Sources[0].SourceName, "创建时的旧群名(群聊)")
+	}
+}
+
+// TestGetSummary_EmptySourceNameNilImDB pins that an empty stored name with
+// no IM DB wired degrades to the deterministic placeholder instead of an
+// empty string (which would make the chip fall back to the raw id again).
+func TestGetSummary_EmptySourceNameNilImDB(t *testing.T) {
+	db, _ := setupListTestDBs(t)
+	const groupNo = "fef0c26327664232a2fd73ce2fb98ec6"
+	taskID := seedEmptyNameSourceTask(t, db, "TST-SRCNAME-NILIM", groupNo)
+
+	h := NewTaskHandler(db, nil, "")
+	r := setupRouter(h)
+
+	w := doRequest(r, "GET", fmt.Sprintf("/api/v1/summaries/%d", taskID), "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data struct {
+			Sources []struct {
+				SourceName string `json:"source_name"`
+			} `json:"sources"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data.Sources) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(resp.Data.Sources))
+	}
+	if resp.Data.Sources[0].SourceName != "来源-fef0c263(群聊)" {
+		t.Errorf("detail source_name = %q, want deterministic fallback %q",
+			resp.Data.Sources[0].SourceName, "来源-fef0c263(群聊)")
+	}
+}
+
+// TestListSummaries_EmptySourceNameResolvedLive mirrors the detail test on
+// the list endpoint (the summary-list page renders the same chip data).
+func TestListSummaries_EmptySourceNameResolvedLive(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	imDB.Exec(`CREATE TABLE IF NOT EXISTS "group" (group_no TEXT, name TEXT, space_id TEXT, status INTEGER, updated_at DATETIME)`)
+	const groupNo = "1b1f1113189540b697742ef264c38091"
+	seedImGroup(t, imDB, groupNo, "产品需求评审群")
+	seedEmptyNameSourceTask(t, db, "TST-SRCNAME-LIST", groupNo)
+
+	h := NewTaskHandler(db, imDB, "")
+	r := setupListRouter(h)
+
+	w := doRequest(r, "GET", "/api/v1/summaries", "creator1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := parseListResponse(t, w)
+	if resp.Data.Total != 1 {
+		t.Fatalf("expected total 1, got %d", resp.Data.Total)
+	}
+	item, ok := resp.Data.Items[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("item not an object: %v", resp.Data.Items[0])
+	}
+	srcs, ok := item["sources"].([]interface{})
+	if !ok || len(srcs) != 1 {
+		t.Fatalf("expected 1 source in list item, got: %v", item["sources"])
+	}
+	only := srcs[0].(map[string]interface{})
+	if only["source_name"] != "产品需求评审群(群聊)" {
+		t.Errorf("list source_name = %v, want %q (empty stored name must be resolved live)",
+			only["source_name"], "产品需求评审群(群聊)")
+	}
+}

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -173,6 +173,21 @@ func (h *TaskHandler) pickDisplayResult(taskID int64) (model.SummaryResult, bool
 	return result, true
 }
 
+// displaySourceName returns the user-visible name for a persisted
+// summary_source row. A non-empty stored name is a creation-time snapshot
+// and is returned as-is (a later group rename must not rewrite history).
+// An empty name — rows written before the agent path resolved names
+// (POST /summaries/agent stored source_id only until this PR) — falls back
+// to a live IM DB lookup so list/detail/share show a readable name instead
+// of a raw channel id. ResolveSourceNameWithType handles nil imDB and
+// lookup misses with a deterministic "来源-xxxxxxxx" placeholder.
+func displaySourceName(s model.SummarySource, imDB *gorm.DB) string {
+	if strings.TrimSpace(s.SourceName) != "" {
+		return s.SourceName
+	}
+	return service.ResolveSourceNameWithType(s.SourceID, s.SourceType, imDB)
+}
+
 func (h *TaskHandler) resolveSummaryTaskParam(c *gin.Context) (int64, bool) {
 	param := c.Param("id")
 	taskID, err := strconv.ParseInt(param, 10, 64)
@@ -773,7 +788,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			srcList = append(srcList, gin.H{
 				"source_type": s.SourceType,
 				"source_id":   s.SourceID,
-				"source_name": s.SourceName,
+				"source_name": displaySourceName(s, h.imDB),
 			})
 		}
 
@@ -1028,7 +1043,7 @@ func (h *TaskHandler) GetSummary(c *gin.Context) {
 		srcList = append(srcList, gin.H{
 			"source_type": s.SourceType,
 			"source_id":   s.SourceID,
-			"source_name": s.SourceName,
+			"source_name": displaySourceName(s, h.imDB),
 		})
 	}
 

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -163,7 +163,7 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 	// Agent summary: persists agent-generated summaries.
 	// (The old /summaries/:id/refine route was removed in favor of the
 	// reference-based chat flow — see CHAT-REFERENCE-BASED-DESIGN-v1.)
-	agentSummaryH := handler.NewAgentSummaryHandler(db, llmApiURL, llmApiKey, llmModel, llmTimeout, llmMaxTokens)
+	agentSummaryH := handler.NewAgentSummaryHandler(db, imDB, llmApiURL, llmApiKey, llmModel, llmTimeout, llmMaxTokens)
 	v1.POST("/summaries/agent", agentSummaryH.CreateAgentSummary)
 
 	return r


### PR DESCRIPTION
Closes #192

fix(summary): resolve agent-path source names so chips stop showing raw channel ids

## 背景

主人实测反馈(2026-08-17):总结详情 ST20260811jcw59o84 的 summary-detail-source-chip
显示「来自fef0c26327664232a2fd73ce2fb98ec6」——一长串裸 channel ID,不是可读的群名。
线上 octo_summary.summary_source 共 54 行:43 行正常、**10 行 source_name 为空**(全部
出自 agent 保存路径)、另有 29 行是 IM 库种子数据双重编码的乱码(另一根因,不在本 PR)。

## 问题

`POST /api/v1/summaries/agent`(CreateAgentSummary)写 source 行时**只存 source_id,
source_name 留空**——代码原注释自己承认:「We do not currently resolve source names via
IM DB ... a future PR can plumb imDB in and call ResolveSourceNameWithType」。对比之下,
即时总结(task.go CreateSummary)、定时总结(buildScheduledTaskSources)、bot 总结
(bot_summary_create.go)三条路径全都实时调 `ResolveSourceNameWithType` 解析名字。

前端 chip 渲染逻辑是 `{src.source_name || src.source_id}`——source_name 为空就 fallback
显示裸 ID。讽刺的是 ST20260811jcw59o84 对应群 `fef0c26...ec6` 在 IM 库里名字完好
(`一个群聊`),纯粹是 agent 路径没接 imDB。

## 改动

两层修复(修未来 + 修存量):

1. **写侧**:AgentSummaryHandler 接上 imDB(router.go 已持有,仅穿线),
   CreateAgentSummary 创建 source 行时调 `ResolveSourceNameWithType`——与即时路径完全
   对齐:客户端传的 source_name 不信(即时路径同样丢弃),imDB 为 nil / 查不到时落到
   确定性兜底「来源-xxxxxxxx」,永不再存空串。
2. **读侧**:新增 `displaySourceName`(task.go)——已存的非空名字是创建时快照,**原样
   返回不覆盖**(后续群改名不改写历史);空名字现场查 IM DB 兜底。接到三处用户可见
   序列化点:ListSummaries、GetSummary、share.Create 快照(ShareHandler 已持有 imDB)。
   这样 10 行存量空名记录无需数据迁移即可显示可读名字。

不碰 reference-context prompt(buildReferencedSummariesContext)——那是 LLM 上下文非
用户可见 chip,且给 AgentChatHandler 通 imDB 会扩大本 PR 面。

## 回归测试

新增 `source_name_display_test.go`,7 个用例,全部 mutation-verified(修复行 revert 即 RED):
- 写侧:IM 库解析带类型后缀「一个群聊(群聊)」;客户端伪造名被丢弃改用真实名;
  nil imDB 落「来源-fef0c263(群聊)」兜底
- 读侧:空名 detail/list 现场解析复现 ST20260811jcw59o84 场景;已存快照不被改名覆盖;
  nil imDB 落确定性兜底而非空串

现有测试 16 处 NewAgentSummaryHandler 调用点签名同步(imDB=nil,均不断言 source 名)。

## 验证

- CGO_ENABLED=0 go test ./... 全绿
- CGO_ENABLED=1 go test -race ./internal/api/handler/ 全绿(16.9s)
- 三个方向的 mutation 验证:写侧 revert→RED、读侧兜底 revert→RED、无条件覆盖快照→RED
