### PR TITLE
feat(summary): agent draft safe-save — trusted message ref + idempotency (SUM-BE1/BE2)

### DIFF
--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -314,25 +314,27 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	}
 	content = stripped
 
-	// SUM-BE1: real agent_save gate. Run the shared validator with the
-	// server-trusted content length (post-strip) so a caller can never
-	// bypass the "empty content" check by lying about the payload, and
-	// so a future preview API can call the same validator without
-	// re-implementing the shape rules. Note: an empty content case is
-	// already rejected upstream via errNoAgentOutput -> 40004, so under
-	// normal flow this call is defense-in-depth; it becomes load-bearing
-	// the moment stripAgentPreamble reduces content to empty (an
-	// all-preamble reply), which would otherwise silently save an
-	// empty deliverable.
-	if bizE := service.ValidateSnapshotScope(userID, service.SnapshotScopeInput{
-		Title:             req.Title,
-		OriginChannelID:   finalChannelID,
-		OriginChannelType: finalChannelType,
-		AgentSave: &service.AgentSaveInput{
-			SessionID:  req.SessionID,
-			ContentLen: len(content),
-		},
-	}, service.TargetAgentSave); bizE != nil {
+	// SUM-BE1 (revised per SUM-9): real agent_save gate. Run the shared
+	// validator with the server-trusted content (post-strip) so a caller
+	// can never bypass the "empty content" check by lying about the
+	// payload. Defense-in-depth normally — becomes load-bearing the moment
+	// stripAgentPreamble reduces content to empty (an all-preamble reply),
+	// which would otherwise silently save an empty deliverable.
+	//
+	// Note on parameters: message ownership / role / session identity are
+	// already enforced by loadLatestAssistantContent's WHERE clause
+	// (user_id + session_id + role='assistant'), so this call does not
+	// re-declare those. Snapshot-version and message-id enforcement remain
+	// BE-2 scope (they require new storage-side reads BE-1 does not add);
+	// keeping them as declared-but-ignored parameters here would be the
+	// exact shell coverage SUM-9 rejected.
+	if bizE := service.ValidateAgentSave(
+		userID,
+		req.Title,
+		req.SessionID,
+		content,
+		finalChannelID, finalChannelType,
+	); bizE != nil {
 		bizErr(c, bizE)
 		return
 	}

--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -147,6 +147,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, apiResponse{Code: 40000, Message: "request_id 非法"})
 		return
 	}
+	req.Title = strings.TrimSpace(req.Title)
 
 	// SUM-24: origin_channel fields are now optional. Distinguish between:
 	// - nil (not provided) → resolve from session
@@ -172,13 +173,71 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		return
 	}
 
+	// SUM-BE2 idempotency preflight must run before any session/origin/draft
+	// lookup. A successful save deletes the session messages, so replay cannot
+	// depend on state that the first request intentionally destroys.
+	keyHeader := http.CanonicalHeaderKey("Idempotency-Key")
+	keyValues, keyPresent := c.Request.Header[keyHeader]
+	idempotencyKey := strings.TrimSpace(c.GetHeader(keyHeader))
+	if keyPresent && (len(keyValues) != 1 || idempotencyKey == "") {
+		c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "valid Idempotency-Key header is required"})
+		return
+	}
+	var requestHash string
+	if idempotencyKey != "" {
+		if !validAgentSaveIdempotencyKey(idempotencyKey) {
+			c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "valid Idempotency-Key header is required"})
+			return
+		}
+		requestHash = canonicalAgentSaveRequestHash(userID, req)
+		existing, mismatched, ok, stale, ferr := findAgentSaveIdempotentTaskWithHash(
+			c.Request.Context(), h.db, spaceID, userID, idempotencyKey, requestHash,
+		)
+		if ferr != nil {
+			log.Printf("[handler] CreateAgentSummary idempotency lookup failed space=%s user=%s key=%s: %v", spaceID, userID, idempotencyKey, ferr)
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency check failed"})
+			return
+		}
+		if stale {
+			c.JSON(http.StatusConflict, apiResponse{
+				Code:    40009,
+				Message: "idempotency key is bound to a deleted summary",
+				Data:    gin.H{"task_id": existing.ID},
+			})
+			return
+		}
+		if ok && mismatched {
+			c.JSON(http.StatusConflict, apiResponse{
+				Code:    40009,
+				Message: "idempotency key already bound to a different agent save request",
+				Data:    gin.H{"task_id": existing.ID, "task_no": existing.TaskNo},
+			})
+			return
+		}
+		if ok {
+			log.Printf("[handler] CreateAgentSummary idempotency replay space=%s user=%s key=%s task_id=%d", spaceID, userID, idempotencyKey, existing.ID)
+			c.JSON(http.StatusOK, apiResponse{
+				Code:    0,
+				Message: "ok",
+				Data: gin.H{
+					"task_id":    existing.ID,
+					"task_no":    existing.TaskNo,
+					"status":     existing.Status,
+					"created_at": existing.CreatedAt,
+					"replayed":   true,
+				},
+			})
+			return
+		}
+	}
+
 	if req.OriginChannelID == nil {
 		// Not provided → resolve from session tool traces
 		resolvedID, resolvedType, err := h.resolveOriginChannelFromSession(c.Request.Context(), req.SessionID, userID)
 		if err != nil {
 			// DB error or other real failure → 500
 			log.Printf("[handler] resolveOriginChannelFromSession failed session=%s: %v", req.SessionID, err)
-			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "resolve origin channel failed: " + err.Error()})
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "resolve origin channel failed"})
 			return
 		}
 		if resolvedID == "" {
@@ -297,7 +356,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	}
 
 	// SUM-BE1: the agent_save-target validator runs a few lines below,
-	// AFTER loadLatestAssistantContent + stripAgentPreamble have resolved
+	// AFTER loadAgentMessageForSave + stripAgentPreamble have resolved
 	// the server-trusted deliverable — that way ContentLen is measured on
 	// the real content the DB will persist, not a request-supplied number
 	// the client could lie about. Running the validator here instead would
@@ -314,7 +373,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	//
 	// Every rejection path collapses to errNoAgentOutput → 40004 so an
 	// attacker cannot probe whether a specific message id exists (matches
-	// loadLatestAssistantContent's owner-scope 404 discipline, SUM-158
+	// the legacy loader's owner-scope 404 discipline, SUM-158
 	// blocker 1).
 	draftMsg, err := loadAgentMessageForSave(h.db.WithContext(c.Request.Context()), req.SessionID, userID, req.AgentMessageID)
 	if err != nil {
@@ -351,7 +410,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	// which would otherwise silently save an empty deliverable.
 	//
 	// Note on parameters: message ownership / role / session identity are
-	// already enforced by loadLatestAssistantContent's WHERE clause
+	// already enforced by loadAgentMessageForSave's WHERE clause
 	// (user_id + session_id + role='assistant'), so this call does not
 	// re-declare those. Snapshot-version and message-id enforcement remain
 	// BE-2 scope (they require new storage-side reads BE-1 does not add);
@@ -368,61 +427,6 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	); bizE != nil {
 		bizErr(c, bizE)
 		return
-	}
-
-	// --- SUM-BE2 idempotency preflight ---
-	// Same-key-same-body: replay the previously-created task without touching
-	// any table. Same-key-different-body: 409 with the original task_id so
-	// the client can recover. Header absent: skip idempotency (legacy path,
-	// removed once FE-2 SUM-7 ships the header on every save).
-	idempotencyKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
-	var requestHash string
-	if idempotencyKey != "" {
-		if !validAgentSaveIdempotencyKey(idempotencyKey) {
-			c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "valid Idempotency-Key header is required"})
-			return
-		}
-		requestHash = canonicalAgentSaveRequestHash(
-			req.SessionID, req.Title, finalChannelID, finalChannelType,
-			resolvedAgentMessageID, req.SnapshotVersion,
-			req.Sources, req.ReferencedTaskIDs,
-		)
-		existing, mismatched, ok, ferr := findAgentSaveIdempotentTaskWithHash(
-			c.Request.Context(), h.db, spaceID, userID, idempotencyKey, requestHash,
-		)
-		if ferr != nil {
-			log.Printf("[handler] CreateAgentSummary idempotency lookup failed space=%s user=%s key=%s: %v", spaceID, userID, idempotencyKey, ferr)
-			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency check failed: " + ferr.Error()})
-			return
-		}
-		if ok && mismatched {
-			// SUMMARY_ALREADY_CREATED conflict variant — same key, different
-			// body. Echo the original task_id so the client can jump to it.
-			c.JSON(http.StatusConflict, apiResponse{
-				Code:    40009,
-				Message: "idempotency key already bound to a different agent save request",
-				Data:    gin.H{"task_id": existing.ID, "task_no": existing.TaskNo},
-			})
-			return
-		}
-		if ok {
-			// Clean replay — the client's retry matched byte-for-byte. Return
-			// the original task without touching the DB. This is the "重复保存
-			// 返回同一 Summary" contract in design section 7.7.
-			log.Printf("[handler] CreateAgentSummary idempotency replay space=%s user=%s key=%s task_id=%d", spaceID, userID, idempotencyKey, existing.ID)
-			c.JSON(http.StatusOK, apiResponse{
-				Code:    0,
-				Message: "ok",
-				Data: gin.H{
-					"task_id":    existing.ID,
-					"task_no":    existing.TaskNo,
-					"status":     existing.Status,
-					"created_at": existing.CreatedAt,
-					"replayed":   true,
-				},
-			})
-			return
-		}
 	}
 
 	// --- title fallback: caller may skip, we generate the same way the
@@ -475,7 +479,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		// assistant" fallback also writes the real message id, not 0).
 		AgentSessionID:  req.SessionID,
 		AgentMessageID:  resolvedAgentMessageID,
-		SnapshotVersion: service.AgentSaveExpectedSnapshotVersion,
+		SnapshotVersion: req.SnapshotVersion,
 	}
 
 	var createdTaskID int64
@@ -658,12 +662,20 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	if errors.Is(err, errAgentSaveIdempotencyConflict) {
 		// A concurrent request won the UNIQUE race. Re-read the binding to
 		// decide replay-vs-mismatch, mirroring bot_summary_create.go's flow.
-		existing, mismatched, ok, ferr := findAgentSaveIdempotentTaskWithHash(
+		existing, mismatched, ok, stale, ferr := findAgentSaveIdempotentTaskWithHash(
 			c.Request.Context(), h.db, spaceID, userID, idempotencyKey, requestHash,
 		)
 		if ferr != nil || !ok {
 			log.Printf("[handler] CreateAgentSummary idempotency race re-read failed space=%s user=%s key=%s ok=%v: %v", spaceID, userID, idempotencyKey, ok, ferr)
 			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency race resolution failed"})
+			return
+		}
+		if stale {
+			c.JSON(http.StatusConflict, apiResponse{
+				Code:    40009,
+				Message: "idempotency key is bound to a deleted summary",
+				Data:    gin.H{"task_id": existing.ID},
+			})
 			return
 		}
 		if mismatched {
@@ -689,7 +701,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	}
 	if err != nil {
 		log.Printf("[handler] CreateAgentSummary tx failed space=%s user=%s session=%s: %v", spaceID, userID, req.SessionID, err)
-		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "落库失败: " + err.Error()})
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "落库失败"})
 		return
 	}
 
@@ -713,27 +725,6 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 // errNoAgentOutput signals that the session exists but has no assistant reply
 // worth persisting as a summary yet — mapped by the handler to error code 40004.
 var errNoAgentOutput = errors.New("no assistant output on session")
-
-// loadLatestAssistantContent returns the latest non-empty assistant message
-// text on the given session (skipping intermediate "call this tool" messages,
-// which are recognisable because they carry a tool_calls payload).
-//
-// owner-scoped：必须传 userID，跨用户匹配返回 errNoAgentOutput（与真实空会话
-// 在响应上不可区分，不泄漏 session 存在）(SUM-158 blocker 1)。
-func loadLatestAssistantContent(db *gorm.DB, sessionID, userID string) (string, error) {
-	var msg model.AgentMessage
-	err := db.Where("user_id = ? AND session_id = ? AND role = ? AND tool_calls IS NULL AND content <> ''", userID, sessionID, "assistant").
-		Order("id DESC").
-		Limit(1).
-		Take(&msg).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return "", errNoAgentOutput
-		}
-		return "", err
-	}
-	return msg.Content, nil
-}
 
 // buildSnapshotV1 constructs the v1 snapshot for an agent-generated summary.
 // This is the initial snapshot (parent_snapshot_version=null, user_instruction=null).

--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // AgentSummaryHandler persists the deliverable produced by the agent
@@ -76,6 +78,18 @@ func NewAgentSummaryHandler(db, imDB *gorm.DB, llmApiURL, llmApiKey, llmModel st
 // createAgentSummaryReq mirrors the SUM-24 v1.0 contract where origin_channel
 // fields are now optional. OriginChannelID is a pointer to distinguish between
 // "not provided" (nil) and "explicitly provided as empty string" (non-nil pointing to "").
+//
+// SUM-BE2 additions (all optional during the FE-2 rollout window; once FE-2
+// SUM-7 ships they become the only valid inputs):
+//   - AgentMessageID: primary key of the assistant reply the user confirmed
+//     as their draft. When >0, the server loads by (id, user, session,
+//     role='assistant', tool_calls IS NULL) instead of "latest assistant";
+//     0 keeps the pre-BE-2 legacy behaviour.
+//   - SnapshotVersion: the snapshot version the client thinks it is saving.
+//     BE-2 only writes v1; other values fail as AGENT_DRAFT_STALE (40901).
+//     Must be paired with a non-zero AgentMessageID.
+//   - Idempotency-Key is HTTP-header-borne (mirrors bot_summary_create.go);
+//     absent header keeps the non-idempotent legacy path.
 type createAgentSummaryReq struct {
 	SessionID         string           `json:"session_id"`
 	OriginChannelID   *string          `json:"origin_channel_id,omitempty"`
@@ -92,6 +106,12 @@ type createAgentSummaryReq struct {
 	// run_id，服务端无法验证跨轮错配；该绑定由客户端负责，SS-08 再持久化
 	// 校验。缺省/未知 → 与 legacy 一致的重算路径。
 	RequestID string `json:"request_id,omitempty"`
+	// AgentMessageID + SnapshotVersion form the trusted draft reference the
+	// design (section 6.5) requires. Both are optional in BE-2 for backward
+	// compat during the FE-2 (SUM-7) rollout; when either is >0 the other
+	// must also be >0 (enforced by service.ValidateAgentSave).
+	AgentMessageID  int64 `json:"agent_message_id,omitempty"`
+	SnapshotVersion int   `json:"snapshot_version,omitempty"`
 }
 
 // CreateAgentSummary handles POST /api/v1/summaries/agent.
@@ -285,11 +305,18 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	// specifically flagged as a bypass risk.
 
 	// --- pull the agent's produced deliverable content from agent_message ---
-	// Contract: use the latest role=assistant message on this session as the
-	// deliverable. Empty content ⇒ 40004 (must block, no empty summary allowed).
-	// We only look at messages with tool_calls IS NULL to skip the intermediate
-	// "call this tool" assistant messages; the final answer never has tool_calls.
-	content, err := loadLatestAssistantContent(h.db, req.SessionID, userID)
+	// SUM-BE2: when the client supplies a positive AgentMessageID we load by
+	// primary key AND owner AND session AND role='assistant' AND
+	// tool_calls IS NULL — every ownership axis the design (section 6.5.2)
+	// requires the server to verify. When AgentMessageID == 0 we fall back
+	// to the pre-BE-2 "latest assistant" behaviour so older frontends keep
+	// working during the FE-2 rollout window.
+	//
+	// Every rejection path collapses to errNoAgentOutput → 40004 so an
+	// attacker cannot probe whether a specific message id exists (matches
+	// loadLatestAssistantContent's owner-scope 404 discipline, SUM-158
+	// blocker 1).
+	draftMsg, err := loadAgentMessageForSave(h.db.WithContext(c.Request.Context()), req.SessionID, userID, req.AgentMessageID)
 	if err != nil {
 		if errors.Is(err, errNoAgentOutput) {
 			c.JSON(http.StatusBadRequest, apiResponse{Code: 40004, Message: "session 无有效产出,请先在对话中生成总结再保存"})
@@ -299,6 +326,8 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "读取 session 产出失败"})
 		return
 	}
+	content := draftMsg.Content
+	resolvedAgentMessageID := draftMsg.ID
 
 	// Strip conversational preamble that agents sometimes leak despite prompt
 	// discipline. Defense-in-depth — see agent_content_strip.go for the
@@ -334,9 +363,66 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		req.SessionID,
 		content,
 		finalChannelID, finalChannelType,
+		req.AgentMessageID,  // client-declared id — 0 means legacy fallback
+		req.SnapshotVersion, // client-declared expected version — 0 means legacy fallback
 	); bizE != nil {
 		bizErr(c, bizE)
 		return
+	}
+
+	// --- SUM-BE2 idempotency preflight ---
+	// Same-key-same-body: replay the previously-created task without touching
+	// any table. Same-key-different-body: 409 with the original task_id so
+	// the client can recover. Header absent: skip idempotency (legacy path,
+	// removed once FE-2 SUM-7 ships the header on every save).
+	idempotencyKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	var requestHash string
+	if idempotencyKey != "" {
+		if !validAgentSaveIdempotencyKey(idempotencyKey) {
+			c.JSON(http.StatusBadRequest, apiResponse{Code: 40005, Message: "valid Idempotency-Key header is required"})
+			return
+		}
+		requestHash = canonicalAgentSaveRequestHash(
+			req.SessionID, req.Title, finalChannelID, finalChannelType,
+			resolvedAgentMessageID, req.SnapshotVersion,
+			req.Sources, req.ReferencedTaskIDs,
+		)
+		existing, mismatched, ok, ferr := findAgentSaveIdempotentTaskWithHash(
+			c.Request.Context(), h.db, spaceID, userID, idempotencyKey, requestHash,
+		)
+		if ferr != nil {
+			log.Printf("[handler] CreateAgentSummary idempotency lookup failed space=%s user=%s key=%s: %v", spaceID, userID, idempotencyKey, ferr)
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency check failed: " + ferr.Error()})
+			return
+		}
+		if ok && mismatched {
+			// SUMMARY_ALREADY_CREATED conflict variant — same key, different
+			// body. Echo the original task_id so the client can jump to it.
+			c.JSON(http.StatusConflict, apiResponse{
+				Code:    40009,
+				Message: "idempotency key already bound to a different agent save request",
+				Data:    gin.H{"task_id": existing.ID, "task_no": existing.TaskNo},
+			})
+			return
+		}
+		if ok {
+			// Clean replay — the client's retry matched byte-for-byte. Return
+			// the original task without touching the DB. This is the "重复保存
+			// 返回同一 Summary" contract in design section 7.7.
+			log.Printf("[handler] CreateAgentSummary idempotency replay space=%s user=%s key=%s task_id=%d", spaceID, userID, idempotencyKey, existing.ID)
+			c.JSON(http.StatusOK, apiResponse{
+				Code:    0,
+				Message: "ok",
+				Data: gin.H{
+					"task_id":    existing.ID,
+					"task_no":    existing.TaskNo,
+					"status":     existing.Status,
+					"created_at": existing.CreatedAt,
+					"replayed":   true,
+				},
+			})
+			return
+		}
 	}
 
 	// --- title fallback: caller may skip, we generate the same way the
@@ -384,6 +470,12 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		// and session-resolved origins keep the zero value (unmasked).
 		OriginFromDerived: finalOriginFromDerived,
 		ReferencedTaskIDs: serializeReferencedTaskIDs(req.ReferencedTaskIDs),
+		// SUM-BE2 audit trail. resolvedAgentMessageID is the id
+		// loadAgentMessageForSave actually returned (so the legacy "latest
+		// assistant" fallback also writes the real message id, not 0).
+		AgentSessionID:  req.SessionID,
+		AgentMessageID:  resolvedAgentMessageID,
+		SnapshotVersion: service.AgentSaveExpectedSnapshotVersion,
 	}
 
 	var createdTaskID int64
@@ -519,6 +611,33 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			}
 		}
 
+		// --- SUM-BE2 idempotency binding ---
+		// When the client sent an Idempotency-Key header, persist the
+		// (space, user, key) -> task_id + request_hash binding inside the
+		// same transaction that created the task. Same-body retries replay
+		// via the preflight above; different-body retries hit the preflight
+		// 409. A concurrent duplicate hitting Create with the same tuple
+		// loses the UNIQUE race, RowsAffected == 0 fires
+		// errAgentSaveIdempotencyConflict, and the outer handler re-reads the
+		// binding to decide replay vs mismatch.
+		if idempotencyKey != "" {
+			binding := model.SummaryAgentSaveIdempotency{
+				SpaceID:        spaceID,
+				UserID:         userID,
+				IdempotencyKey: idempotencyKey,
+				RequestHash:    requestHash,
+				TaskID:         task.ID,
+				CreatedAt:      now,
+			}
+			insert := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&binding)
+			if insert.Error != nil {
+				return fmt.Errorf("create agent save idempotency: %w", insert.Error)
+			}
+			if insert.RowsAffected == 0 {
+				return errAgentSaveIdempotencyConflict
+			}
+		}
+
 		// Session lifecycle: chat is a "temporary workshop" — once the
 		// deliverable is persisted, DELETE all agent_message rows for this
 		// session so the workshop cannot be revisited (see
@@ -536,6 +655,38 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 
 		return nil
 	})
+	if errors.Is(err, errAgentSaveIdempotencyConflict) {
+		// A concurrent request won the UNIQUE race. Re-read the binding to
+		// decide replay-vs-mismatch, mirroring bot_summary_create.go's flow.
+		existing, mismatched, ok, ferr := findAgentSaveIdempotentTaskWithHash(
+			c.Request.Context(), h.db, spaceID, userID, idempotencyKey, requestHash,
+		)
+		if ferr != nil || !ok {
+			log.Printf("[handler] CreateAgentSummary idempotency race re-read failed space=%s user=%s key=%s ok=%v: %v", spaceID, userID, idempotencyKey, ok, ferr)
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency race resolution failed"})
+			return
+		}
+		if mismatched {
+			c.JSON(http.StatusConflict, apiResponse{
+				Code:    40009,
+				Message: "idempotency key already bound to a different agent save request",
+				Data:    gin.H{"task_id": existing.ID, "task_no": existing.TaskNo},
+			})
+			return
+		}
+		c.JSON(http.StatusOK, apiResponse{
+			Code:    0,
+			Message: "ok",
+			Data: gin.H{
+				"task_id":    existing.ID,
+				"task_no":    existing.TaskNo,
+				"status":     existing.Status,
+				"created_at": existing.CreatedAt,
+				"replayed":   true,
+			},
+		})
+		return
+	}
 	if err != nil {
 		log.Printf("[handler] CreateAgentSummary tx failed space=%s user=%s session=%s: %v", spaceID, userID, req.SessionID, err)
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "落库失败: " + err.Error()})

--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 // AgentSummaryHandler persists the deliverable produced by the agent
@@ -53,6 +52,9 @@ type AgentSummaryHandler struct {
 	// Not exposed via NewAgentSummaryHandler — tests assign this field
 	// directly using same-package access.
 	runnerFactory func(profile, uid string) (refineRunner, string, error)
+	// beforeDraftLoad is a test-only synchronization hook used to exercise
+	// the race where another request commits after idempotency preflight.
+	beforeDraftLoad func()
 }
 
 // refineRunner is the minimal subset of *agent.Runner used by RefineAgentSummary.
@@ -198,35 +200,8 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency check failed"})
 			return
 		}
-		if stale {
-			c.JSON(http.StatusConflict, apiResponse{
-				Code:    40009,
-				Message: "idempotency key is bound to a deleted summary",
-				Data:    gin.H{"task_id": existing.ID},
-			})
-			return
-		}
-		if ok && mismatched {
-			c.JSON(http.StatusConflict, apiResponse{
-				Code:    40009,
-				Message: "idempotency key already bound to a different agent save request",
-				Data:    gin.H{"task_id": existing.ID, "task_no": existing.TaskNo},
-			})
-			return
-		}
 		if ok {
-			log.Printf("[handler] CreateAgentSummary idempotency replay space=%s user=%s key=%s task_id=%d", spaceID, userID, idempotencyKey, existing.ID)
-			c.JSON(http.StatusOK, apiResponse{
-				Code:    0,
-				Message: "ok",
-				Data: gin.H{
-					"task_id":    existing.ID,
-					"task_no":    existing.TaskNo,
-					"status":     existing.Status,
-					"created_at": existing.CreatedAt,
-					"replayed":   true,
-				},
-			})
+			writeAgentSaveIdempotencyResponse(c, existing, mismatched, stale)
 			return
 		}
 	}
@@ -375,9 +350,29 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	// attacker cannot probe whether a specific message id exists (matches
 	// the legacy loader's owner-scope 404 discipline, SUM-158
 	// blocker 1).
+	if h.beforeDraftLoad != nil {
+		h.beforeDraftLoad()
+	}
 	draftMsg, err := loadAgentMessageForSave(h.db.WithContext(c.Request.Context()), req.SessionID, userID, req.AgentMessageID)
 	if err != nil {
 		if errors.Is(err, errNoAgentOutput) {
+			// A concurrent winner may have committed after our preflight and
+			// deleted the shared draft. Re-check the durable binding before
+			// reporting a missing output so an overlapping retry still replays.
+			if idempotencyKey != "" {
+				existing, mismatched, ok, stale, ferr := findAgentSaveIdempotentTaskWithHash(
+					c.Request.Context(), h.db, spaceID, userID, idempotencyKey, requestHash,
+				)
+				if ferr != nil {
+					log.Printf("[handler] CreateAgentSummary idempotency retry lookup failed space=%s user=%s key=%s: %v", spaceID, userID, idempotencyKey, ferr)
+					c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency check failed"})
+					return
+				}
+				if ok {
+					writeAgentSaveIdempotencyResponse(c, existing, mismatched, stale)
+					return
+				}
+			}
 			c.JSON(http.StatusBadRequest, apiResponse{Code: 40004, Message: "session 无有效产出,请先在对话中生成总结再保存"})
 			return
 		}
@@ -549,7 +544,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			UpdatedAt:        now,
 		}
 		// Build citations from session tool traces (fallback to empty array on error)
-		cits, cerr := h.buildCitationsForSession(c.Request.Context(), req.SessionID, content, userID, req.RequestID)
+		cits, cerr := h.buildCitationsForSessionWithDB(c.Request.Context(), tx, req.SessionID, content, userID, req.RequestID)
 		if cerr != nil {
 			log.Printf("[handler] buildCitationsForSession failed session=%s: %v (fallback to empty)", req.SessionID, cerr)
 			cits = nil
@@ -621,9 +616,9 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		// same transaction that created the task. Same-body retries replay
 		// via the preflight above; different-body retries hit the preflight
 		// 409. A concurrent duplicate hitting Create with the same tuple
-		// loses the UNIQUE race, RowsAffected == 0 fires
-		// errAgentSaveIdempotencyConflict, and the outer handler re-reads the
-		// binding to decide replay vs mismatch.
+		// loses the UNIQUE race; a locked read-back identifies the winner
+		// without relying on MySQL's DSN-sensitive RowsAffected value. The
+		// outer handler then re-reads the binding to decide replay vs mismatch.
 		if idempotencyKey != "" {
 			binding := model.SummaryAgentSaveIdempotency{
 				SpaceID:        spaceID,
@@ -633,12 +628,8 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 				TaskID:         task.ID,
 				CreatedAt:      now,
 			}
-			insert := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&binding)
-			if insert.Error != nil {
-				return fmt.Errorf("create agent save idempotency: %w", insert.Error)
-			}
-			if insert.RowsAffected == 0 {
-				return errAgentSaveIdempotencyConflict
+			if err := createAgentSaveIdempotencyBinding(tx, &binding); err != nil {
+				return err
 			}
 		}
 
@@ -670,33 +661,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "idempotency race resolution failed"})
 			return
 		}
-		if stale {
-			c.JSON(http.StatusConflict, apiResponse{
-				Code:    40009,
-				Message: "idempotency key is bound to a deleted summary",
-				Data:    gin.H{"task_id": existing.ID},
-			})
-			return
-		}
-		if mismatched {
-			c.JSON(http.StatusConflict, apiResponse{
-				Code:    40009,
-				Message: "idempotency key already bound to a different agent save request",
-				Data:    gin.H{"task_id": existing.ID, "task_no": existing.TaskNo},
-			})
-			return
-		}
-		c.JSON(http.StatusOK, apiResponse{
-			Code:    0,
-			Message: "ok",
-			Data: gin.H{
-				"task_id":    existing.ID,
-				"task_no":    existing.TaskNo,
-				"status":     existing.Status,
-				"created_at": existing.CreatedAt,
-				"replayed":   true,
-			},
-		})
+		writeAgentSaveIdempotencyResponse(c, existing, mismatched, stale)
 		return
 	}
 	if err != nil {
@@ -718,6 +683,47 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			"task_no":    task.TaskNo,
 			"status":     task.Status,
 			"created_at": task.CreatedAt,
+		},
+	})
+}
+
+func writeAgentSaveIdempotencyResponse(c *gin.Context, task model.SummaryTask, mismatched, stale bool) {
+	if stale {
+		c.JSON(http.StatusConflict, apiResponse{
+			Code:    40009,
+			Message: "idempotency key is bound to a deleted summary",
+			Data: gin.H{
+				"task_id":         task.ID,
+				"task_no":         task.TaskNo,
+				"reason":          "deleted_summary",
+				"recovery_action": "start_new_summary",
+			},
+		})
+		return
+	}
+	if mismatched {
+		c.JSON(http.StatusConflict, apiResponse{
+			Code:    40009,
+			Message: "idempotency key already bound to a different agent save request; open the existing summary to edit it",
+			Data: gin.H{
+				"task_id":         task.ID,
+				"task_no":         task.TaskNo,
+				"reason":          "request_mismatch",
+				"recovery_action": "open_existing_summary",
+			},
+		})
+		return
+	}
+	log.Printf("[handler] CreateAgentSummary idempotency replay task_id=%d", task.ID)
+	c.JSON(http.StatusOK, apiResponse{
+		Code:    0,
+		Message: "ok",
+		Data: gin.H{
+			"task_id":    task.ID,
+			"task_no":    task.TaskNo,
+			"status":     task.Status,
+			"created_at": task.CreatedAt,
+			"replayed":   true,
 		},
 	})
 }

--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"sort"
-	"unicode/utf8"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
@@ -277,10 +276,13 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		}
 	}
 
-	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
-		return
-	}
+	// SUM-BE1: the agent_save-target validator runs a few lines below,
+	// AFTER loadLatestAssistantContent + stripAgentPreamble have resolved
+	// the server-trusted deliverable — that way ContentLen is measured on
+	// the real content the DB will persist, not a request-supplied number
+	// the client could lie about. Running the validator here instead would
+	// force a placeholder ContentLen, which the review comment on SUM-3
+	// specifically flagged as a bypass risk.
 
 	// --- pull the agent's produced deliverable content from agent_message ---
 	// Contract: use the latest role=assistant message on this session as the
@@ -311,6 +313,29 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		log.Printf("[handler] CreateAgentSummary session %s: stripped %d chars of preamble", req.SessionID, len(content)-len(stripped))
 	}
 	content = stripped
+
+	// SUM-BE1: real agent_save gate. Run the shared validator with the
+	// server-trusted content length (post-strip) so a caller can never
+	// bypass the "empty content" check by lying about the payload, and
+	// so a future preview API can call the same validator without
+	// re-implementing the shape rules. Note: an empty content case is
+	// already rejected upstream via errNoAgentOutput -> 40004, so under
+	// normal flow this call is defense-in-depth; it becomes load-bearing
+	// the moment stripAgentPreamble reduces content to empty (an
+	// all-preamble reply), which would otherwise silently save an
+	// empty deliverable.
+	if bizE := service.ValidateSnapshotScope(userID, service.SnapshotScopeInput{
+		Title:             req.Title,
+		OriginChannelID:   finalChannelID,
+		OriginChannelType: finalChannelType,
+		AgentSave: &service.AgentSaveInput{
+			SessionID:  req.SessionID,
+			ContentLen: len(content),
+		},
+	}, service.TargetAgentSave); bizE != nil {
+		bizErr(c, bizE)
+		return
+	}
 
 	// --- title fallback: caller may skip, we generate the same way the
 	// traditional endpoint does so the two look identical in list views. ---

--- a/internal/api/handler/agent_summary_be2_test.go
+++ b/internal/api/handler/agent_summary_be2_test.go
@@ -1,0 +1,485 @@
+//go:build cgo
+
+package handler
+
+// SUM-BE2 handler tests: trusted draft reference (agent_message_id +
+// snapshot_version), idempotency (Idempotency-Key header), and the "agent
+// draft never enters the traditional Processor" contract.
+//
+// These are cgo-gated because setupAgentSummaryTestDB (see
+// agent_summary_test.go) uses the sqlite3 driver.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+
+	"gorm.io/gorm"
+)
+
+// seedAssistantMessage writes one assistant reply into agent_message and
+// returns the generated row (id, ...). All BE-2 tests reference a real DB
+// message so the ownership WHERE clause in loadAgentMessageForSave has
+// something to match.
+func seedAssistantMessage(t *testing.T, db *gorm.DB, userID, sessionID, content string) model.AgentMessage {
+	t.Helper()
+	msg := model.AgentMessage{
+		UserID:    userID,
+		SessionID: sessionID,
+		Role:      "assistant",
+		Content:   content,
+	}
+	if err := db.Create(&msg).Error; err != nil {
+		t.Fatalf("seed assistant message: %v", err)
+	}
+	return msg
+}
+
+func doAgentSave(t *testing.T, r http.Handler, body map[string]interface{}, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/summaries/agent", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Token", "test-user")
+	req.Header.Set("X-Space-Id", "test-space")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// -----------------------------------------------------------------------
+// 1. Message ownership / role / session / tool-call filtering
+// -----------------------------------------------------------------------
+
+func TestCreateAgentSummary_BE2_MessageIDCrossUser_404(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	// Seed a message owned by SOMEONE ELSE on the same session id.
+	other := seedAssistantMessage(t, db, "someone-else", "sess-x", "not mine")
+
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-x",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    other.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for cross-user message id, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"].(float64) != 40004 {
+		t.Errorf("expected code=40004 (no output), got %v", resp["code"])
+	}
+	// Draft preservation contract: the row we planted must still be there.
+	var count int64
+	db.Model(&model.AgentMessage{}).Where("id = ?", other.ID).Count(&count)
+	if count != 1 {
+		t.Errorf("cross-user rejection should NOT delete the victim's draft; want 1 row, got %d", count)
+	}
+}
+
+func TestCreateAgentSummary_BE2_MessageIDWrongSession_404(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	// Seed for this user but on a DIFFERENT session id.
+	msg := seedAssistantMessage(t, db, "test-user", "sess-A", "hi")
+
+	// Client asks to save that id but claims a different session.
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-B",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for wrong-session id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateAgentSummary_BE2_MessageIDUserRole_404(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	// Seed a role=user row (not an assistant reply).
+	userRow := model.AgentMessage{
+		UserID:    "test-user",
+		SessionID: "sess-U",
+		Role:      "user",
+		Content:   "please summarize",
+	}
+	if err := db.Create(&userRow).Error; err != nil {
+		t.Fatalf("seed user row: %v", err)
+	}
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-U",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    userRow.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for user-role id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateAgentSummary_BE2_MessageIDToolCall_404(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	// Assistant row that carries a tool_calls payload (intermediate "call
+	// this tool" step, never a save target).
+	tc := "[{\"id\":\"call-1\",\"type\":\"function\"}]"
+	row := model.AgentMessage{
+		UserID:    "test-user",
+		SessionID: "sess-T",
+		Role:      "assistant",
+		Content:   "invoking tool...",
+		ToolCalls: &tc,
+	}
+	if err := db.Create(&row).Error; err != nil {
+		t.Fatalf("seed tool-call row: %v", err)
+	}
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-T",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    row.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for tool-call id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// -----------------------------------------------------------------------
+// 2. Snapshot version conflict — AGENT_DRAFT_STALE (40901 / 409)
+// -----------------------------------------------------------------------
+
+func TestCreateAgentSummary_BE2_SnapshotVersionConflict_409(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+	msg := seedAssistantMessage(t, db, "test-user", "sess-v", "final answer")
+
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-v",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    2, // BE-2 only writes v1
+	}, nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for snapshot_version=2, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"].(float64) != 40901 {
+		t.Errorf("expected AGENT_DRAFT_STALE code=40901, got %v", resp["code"])
+	}
+}
+
+func TestCreateAgentSummary_BE2_MessageIDWithoutVersion_400(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+	msg := seedAssistantMessage(t, db, "test-user", "sess-half", "final")
+
+	// Half-supplied: msg id without snapshot_version.
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-half",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for half-supplied ref, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// -----------------------------------------------------------------------
+// 3. Idempotency — same key + same body = replay; same key + different body = 409
+// -----------------------------------------------------------------------
+
+func TestCreateAgentSummary_BE2_IdempotencyReplaysSameTask(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
+		t.Fatalf("migrate idempotency table: %v", err)
+	}
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	msg := seedAssistantMessage(t, db, "test-user", "sess-idem", "final answer")
+
+	body := map[string]interface{}{
+		"session_id":          "sess-idem",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"title":               "Weekly",
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+	}
+	headers := map[string]string{"Idempotency-Key": "req-abc-001"}
+
+	// First save.
+	w1 := doAgentSave(t, r, body, headers)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first save want 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+	var r1 map[string]interface{}
+	_ = json.Unmarshal(w1.Body.Bytes(), &r1)
+	taskID1 := r1["data"].(map[string]interface{})["task_id"]
+
+	// Re-seed the assistant message: the first save's tx DELETEs it. A
+	// replay must NOT need the draft any more (the whole point of
+	// idempotency is that the client can retry without holding session
+	// state). If the preflight works, we never re-read agent_message and
+	// the replay succeeds.
+	//
+	// If BE-2 accidentally re-reads on replay, this test fails with
+	// 40004 — a strong regression signal that the preflight is missing.
+
+	w2 := doAgentSave(t, r, body, headers)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("replay want 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var r2 map[string]interface{}
+	_ = json.Unmarshal(w2.Body.Bytes(), &r2)
+	data2 := r2["data"].(map[string]interface{})
+	if data2["task_id"] != taskID1 {
+		t.Errorf("replay task_id mismatch: first=%v replay=%v", taskID1, data2["task_id"])
+	}
+	if data2["replayed"] != true {
+		t.Errorf("replay must set data.replayed=true, got %v", data2["replayed"])
+	}
+
+	// Only ONE row in summary_task for this user — the replay must not
+	// have written a second task.
+	var count int64
+	db.Model(&model.SummaryTask{}).Where("creator_id = ?", "test-user").Count(&count)
+	if count != 1 {
+		t.Errorf("idempotent replay produced %d tasks, want 1", count)
+	}
+}
+
+func TestCreateAgentSummary_BE2_IdempotencyMismatch409(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
+		t.Fatalf("migrate idempotency table: %v", err)
+	}
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	msg1 := seedAssistantMessage(t, db, "test-user", "sess-mismatch-A", "answer A")
+
+	body1 := map[string]interface{}{
+		"session_id":          "sess-mismatch-A",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"title":               "Weekly",
+		"agent_message_id":    msg1.ID,
+		"snapshot_version":    1,
+	}
+	headers := map[string]string{"Idempotency-Key": "req-mismatch-001"}
+
+	w1 := doAgentSave(t, r, body1, headers)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first save want 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+	var r1 map[string]interface{}
+	_ = json.Unmarshal(w1.Body.Bytes(), &r1)
+	originalTaskID := r1["data"].(map[string]interface{})["task_id"]
+
+	// Seed a second session + message so the second request has a valid
+	// draft to reference. The DIFFERENT session id is what forces the
+	// hash mismatch (session_id is a hashed axis).
+	msg2 := seedAssistantMessage(t, db, "test-user", "sess-mismatch-B", "answer B")
+	body2 := map[string]interface{}{
+		"session_id":          "sess-mismatch-B",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"title":               "Weekly",
+		"agent_message_id":    msg2.ID,
+		"snapshot_version":    1,
+	}
+
+	w2 := doAgentSave(t, r, body2, headers)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("mismatched retry want 409, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var r2 map[string]interface{}
+	_ = json.Unmarshal(w2.Body.Bytes(), &r2)
+	if r2["code"].(float64) != 40009 {
+		t.Errorf("expected code=40009, got %v", r2["code"])
+	}
+	if r2["data"].(map[string]interface{})["task_id"] != originalTaskID {
+		t.Errorf("409 must echo the original task_id, got %v", r2["data"])
+	}
+}
+
+// -----------------------------------------------------------------------
+// 4. Agent draft never enters the traditional personal / meta Processor
+// -----------------------------------------------------------------------
+
+func TestCreateAgentSummary_BE2_AgentDraftDoesNotEnterPersonalProcessor(t *testing.T) {
+	// The traditional worker (worker/personal_processor.go) picks up
+	// PersonalResult rows with worker_status = PersonalStatusPending. This
+	// test asserts that the Agent save path writes worker_status =
+	// PersonalStatusCompleted straight away, so no worker ever sees the
+	// draft. Design section 2.2: "不能把 Agent 草稿交给 personal/meta Processor
+	// 再生成一次".
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	msg := seedAssistantMessage(t, db, "test-user", "sess-proc", "final content")
+
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-proc",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("save want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// 1. summary_task.trigger_type MUST be TriggerAgent (== 3).
+	// 2. summary_task.status MUST be StatusCompleted (Agent tasks skip
+	//    Pending/Processing entirely).
+	// 3. NO summary_personal_result row for this task may have
+	//    worker_status = PersonalStatusPending (the worker's pickup
+	//    predicate) — everything must be Completed.
+	var task model.SummaryTask
+	if err := db.Where("creator_id = ?", "test-user").Order("id DESC").First(&task).Error; err != nil {
+		t.Fatalf("read task: %v", err)
+	}
+	if task.TriggerType != model.TriggerAgent {
+		t.Errorf("trigger_type=%d, want TriggerAgent=%d", task.TriggerType, model.TriggerAgent)
+	}
+	if task.Status != model.StatusCompleted {
+		t.Errorf("task.status=%d, want StatusCompleted=%d (agent path skips worker)",
+			task.Status, model.StatusCompleted)
+	}
+	// SUM-BE2 audit-trail columns must be set.
+	if task.AgentSessionID != "sess-proc" || task.AgentMessageID != msg.ID || task.SnapshotVersion != 1 {
+		t.Errorf("audit trail wrong: session=%q msg_id=%d snap_v=%d (want sess-proc/%d/1)",
+			task.AgentSessionID, task.AgentMessageID, task.SnapshotVersion, msg.ID)
+	}
+
+	var pendingCount int64
+	db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND worker_status = ?", task.ID, model.PersonalStatusPending).
+		Count(&pendingCount)
+	if pendingCount != 0 {
+		t.Errorf("agent save produced %d PersonalResult(s) with worker_status=Pending — the traditional Processor would pick them up",
+			pendingCount)
+	}
+}
+
+// -----------------------------------------------------------------------
+// 5. Legacy path (no BE-2 fields) still works and now writes the audit trail
+// -----------------------------------------------------------------------
+
+func TestCreateAgentSummary_BE2_LegacyPathStillWorksAndWritesAudit(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	msg := seedAssistantMessage(t, db, "test-user", "sess-legacy", "old client answer")
+
+	// No agent_message_id, no snapshot_version, no Idempotency-Key. This
+	// is what a pre-FE-2 client sends. Must succeed AND the audit trail
+	// must be filled from the resolved (latest-assistant) row.
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-legacy",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+	}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("legacy save want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var task model.SummaryTask
+	if err := db.Where("creator_id = ?", "test-user").First(&task).Error; err != nil {
+		t.Fatalf("read task: %v", err)
+	}
+	if task.AgentSessionID != "sess-legacy" {
+		t.Errorf("audit AgentSessionID=%q want sess-legacy", task.AgentSessionID)
+	}
+	if task.AgentMessageID != msg.ID {
+		t.Errorf("audit AgentMessageID=%d want %d (resolved from latest assistant)", task.AgentMessageID, msg.ID)
+	}
+	if task.SnapshotVersion != 1 {
+		t.Errorf("audit SnapshotVersion=%d want 1", task.SnapshotVersion)
+	}
+}
+
+// -----------------------------------------------------------------------
+// 6. Failed save preserves the draft (agent_message row is not deleted)
+// -----------------------------------------------------------------------
+
+func TestCreateAgentSummary_BE2_ValidationFailureKeepsDraft(t *testing.T) {
+	// A save that fails validation (here: snapshot_version=2 → 409) must
+	// NOT delete the client's draft messages, so they can retry with a
+	// corrected snapshot_version and reach the same content. Design
+	// section 7.7: "保存失败时保留草稿,可安全重试".
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+
+	// Seed two messages (a user turn + an assistant reply) so we can
+	// verify both survive a failed save.
+	userTurn := model.AgentMessage{UserID: "test-user", SessionID: "sess-keep", Role: "user", Content: "make it short"}
+	if err := db.Create(&userTurn).Error; err != nil {
+		t.Fatalf("seed user turn: %v", err)
+	}
+	msg := seedAssistantMessage(t, db, "test-user", "sess-keep", "the summary")
+
+	// Bad request — stale snapshot version.
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-keep",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    99,
+	}, nil)
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected non-2xx, got 200: %s", w.Body.String())
+	}
+
+	// Both rows must still be present.
+	var count int64
+	db.Model(&model.AgentMessage{}).
+		Where("user_id = ? AND session_id = ?", "test-user", "sess-keep").
+		Count(&count)
+	if count != 2 {
+		t.Errorf("failed save should not touch the draft; want 2 messages, got %d", count)
+	}
+
+	// And no task was created for this user.
+	var taskCount int64
+	db.Model(&model.SummaryTask{}).Where("creator_id = ?", "test-user").Count(&taskCount)
+	if taskCount != 0 {
+		t.Errorf("failed save should not create a task, got %d", taskCount)
+	}
+}

--- a/internal/api/handler/agent_summary_be2_test.go
+++ b/internal/api/handler/agent_summary_be2_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 
@@ -63,7 +64,7 @@ func doAgentSave(t *testing.T, r http.Handler, body map[string]interface{}, head
 
 func TestCreateAgentSummary_BE2_MessageIDCrossUser_404(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed a message owned by SOMEONE ELSE on the same session id.
@@ -94,7 +95,7 @@ func TestCreateAgentSummary_BE2_MessageIDCrossUser_404(t *testing.T) {
 
 func TestCreateAgentSummary_BE2_MessageIDWrongSession_404(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed for this user but on a DIFFERENT session id.
@@ -115,7 +116,7 @@ func TestCreateAgentSummary_BE2_MessageIDWrongSession_404(t *testing.T) {
 
 func TestCreateAgentSummary_BE2_MessageIDUserRole_404(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed a role=user row (not an assistant reply).
@@ -142,7 +143,7 @@ func TestCreateAgentSummary_BE2_MessageIDUserRole_404(t *testing.T) {
 
 func TestCreateAgentSummary_BE2_MessageIDToolCall_404(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Assistant row that carries a tool_calls payload (intermediate "call
@@ -176,7 +177,7 @@ func TestCreateAgentSummary_BE2_MessageIDToolCall_404(t *testing.T) {
 
 func TestCreateAgentSummary_BE2_SnapshotVersionConflict_409(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 	msg := seedAssistantMessage(t, db, "test-user", "sess-v", "final answer")
 
@@ -199,7 +200,7 @@ func TestCreateAgentSummary_BE2_SnapshotVersionConflict_409(t *testing.T) {
 
 func TestCreateAgentSummary_BE2_MessageIDWithoutVersion_400(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 	msg := seedAssistantMessage(t, db, "test-user", "sess-half", "final")
 
@@ -224,7 +225,7 @@ func TestCreateAgentSummary_BE2_IdempotencyReplaysSameTask(t *testing.T) {
 	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
 		t.Fatalf("migrate idempotency table: %v", err)
 	}
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	msg := seedAssistantMessage(t, db, "test-user", "sess-idem", "final answer")
@@ -248,8 +249,8 @@ func TestCreateAgentSummary_BE2_IdempotencyReplaysSameTask(t *testing.T) {
 	_ = json.Unmarshal(w1.Body.Bytes(), &r1)
 	taskID1 := r1["data"].(map[string]interface{})["task_id"]
 
-	// Re-seed the assistant message: the first save's tx DELETEs it. A
-	// replay must NOT need the draft any more (the whole point of
+	// The first save's tx DELETEs the assistant message. A replay must NOT
+	// need the draft any more (the whole point of
 	// idempotency is that the client can retry without holding session
 	// state). If the preflight works, we never re-read agent_message and
 	// the replay succeeds.
@@ -285,7 +286,7 @@ func TestCreateAgentSummary_BE2_IdempotencyMismatch409(t *testing.T) {
 	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
 		t.Fatalf("migrate idempotency table: %v", err)
 	}
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	msg1 := seedAssistantMessage(t, db, "test-user", "sess-mismatch-A", "answer A")
@@ -298,7 +299,7 @@ func TestCreateAgentSummary_BE2_IdempotencyMismatch409(t *testing.T) {
 		"agent_message_id":    msg1.ID,
 		"snapshot_version":    1,
 	}
-	headers := map[string]string{"Idempotency-Key": "req-mismatch-001"}
+	headers := map[string]string{"Idempotency-Key": "idem-mismatch-example"}
 
 	w1 := doAgentSave(t, r, body1, headers)
 	if w1.Code != http.StatusOK {
@@ -335,6 +336,85 @@ func TestCreateAgentSummary_BE2_IdempotencyMismatch409(t *testing.T) {
 	}
 }
 
+func TestCreateAgentSummary_BE2_ParticipantChangeConflictsBeforeDraftRead(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
+		t.Fatalf("migrate idempotency table: %v", err)
+	}
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+	msg := seedAssistantMessage(t, db, "test-user", "sess-participants", "final answer")
+	body := map[string]interface{}{
+		"session_id":          "sess-participants",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+		"participants":        []map[string]interface{}{{"user_id": "alice"}},
+	}
+	headers := map[string]string{"Idempotency-Key": "idem-participants-example"}
+	if w := doAgentSave(t, r, body, headers); w.Code != http.StatusOK {
+		t.Fatalf("first save want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body["participants"] = []map[string]interface{}{{"user_id": "bob"}}
+	w := doAgentSave(t, r, body, headers)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("participant-changing retry want 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateAgentSummary_BE2_DeletedTaskIsNotReplayed(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
+		t.Fatalf("migrate idempotency table: %v", err)
+	}
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+	msg := seedAssistantMessage(t, db, "test-user", "sess-deleted", "final answer")
+	body := map[string]interface{}{
+		"session_id":          "sess-deleted",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+	}
+	headers := map[string]string{"Idempotency-Key": "idem-deleted-example"}
+	w1 := doAgentSave(t, r, body, headers)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first save want 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+	var first map[string]interface{}
+	_ = json.Unmarshal(w1.Body.Bytes(), &first)
+	taskID := int64(first["data"].(map[string]interface{})["task_id"].(float64))
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).Update("deleted_at", time.Now()).Error; err != nil {
+		t.Fatalf("soft delete task: %v", err)
+	}
+	w2 := doAgentSave(t, r, body, headers)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("deleted-task retry want 409, got %d: %s", w2.Code, w2.Body.String())
+	}
+	if bytes.Contains(w2.Body.Bytes(), []byte(`"replayed":true`)) {
+		t.Fatalf("deleted task must not be replayed: %s", w2.Body.String())
+	}
+}
+
+func TestCreateAgentSummary_BE2_WhitespaceIdempotencyKeyRejected(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+	msg := seedAssistantMessage(t, db, "test-user", "sess-blank-key", "final answer")
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id":          "sess-blank-key",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+	}, map[string]string{"Idempotency-Key": "   "})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("blank key want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // -----------------------------------------------------------------------
 // 4. Agent draft never enters the traditional personal / meta Processor
 // -----------------------------------------------------------------------
@@ -347,7 +427,7 @@ func TestCreateAgentSummary_BE2_AgentDraftDoesNotEnterPersonalProcessor(t *testi
 	// draft. Design section 2.2: "不能把 Agent 草稿交给 personal/meta Processor
 	// 再生成一次".
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	msg := seedAssistantMessage(t, db, "test-user", "sess-proc", "final content")
@@ -402,7 +482,7 @@ func TestCreateAgentSummary_BE2_AgentDraftDoesNotEnterPersonalProcessor(t *testi
 
 func TestCreateAgentSummary_BE2_LegacyPathStillWorksAndWritesAudit(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	msg := seedAssistantMessage(t, db, "test-user", "sess-legacy", "old client answer")
@@ -429,8 +509,8 @@ func TestCreateAgentSummary_BE2_LegacyPathStillWorksAndWritesAudit(t *testing.T)
 	if task.AgentMessageID != msg.ID {
 		t.Errorf("audit AgentMessageID=%d want %d (resolved from latest assistant)", task.AgentMessageID, msg.ID)
 	}
-	if task.SnapshotVersion != 1 {
-		t.Errorf("audit SnapshotVersion=%d want 1", task.SnapshotVersion)
+	if task.SnapshotVersion != 0 {
+		t.Errorf("legacy audit SnapshotVersion=%d want 0", task.SnapshotVersion)
 	}
 }
 
@@ -444,7 +524,7 @@ func TestCreateAgentSummary_BE2_ValidationFailureKeepsDraft(t *testing.T) {
 	// corrected snapshot_version and reach the same content. Design
 	// section 7.7: "保存失败时保留草稿,可安全重试".
 	db := setupAgentSummaryTestDB(t)
-	h := NewAgentSummaryHandler(db, "", "", "", 0, 0)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
 	// Seed two messages (a user turn + an assistant reply) so we can

--- a/internal/api/handler/agent_summary_be2_test.go
+++ b/internal/api/handler/agent_summary_be2_test.go
@@ -12,6 +12,7 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -222,9 +223,6 @@ func TestCreateAgentSummary_BE2_MessageIDWithoutVersion_400(t *testing.T) {
 
 func TestCreateAgentSummary_BE2_IdempotencyReplaysSameTask(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
-		t.Fatalf("migrate idempotency table: %v", err)
-	}
 	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
@@ -281,11 +279,92 @@ func TestCreateAgentSummary_BE2_IdempotencyReplaysSameTask(t *testing.T) {
 	}
 }
 
+func TestCreateAgentSaveIdempotencyBinding_DetectsConflictByReadBack(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	winner := model.SummaryAgentSaveIdempotency{
+		SpaceID: "test-space", UserID: "test-user", IdempotencyKey: "same-key",
+		RequestHash: "winner-hash", TaskID: 101, CreatedAt: time.Now(),
+	}
+	if err := db.Create(&winner).Error; err != nil {
+		t.Fatalf("seed winner binding: %v", err)
+	}
+
+	loser := model.SummaryAgentSaveIdempotency{
+		SpaceID: "test-space", UserID: "test-user", IdempotencyKey: "same-key",
+		RequestHash: "loser-hash", TaskID: 202, CreatedAt: time.Now(),
+	}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return createAgentSaveIdempotencyBinding(tx, &loser)
+	})
+	if !errors.Is(err, errAgentSaveIdempotencyConflict) {
+		t.Fatalf("conflicting binding must lose after tuple read-back, got %v", err)
+	}
+
+	var persisted model.SummaryAgentSaveIdempotency
+	if err := db.Where("space_id = ? AND user_id = ? AND idempotency_key = ?", "test-space", "test-user", "same-key").First(&persisted).Error; err != nil {
+		t.Fatalf("read persisted binding: %v", err)
+	}
+	if persisted.TaskID != winner.TaskID || persisted.RequestHash != winner.RequestHash {
+		t.Fatalf("winner binding changed: task=%d hash=%q", persisted.TaskID, persisted.RequestHash)
+	}
+}
+
+func TestCreateAgentSummary_BE2_OverlappingRetryReplaysAfterDraftDisappears(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	r := setupAgentSummaryRouter(h)
+	msg := seedAssistantMessage(t, db, "test-user", "sess-overlap", "final answer")
+
+	now := time.Now()
+	winner := model.SummaryTask{
+		TaskNo: "ST-overlap-winner", SpaceID: "test-space", CreatorID: "test-user",
+		Title: "Weekly", Topic: "Weekly", SummaryMode: model.ModeByPerson,
+		TimeRangeStart: now, TimeRangeEnd: now, Status: model.StatusCompleted,
+		TriggerType: model.TriggerAgent, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&winner).Error; err != nil {
+		t.Fatalf("seed winner task: %v", err)
+	}
+
+	origin := "chan-1"
+	req := createAgentSummaryReq{
+		SessionID: "sess-overlap", OriginChannelID: &origin, OriginChannelType: 1,
+		Title: "Weekly", AgentMessageID: msg.ID, SnapshotVersion: 1,
+	}
+	var hookErr error
+	h.beforeDraftLoad = func() {
+		h.beforeDraftLoad = nil
+		hookErr = db.Create(&model.SummaryAgentSaveIdempotency{
+			SpaceID: "test-space", UserID: "test-user", IdempotencyKey: "idem-overlap",
+			RequestHash: canonicalAgentSaveRequestHash("test-user", req),
+			TaskID:      winner.ID, CreatedAt: now,
+		}).Error
+		if hookErr == nil {
+			hookErr = db.Delete(&model.AgentMessage{}, msg.ID).Error
+		}
+	}
+
+	w := doAgentSave(t, r, map[string]interface{}{
+		"session_id": "sess-overlap", "origin_channel_id": origin,
+		"origin_channel_type": 1, "title": "Weekly",
+		"agent_message_id": msg.ID, "snapshot_version": 1,
+	}, map[string]string{"Idempotency-Key": "idem-overlap"})
+	if hookErr != nil {
+		t.Fatalf("install concurrent winner state: %v", hookErr)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("overlapping retry must replay instead of 40004, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	if data["task_id"] != float64(winner.ID) || data["replayed"] != true {
+		t.Fatalf("unexpected replay response: %s", w.Body.String())
+	}
+}
+
 func TestCreateAgentSummary_BE2_IdempotencyMismatch409(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
-		t.Fatalf("migrate idempotency table: %v", err)
-	}
 	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 
@@ -334,13 +413,13 @@ func TestCreateAgentSummary_BE2_IdempotencyMismatch409(t *testing.T) {
 	if r2["data"].(map[string]interface{})["task_id"] != originalTaskID {
 		t.Errorf("409 must echo the original task_id, got %v", r2["data"])
 	}
+	if r2["data"].(map[string]interface{})["reason"] != "request_mismatch" {
+		t.Errorf("409 must expose a machine-readable reason, got %v", r2["data"])
+	}
 }
 
 func TestCreateAgentSummary_BE2_ParticipantChangeConflictsBeforeDraftRead(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
-		t.Fatalf("migrate idempotency table: %v", err)
-	}
 	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 	msg := seedAssistantMessage(t, db, "test-user", "sess-participants", "final answer")
@@ -365,9 +444,6 @@ func TestCreateAgentSummary_BE2_ParticipantChangeConflictsBeforeDraftRead(t *tes
 
 func TestCreateAgentSummary_BE2_DeletedTaskIsNotReplayed(t *testing.T) {
 	db := setupAgentSummaryTestDB(t)
-	if err := db.AutoMigrate(&model.SummaryAgentSaveIdempotency{}); err != nil {
-		t.Fatalf("migrate idempotency table: %v", err)
-	}
 	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
 	r := setupAgentSummaryRouter(h)
 	msg := seedAssistantMessage(t, db, "test-user", "sess-deleted", "final answer")
@@ -395,6 +471,11 @@ func TestCreateAgentSummary_BE2_DeletedTaskIsNotReplayed(t *testing.T) {
 	}
 	if bytes.Contains(w2.Body.Bytes(), []byte(`"replayed":true`)) {
 		t.Fatalf("deleted task must not be replayed: %s", w2.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w2.Body.Bytes(), &resp)
+	if resp["data"].(map[string]interface{})["reason"] != "deleted_summary" {
+		t.Errorf("deleted-task conflict must expose a machine-readable reason: %s", w2.Body.String())
 	}
 }
 

--- a/internal/api/handler/agent_summary_citations.go
+++ b/internal/api/handler/agent_summary_citations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/worker"
+	"gorm.io/gorm"
 )
 
 // buildCitationsForSession 反查 session_id 的所有工具轨迹,组 messages 池,
@@ -47,6 +48,17 @@ func (h *AgentSummaryHandler) buildCitationsForSession(
 	uid string,
 	requestID string,
 ) ([]model.Citation, error) {
+	return h.buildCitationsForSessionWithDB(ctx, h.db, sessionID, content, uid, requestID)
+}
+
+func (h *AgentSummaryHandler) buildCitationsForSessionWithDB(
+	ctx context.Context,
+	db *gorm.DB,
+	sessionID string,
+	content string,
+	uid string,
+	requestID string,
+) ([]model.Citation, error) {
 	// 1. Discover handles from agent_message_evidence — must stay symmetric
 	// with getSessionMessagePool in tool_summarize_chunk.go. Rows are written
 	// synchronously by PersistEvidence inside every data-fetching tool
@@ -55,7 +67,7 @@ func (h *AgentSummaryHandler) buildCitationsForSession(
 	// handle the LLM could cite — regardless of whether the subsequent
 	// AppendMessages persisted the corresponding agent_message tool row.
 	var evidenceRows []model.AgentMessageEvidence
-	err := h.db.WithContext(ctx).
+	err := db.WithContext(ctx).
 		Where("user_id = ? AND session_id = ?", uid, sessionID).
 		Order("created_at ASC, handle ASC").
 		Find(&evidenceRows).Error
@@ -148,7 +160,7 @@ func (h *AgentSummaryHandler) buildCitationsForSession(
 	// here would renumber/drop its citations deterministically. No request_id
 	// → keep the recomputed indexes (legacy path), never a partial override.
 	if agent.SummaryV2Enabled() && requestID != "" {
-		allMessages = h.overrideWithRunManifest(ctx, uid, sessionID, requestID, allMessages)
+		allMessages = overrideWithRunManifest(ctx, db, uid, sessionID, requestID, allMessages)
 	}
 
 	// 5. Build nameMap
@@ -176,15 +188,15 @@ func (h *AgentSummaryHandler) buildCitationsForSession(
 // time, or a replay), no manifest frozen by that run, or a DB error — it
 // returns the input unchanged and keeps the recomputed indexes. The fallback
 // is always the full legacy recompute, never a partial override.
-func (h *AgentSummaryHandler) overrideWithRunManifest(ctx context.Context, uid, sessionID, requestID string, msgs []pipeline.Message) []pipeline.Message {
-	if h.db == nil {
+func overrideWithRunManifest(ctx context.Context, db *gorm.DB, uid, sessionID, requestID string, msgs []pipeline.Message) []pipeline.Message {
+	if db == nil {
 		return msgs
 	}
-	run, err := summaryrun.NewStore(h.db).GetByRequest(ctx, uid, sessionID, requestID)
+	run, err := summaryrun.NewStore(db).GetByRequest(ctx, uid, sessionID, requestID)
 	if err != nil {
 		return msgs
 	}
-	_, entries, found, err := artifact.NewStore(h.db).GetFrozenManifestByRun(ctx, uid, run.RunID)
+	_, entries, found, err := artifact.NewStore(db).GetFrozenManifestByRun(ctx, uid, run.RunID)
 	if err != nil || !found {
 		return msgs
 	}

--- a/internal/api/handler/agent_summary_save.go
+++ b/internal/api/handler/agent_summary_save.go
@@ -1,0 +1,230 @@
+package handler
+
+// SUM-BE2 (Agent 草稿与安全落库) — save-time helpers for CreateAgentSummary.
+//
+// This file is the storage-side counterpart the SUM-9 review said BE-1 could
+// not add: it introduces
+//
+//  1. a targeted assistant-message loader that reads by (id, user, session,
+//     role='assistant', tool_calls IS NULL) — so the caller-supplied
+//     agent_message_id is verified against server-trusted rows instead of
+//     the pre-BE-2 "latest assistant on session" heuristic;
+//
+//  2. an idempotency binding for Agent save, shaped exactly like
+//     summary_bot_create_idempotency (see bot_summary_create.go) — same
+//     replay contract, same request-hash mismatch → 409 semantics — but
+//     keyed on (space_id, user_id, idempotency_key) instead of bot_id
+//     because Agent save is user-owned;
+//
+//  3. a canonical request-hash so a retry with identical semantics replays,
+//     a retry with different semantics 409s.
+//
+// Everything Agent-save-only lives here so agent_summary.go stays focused on
+// origin-channel resolution + citations, and so review can look at storage
+// and hashing in isolation.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+
+	"gorm.io/gorm"
+)
+
+// errAgentSaveIdempotencyConflict signals that the transaction detected a
+// competing row for the same (space, user, key) tuple; the caller re-reads
+// the existing binding to decide replay vs mismatch (parallels
+// errBotIdempotencyConflict in bot_summary_create.go).
+var errAgentSaveIdempotencyConflict = errors.New("agent save idempotency conflict")
+
+// Reuse the bot handler's Idempotency-Key regex + length cap so the two
+// user-facing endpoints share one canonical validation rule. Declared here as
+// package-local aliases to keep this file self-contained on read; they point
+// at the same const/var so the shared contract cannot drift.
+const maxAgentSaveIdempotencyKeyLen = maxBotIdempotencyKeyLen
+
+var agentSaveIdempotencyKeyPattern = botIdempotencyKeyPattern
+
+// agentSaveKeyPresentPattern rejects a header the client explicitly sent but
+// filled with only whitespace / bracket noise. len==0 (header absent) is the
+// pre-BE-2 legacy path handled separately by the caller.
+var agentSaveKeyPresentPattern = regexp.MustCompile(`\S`)
+
+// validAgentSaveIdempotencyKey mirrors validBotIdempotencyKey.
+func validAgentSaveIdempotencyKey(key string) bool {
+	return len(key) > 0 &&
+		len(key) <= maxAgentSaveIdempotencyKeyLen &&
+		agentSaveIdempotencyKeyPattern.MatchString(key)
+}
+
+// loadAgentMessageForSave loads the assistant message the client claims is
+// the draft to save, verifying every DB-side identity axis in one WHERE
+// clause. Non-assistant / tool-call / cross-user / cross-session / deleted
+// message ids all return errNoAgentOutput (indistinguishable from "session
+// has no output" so the API surface does not leak whether the id exists —
+// mirrors loadLatestAssistantContent's owner-scope 404 discipline).
+//
+// Callers pass a positive messageID to opt into the BE-2 targeted lookup;
+// messageID == 0 keeps the pre-BE-2 "latest assistant on session" behaviour
+// (see loadLatestAssistantContent). This dual mode lets FE-2 (SUM-7) roll
+// out the strict form while older frontends keep working during the release
+// window; once FE-2 ships, the fallback can be removed in a follow-up.
+func loadAgentMessageForSave(db *gorm.DB, sessionID, userID string, messageID int64) (model.AgentMessage, error) {
+	var msg model.AgentMessage
+	if messageID <= 0 {
+		// Legacy fallback: reuse loadLatestAssistantContent's semantics but
+		// return the row (not just the content) so the caller can echo the
+		// resolved AgentMessageID onto SummaryTask for audit even on the
+		// legacy path.
+		err := db.Where(
+			"user_id = ? AND session_id = ? AND role = ? AND tool_calls IS NULL AND content <> ''",
+			userID, sessionID, "assistant",
+		).Order("id DESC").Limit(1).Take(&msg).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return model.AgentMessage{}, errNoAgentOutput
+			}
+			return model.AgentMessage{}, err
+		}
+		return msg, nil
+	}
+	err := db.Where(
+		"id = ? AND user_id = ? AND session_id = ? AND role = ? AND tool_calls IS NULL AND content <> ''",
+		messageID, userID, sessionID, "assistant",
+	).Take(&msg).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Wrong owner, wrong session, wrong role, tool-call message, or
+			// simply not found — all collapse to the same public error so an
+			// attacker cannot probe existence.
+			return model.AgentMessage{}, errNoAgentOutput
+		}
+		return model.AgentMessage{}, err
+	}
+	return msg, nil
+}
+
+// canonicalAgentSaveRequestHash returns a deterministic sha256 fingerprint of
+// the semantic content of an Agent-save request. Fields deliberately EXCLUDE
+// the ambient user/space identity (already keyed in the unique index) and
+// the assistant content (server-trusted, would defeat the hash-vs-body-drift
+// contract because the client can't see server-canonicalised text).
+//
+// Included:
+//   - session_id + agent_message_id + snapshot_version — the exact draft
+//     the client thinks it is saving;
+//   - title (post-trim), origin channel (id + type after resolution);
+//   - referenced_task_ids (sorted, deduped) — same task retried should hash
+//     the same regardless of ordering;
+//   - sources (sorted by (type, id)).
+func canonicalAgentSaveRequestHash(
+	sessionID, title, originID string,
+	originType int,
+	messageID int64,
+	snapshotVersion int,
+	sources []sourceReq,
+	referencedTaskIDs []int64,
+) string {
+	sortedSources := make([]sourceReq, 0, len(sources))
+	for _, s := range sources {
+		if s.SourceID == "" {
+			continue
+		}
+		sortedSources = append(sortedSources, s)
+	}
+	sort.SliceStable(sortedSources, func(i, j int) bool {
+		if sortedSources[i].SourceType != sortedSources[j].SourceType {
+			return sortedSources[i].SourceType < sortedSources[j].SourceType
+		}
+		return sortedSources[i].SourceID < sortedSources[j].SourceID
+	})
+
+	refCopy := append([]int64(nil), referencedTaskIDs...)
+	sort.Slice(refCopy, func(i, j int) bool { return refCopy[i] < refCopy[j] })
+	// De-dup adjacent equal ids after sort.
+	if len(refCopy) > 1 {
+		w := 1
+		for i := 1; i < len(refCopy); i++ {
+			if refCopy[i] != refCopy[i-1] {
+				refCopy[w] = refCopy[i]
+				w++
+			}
+		}
+		refCopy = refCopy[:w]
+	}
+
+	payload := struct {
+		SessionID         string      `json:"session_id"`
+		AgentMessageID    int64       `json:"agent_message_id"`
+		SnapshotVersion   int         `json:"snapshot_version"`
+		Title             string      `json:"title"`
+		OriginChannelID   string      `json:"origin_channel_id"`
+		OriginChannelType int         `json:"origin_channel_type"`
+		Sources           []sourceReq `json:"sources"`
+		ReferencedTaskIDs []int64     `json:"referenced_task_ids"`
+	}{
+		SessionID:         strings.TrimSpace(sessionID),
+		AgentMessageID:    messageID,
+		SnapshotVersion:   snapshotVersion,
+		Title:             strings.TrimSpace(title),
+		OriginChannelID:   originID,
+		OriginChannelType: originType,
+		Sources:           sortedSources,
+		ReferencedTaskIDs: refCopy,
+	}
+	// json.Marshal on a struct is field-order deterministic — same layout in
+	// two processes hashes identically.
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		// Marshal only fails on unmarshalable types (chan, func); the
+		// payload here is a concrete struct of plain types so this is
+		// unreachable in practice. Fall back to Sprintf so we never panic
+		// and the hash still differs across different inputs.
+		buf = []byte(fmt.Sprintf("%#v", payload))
+	}
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// findAgentSaveIdempotentTaskWithHash mirrors
+// findBotIdempotentTaskWithHash. See there for the return-tuple contract;
+// the only axis change is the unique key (space, user, key) instead of
+// (space, bot, key).
+func findAgentSaveIdempotentTaskWithHash(
+	ctx context.Context, db *gorm.DB,
+	spaceID, userID, key, requestHash string,
+) (model.SummaryTask, bool, bool, error) {
+	var binding model.SummaryAgentSaveIdempotency
+	if err := db.WithContext(ctx).
+		Where("space_id = ? AND user_id = ? AND idempotency_key = ?", spaceID, userID, key).
+		First(&binding).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.SummaryTask{}, false, false, nil
+		}
+		return model.SummaryTask{}, false, false, err
+	}
+	// Load the referenced task (space + creator scoped so a stale binding
+	// whose task was hard-deleted falls through to a fresh create instead
+	// of silently pointing at another user's row).
+	var task model.SummaryTask
+	if err := db.WithContext(ctx).
+		Where("id = ? AND space_id = ? AND creator_id = ?", binding.TaskID, spaceID, userID).
+		First(&task).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return model.SummaryTask{}, false, false, nil
+		}
+		return model.SummaryTask{}, false, false, err
+	}
+	if binding.RequestHash != requestHash {
+		return task, true, true, nil
+	}
+	return task, false, true, nil
+}

--- a/internal/api/handler/agent_summary_save.go
+++ b/internal/api/handler/agent_summary_save.go
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -53,11 +52,6 @@ const maxAgentSaveIdempotencyKeyLen = maxBotIdempotencyKeyLen
 
 var agentSaveIdempotencyKeyPattern = botIdempotencyKeyPattern
 
-// agentSaveKeyPresentPattern rejects a header the client explicitly sent but
-// filled with only whitespace / bracket noise. len==0 (header absent) is the
-// pre-BE-2 legacy path handled separately by the caller.
-var agentSaveKeyPresentPattern = regexp.MustCompile(`\S`)
-
 // validAgentSaveIdempotencyKey mirrors validBotIdempotencyKey.
 func validAgentSaveIdempotencyKey(key string) bool {
 	return len(key) > 0 &&
@@ -69,19 +63,17 @@ func validAgentSaveIdempotencyKey(key string) bool {
 // the draft to save, verifying every DB-side identity axis in one WHERE
 // clause. Non-assistant / tool-call / cross-user / cross-session / deleted
 // message ids all return errNoAgentOutput (indistinguishable from "session
-// has no output" so the API surface does not leak whether the id exists —
-// mirrors loadLatestAssistantContent's owner-scope 404 discipline).
+// has no output" so the API surface does not leak whether the id exists).
 //
 // Callers pass a positive messageID to opt into the BE-2 targeted lookup;
-// messageID == 0 keeps the pre-BE-2 "latest assistant on session" behaviour
-// (see loadLatestAssistantContent). This dual mode lets FE-2 (SUM-7) roll
+// messageID == 0 keeps the pre-BE-2 "latest assistant on session" behaviour.
+// This dual mode lets FE-2 (SUM-7) roll
 // out the strict form while older frontends keep working during the release
 // window; once FE-2 ships, the fallback can be removed in a follow-up.
 func loadAgentMessageForSave(db *gorm.DB, sessionID, userID string, messageID int64) (model.AgentMessage, error) {
 	var msg model.AgentMessage
 	if messageID <= 0 {
-		// Legacy fallback: reuse loadLatestAssistantContent's semantics but
-		// return the row (not just the content) so the caller can echo the
+		// Legacy fallback returns the row (not just the content) so the caller can echo the
 		// resolved AgentMessageID onto SummaryTask for audit even on the
 		// legacy path.
 		err := db.Where(
@@ -118,27 +110,31 @@ func loadAgentMessageForSave(db *gorm.DB, sessionID, userID string, messageID in
 // the assistant content (server-trusted, would defeat the hash-vs-body-drift
 // contract because the client can't see server-canonicalised text).
 //
-// Included:
-//   - session_id + agent_message_id + snapshot_version — the exact draft
-//     the client thinks it is saving;
-//   - title (post-trim), origin channel (id + type after resolution);
-//   - referenced_task_ids (sorted, deduped) — same task retried should hash
-//     the same regardless of ordering;
-//   - sources (sorted by (type, id)).
-func canonicalAgentSaveRequestHash(
-	sessionID, title, originID string,
-	originType int,
-	messageID int64,
-	snapshotVersion int,
-	sources []sourceReq,
-	referencedTaskIDs []int64,
-) string {
-	sortedSources := make([]sourceReq, 0, len(sources))
-	for _, s := range sources {
+// The hash is intentionally computed from request-owned fields only, before
+// any session/message read. A successful save deletes agent_message rows, so
+// server-resolved values cannot be part of a replay key.
+func canonicalAgentSaveRequestHash(userID string, req createAgentSummaryReq) string {
+	type canonicalSource struct {
+		SourceType int    `json:"source_type"`
+		SourceID   string `json:"source_id"`
+	}
+	type canonicalParticipant struct {
+		UserID   string `json:"user_id"`
+		UserName string `json:"user_name"`
+	}
+
+	sortedSources := make([]canonicalSource, 0, len(req.Sources))
+	seenSources := make(map[string]struct{}, len(req.Sources))
+	for _, s := range req.Sources {
 		if s.SourceID == "" {
 			continue
 		}
-		sortedSources = append(sortedSources, s)
+		key := fmt.Sprintf("%d:%s", s.SourceType, s.SourceID)
+		if _, exists := seenSources[key]; exists {
+			continue
+		}
+		seenSources[key] = struct{}{}
+		sortedSources = append(sortedSources, canonicalSource{SourceType: s.SourceType, SourceID: s.SourceID})
 	}
 	sort.SliceStable(sortedSources, func(i, j int) bool {
 		if sortedSources[i].SourceType != sortedSources[j].SourceType {
@@ -147,7 +143,21 @@ func canonicalAgentSaveRequestHash(
 		return sortedSources[i].SourceID < sortedSources[j].SourceID
 	})
 
-	refCopy := append([]int64(nil), referencedTaskIDs...)
+	participants := make([]canonicalParticipant, 0, len(req.Participants))
+	seenParticipants := map[string]struct{}{userID: {}}
+	for _, p := range req.Participants {
+		if p.UserID == "" {
+			continue
+		}
+		if _, exists := seenParticipants[p.UserID]; exists {
+			continue
+		}
+		seenParticipants[p.UserID] = struct{}{}
+		participants = append(participants, canonicalParticipant{UserID: p.UserID, UserName: p.UserName})
+	}
+	sort.Slice(participants, func(i, j int) bool { return participants[i].UserID < participants[j].UserID })
+
+	refCopy := append([]int64(nil), req.ReferencedTaskIDs...)
 	sort.Slice(refCopy, func(i, j int) bool { return refCopy[i] < refCopy[j] })
 	// De-dup adjacent equal ids after sort.
 	if len(refCopy) > 1 {
@@ -161,23 +171,36 @@ func canonicalAgentSaveRequestHash(
 		refCopy = refCopy[:w]
 	}
 
+	originProvided := req.OriginChannelID != nil
+	originID := ""
+	originType := 0
+	if originProvided {
+		originID = *req.OriginChannelID
+		originType = req.OriginChannelType
+	}
 	payload := struct {
-		SessionID         string      `json:"session_id"`
-		AgentMessageID    int64       `json:"agent_message_id"`
-		SnapshotVersion   int         `json:"snapshot_version"`
-		Title             string      `json:"title"`
-		OriginChannelID   string      `json:"origin_channel_id"`
-		OriginChannelType int         `json:"origin_channel_type"`
-		Sources           []sourceReq `json:"sources"`
-		ReferencedTaskIDs []int64     `json:"referenced_task_ids"`
+		SessionID         string                 `json:"session_id"`
+		RequestID         string                 `json:"request_id"`
+		AgentMessageID    int64                  `json:"agent_message_id"`
+		SnapshotVersion   int                    `json:"snapshot_version"`
+		Title             string                 `json:"title"`
+		OriginProvided    bool                   `json:"origin_provided"`
+		OriginChannelID   string                 `json:"origin_channel_id"`
+		OriginChannelType int                    `json:"origin_channel_type"`
+		Sources           []canonicalSource      `json:"sources"`
+		Participants      []canonicalParticipant `json:"participants"`
+		ReferencedTaskIDs []int64                `json:"referenced_task_ids"`
 	}{
-		SessionID:         strings.TrimSpace(sessionID),
-		AgentMessageID:    messageID,
-		SnapshotVersion:   snapshotVersion,
-		Title:             strings.TrimSpace(title),
+		SessionID:         strings.TrimSpace(req.SessionID),
+		RequestID:         strings.TrimSpace(req.RequestID),
+		AgentMessageID:    req.AgentMessageID,
+		SnapshotVersion:   req.SnapshotVersion,
+		Title:             strings.TrimSpace(req.Title),
+		OriginProvided:    originProvided,
 		OriginChannelID:   originID,
 		OriginChannelType: originType,
 		Sources:           sortedSources,
+		Participants:      participants,
 		ReferencedTaskIDs: refCopy,
 	}
 	// json.Marshal on a struct is field-order deterministic — same layout in
@@ -201,30 +224,32 @@ func canonicalAgentSaveRequestHash(
 func findAgentSaveIdempotentTaskWithHash(
 	ctx context.Context, db *gorm.DB,
 	spaceID, userID, key, requestHash string,
-) (model.SummaryTask, bool, bool, error) {
+) (model.SummaryTask, bool, bool, bool, error) {
 	var binding model.SummaryAgentSaveIdempotency
 	if err := db.WithContext(ctx).
 		Where("space_id = ? AND user_id = ? AND idempotency_key = ?", spaceID, userID, key).
 		First(&binding).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return model.SummaryTask{}, false, false, nil
+			return model.SummaryTask{}, false, false, false, nil
 		}
-		return model.SummaryTask{}, false, false, err
+		return model.SummaryTask{}, false, false, false, err
 	}
-	// Load the referenced task (space + creator scoped so a stale binding
-	// whose task was hard-deleted falls through to a fresh create instead
-	// of silently pointing at another user's row).
+	// Load only a live referenced task. SummaryTask.DeletedAt is *time.Time,
+	// not gorm.DeletedAt, so the predicate must be explicit.
 	var task model.SummaryTask
 	if err := db.WithContext(ctx).
-		Where("id = ? AND space_id = ? AND creator_id = ?", binding.TaskID, spaceID, userID).
+		Where("id = ? AND space_id = ? AND creator_id = ? AND deleted_at IS NULL", binding.TaskID, spaceID, userID).
 		First(&task).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return model.SummaryTask{}, false, false, nil
+			// Keep the binding as a tombstone. Reusing an idempotency key after
+			// its resource was deleted must not recreate a side effect, and must
+			// not fall into the UNIQUE-conflict -> 500 loop either.
+			return model.SummaryTask{ID: binding.TaskID}, binding.RequestHash != requestHash, true, true, nil
 		}
-		return model.SummaryTask{}, false, false, err
+		return model.SummaryTask{}, false, false, false, err
 	}
 	if binding.RequestHash != requestHash {
-		return task, true, true, nil
+		return task, true, true, false, nil
 	}
-	return task, false, true, nil
+	return task, false, true, false, nil
 }

--- a/internal/api/handler/agent_summary_save.go
+++ b/internal/api/handler/agent_summary_save.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // errAgentSaveIdempotencyConflict signals that the transaction detected a
@@ -157,19 +158,10 @@ func canonicalAgentSaveRequestHash(userID string, req createAgentSummaryReq) str
 	}
 	sort.Slice(participants, func(i, j int) bool { return participants[i].UserID < participants[j].UserID })
 
-	refCopy := append([]int64(nil), req.ReferencedTaskIDs...)
-	sort.Slice(refCopy, func(i, j int) bool { return refCopy[i] < refCopy[j] })
-	// De-dup adjacent equal ids after sort.
-	if len(refCopy) > 1 {
-		w := 1
-		for i := 1; i < len(refCopy); i++ {
-			if refCopy[i] != refCopy[i-1] {
-				refCopy[w] = refCopy[i]
-				w++
-			}
-		}
-		refCopy = refCopy[:w]
-	}
+	// ReferencedTaskIDs are order-sensitive: element 0 is the origin/citation
+	// inheritance source. Preserve first-occurrence order while removing
+	// duplicates, matching the normalization performed at handler entry.
+	refCopy := dedupReferencedTaskIDs(req.ReferencedTaskIDs)
 
 	originProvided := req.OriginChannelID != nil
 	originID := ""
@@ -215,6 +207,27 @@ func canonicalAgentSaveRequestHash(userID string, req createAgentSummaryReq) str
 	}
 	sum := sha256.Sum256(buf)
 	return hex.EncodeToString(sum[:])
+}
+
+// createAgentSaveIdempotencyBinding inserts the unique save binding and then
+// reads the tuple back to determine whether this transaction won. Do not use
+// RowsAffected for this decision: GORM maps DoNothing to a MySQL no-op update,
+// and clientFoundRows=true reports that conflict as one affected row.
+func createAgentSaveIdempotencyBinding(tx *gorm.DB, binding *model.SummaryAgentSaveIdempotency) error {
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(binding).Error; err != nil {
+		return fmt.Errorf("create agent save idempotency: %w", err)
+	}
+
+	var persisted model.SummaryAgentSaveIdempotency
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("space_id = ? AND user_id = ? AND idempotency_key = ?", binding.SpaceID, binding.UserID, binding.IdempotencyKey).
+		First(&persisted).Error; err != nil {
+		return fmt.Errorf("read back agent save idempotency: %w", err)
+	}
+	if persisted.TaskID != binding.TaskID {
+		return errAgentSaveIdempotencyConflict
+	}
+	return nil
 }
 
 // findAgentSaveIdempotentTaskWithHash mirrors

--- a/internal/api/handler/agent_summary_save_pure_test.go
+++ b/internal/api/handler/agent_summary_save_pure_test.go
@@ -1,0 +1,108 @@
+package handler
+
+// SUM-BE2 pure-Go tests for the Agent-save helpers that do not need a DB.
+// These run under CGO_ENABLED=0 so the developer can iterate without a
+// working cgo toolchain (BE-1 review flagged this gap on
+// snapshot_validator.go). The DB-side ownership tests live in the cgo-gated
+// agent_summary_be2_test.go alongside the other handler cgo tests.
+
+import (
+	"testing"
+)
+
+func TestValidAgentSaveIdempotencyKey(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{"empty rejected", "", false},
+		{"single char accepted", "a", true},
+		{"typical uuidish accepted", "5b06aa4b-de4a-4e17-a64a-76592337ad30", true},
+		{"underscore/colon/dot accepted", "svc.checkout_v1:req_42", true},
+		{"leading dot rejected", ".starts-with-dot", false},
+		{"leading dash rejected", "-starts-with-dash", false},
+		{"space rejected", "has space", false},
+		{"over cap rejected", string(make([]byte, maxAgentSaveIdempotencyKeyLen+1)), false},
+	}
+	// Fill the over-cap case with real chars (zero bytes fail the pattern anyway).
+	over := make([]byte, maxAgentSaveIdempotencyKeyLen+1)
+	for i := range over {
+		over[i] = 'a'
+	}
+	cases[len(cases)-1].key = string(over)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := validAgentSaveIdempotencyKey(tc.key); got != tc.want {
+				t.Errorf("validAgentSaveIdempotencyKey(%q)=%v, want %v", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalAgentSaveRequestHash_StableAcrossOrdering(t *testing.T) {
+	// Same semantic body, different source/reference ORDER — must hash the
+	// same (client retry with re-sorted maps must replay, not 409).
+	base := "sess-abc"
+	a := canonicalAgentSaveRequestHash(
+		base, "Weekly", "chan-1", 1, 42, 1,
+		[]sourceReq{{SourceType: 1, SourceID: "s1"}, {SourceType: 1, SourceID: "s2"}},
+		[]int64{7, 3, 5},
+	)
+	b := canonicalAgentSaveRequestHash(
+		base, "Weekly", "chan-1", 1, 42, 1,
+		[]sourceReq{{SourceType: 1, SourceID: "s2"}, {SourceType: 1, SourceID: "s1"}},
+		[]int64{5, 3, 7, 3}, // includes a duplicate — de-dup contract
+	)
+	if a != b {
+		t.Fatalf("hash should be order+dedup invariant, got a=%s b=%s", a, b)
+	}
+}
+
+func TestCanonicalAgentSaveRequestHash_DifferentBodyDiffers(t *testing.T) {
+	base := canonicalAgentSaveRequestHash(
+		"sess-abc", "Weekly", "chan-1", 1, 42, 1,
+		[]sourceReq{{SourceType: 1, SourceID: "s1"}}, nil,
+	)
+	// Changing ANY of the identity axes must produce a different hash so a
+	// same-key-different-body retry hits the 409 path.
+	shifts := map[string]string{
+		"session":    canonicalAgentSaveRequestHash("sess-xyz", "Weekly", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
+		"title":      canonicalAgentSaveRequestHash("sess-abc", "Daily", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
+		"channel_id": canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-2", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
+		"channel_tp": canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 2, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
+		"msg_id":     canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 43, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
+		"snap_ver":   canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 42, 2, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
+		"sources":    canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 2, SourceID: "s1"}}, nil),
+		"refs":       canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, []int64{99}),
+	}
+	for axis, h := range shifts {
+		if h == base {
+			t.Errorf("axis %q did not change the hash", axis)
+		}
+	}
+}
+
+func TestCanonicalAgentSaveRequestHash_TitleTrimmed(t *testing.T) {
+	// Whitespace-only title differences should NOT split idempotency
+	// (mirrors bot hash contract on trimmed title/topic).
+	a := canonicalAgentSaveRequestHash("sess", "Weekly", "c", 1, 1, 1, nil, nil)
+	b := canonicalAgentSaveRequestHash("sess", "  Weekly  ", "c", 1, 1, 1, nil, nil)
+	if a != b {
+		t.Errorf("title whitespace should be trimmed for hashing")
+	}
+}
+
+func TestCanonicalAgentSaveRequestHash_EmptySourceIDDropped(t *testing.T) {
+	// A source row with empty id is skipped up-front (matches what the tx
+	// insert loop does — it too skips empty ids). Client accidentally
+	// sending {source_type:1, source_id:""} on one retry vs skipping it on
+	// the next must replay cleanly.
+	a := canonicalAgentSaveRequestHash("sess", "t", "c", 1, 1, 1,
+		[]sourceReq{{SourceType: 1, SourceID: "real"}}, nil)
+	b := canonicalAgentSaveRequestHash("sess", "t", "c", 1, 1, 1,
+		[]sourceReq{{SourceType: 1, SourceID: ""}, {SourceType: 1, SourceID: "real"}}, nil)
+	if a != b {
+		t.Errorf("empty source id should be dropped, got a=%s b=%s", a, b)
+	}
+}

--- a/internal/api/handler/agent_summary_save_pure_test.go
+++ b/internal/api/handler/agent_summary_save_pure_test.go
@@ -40,9 +40,9 @@ func TestValidAgentSaveIdempotencyKey(t *testing.T) {
 	}
 }
 
-func TestCanonicalAgentSaveRequestHash_StableAcrossOrdering(t *testing.T) {
-	// Same semantic body, different source/reference ORDER — must hash the
-	// same (client retry with re-sorted maps must replay, not 409).
+func TestCanonicalAgentSaveRequestHash_StableAcrossSetLikeOrdering(t *testing.T) {
+	// Sources and participants are set-like, while referenced task order is
+	// preserved because the first task drives origin/citation inheritance.
 	origin := "chan-1"
 	a := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{
 		SessionID: "sess-abc", Title: "Weekly", OriginChannelID: &origin, OriginChannelType: 1,
@@ -56,10 +56,27 @@ func TestCanonicalAgentSaveRequestHash_StableAcrossOrdering(t *testing.T) {
 		AgentMessageID: 42, SnapshotVersion: 1,
 		Sources:           []sourceReq{{SourceType: 1, SourceID: "s2"}, {SourceType: 1, SourceID: "s1"}, {SourceType: 1, SourceID: "s1", SourceName: "ignored"}},
 		Participants:      []participantReq{{UserID: "u2", UserName: "U2"}, {UserID: "u3", UserName: "U3"}, {UserID: "u2", UserName: "ignored duplicate"}},
-		ReferencedTaskIDs: []int64{5, 3, 7, 3},
+		ReferencedTaskIDs: []int64{7, 3, 5, 3},
 	})
 	if a != b {
-		t.Fatalf("hash should be order+dedup invariant, got a=%s b=%s", a, b)
+		t.Fatalf("hash should normalize set-like fields and duplicate refs, got a=%s b=%s", a, b)
+	}
+}
+
+func TestCanonicalAgentSaveRequestHash_ReferencedTaskOrderMatters(t *testing.T) {
+	origin := "chan-1"
+	a := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{
+		SessionID: "sess-abc", OriginChannelID: &origin, OriginChannelType: 1,
+		AgentMessageID: 42, SnapshotVersion: 1,
+		ReferencedTaskIDs: []int64{7, 3},
+	})
+	b := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{
+		SessionID: "sess-abc", OriginChannelID: &origin, OriginChannelType: 1,
+		AgentMessageID: 42, SnapshotVersion: 1,
+		ReferencedTaskIDs: []int64{3, 7},
+	})
+	if a == b {
+		t.Fatal("reordering referenced tasks must change the hash because element 0 drives inheritance")
 	}
 }
 

--- a/internal/api/handler/agent_summary_save_pure_test.go
+++ b/internal/api/handler/agent_summary_save_pure_test.go
@@ -43,38 +43,57 @@ func TestValidAgentSaveIdempotencyKey(t *testing.T) {
 func TestCanonicalAgentSaveRequestHash_StableAcrossOrdering(t *testing.T) {
 	// Same semantic body, different source/reference ORDER — must hash the
 	// same (client retry with re-sorted maps must replay, not 409).
-	base := "sess-abc"
-	a := canonicalAgentSaveRequestHash(
-		base, "Weekly", "chan-1", 1, 42, 1,
-		[]sourceReq{{SourceType: 1, SourceID: "s1"}, {SourceType: 1, SourceID: "s2"}},
-		[]int64{7, 3, 5},
-	)
-	b := canonicalAgentSaveRequestHash(
-		base, "Weekly", "chan-1", 1, 42, 1,
-		[]sourceReq{{SourceType: 1, SourceID: "s2"}, {SourceType: 1, SourceID: "s1"}},
-		[]int64{5, 3, 7, 3}, // includes a duplicate — de-dup contract
-	)
+	origin := "chan-1"
+	a := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{
+		SessionID: "sess-abc", Title: "Weekly", OriginChannelID: &origin, OriginChannelType: 1,
+		AgentMessageID: 42, SnapshotVersion: 1,
+		Sources:           []sourceReq{{SourceType: 1, SourceID: "s1"}, {SourceType: 1, SourceID: "s2"}},
+		Participants:      []participantReq{{UserID: "u3", UserName: "U3"}, {UserID: "u2", UserName: "U2"}},
+		ReferencedTaskIDs: []int64{7, 3, 5},
+	})
+	b := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{
+		SessionID: "sess-abc", Title: "Weekly", OriginChannelID: &origin, OriginChannelType: 1,
+		AgentMessageID: 42, SnapshotVersion: 1,
+		Sources:           []sourceReq{{SourceType: 1, SourceID: "s2"}, {SourceType: 1, SourceID: "s1"}, {SourceType: 1, SourceID: "s1", SourceName: "ignored"}},
+		Participants:      []participantReq{{UserID: "u2", UserName: "U2"}, {UserID: "u3", UserName: "U3"}, {UserID: "u2", UserName: "ignored duplicate"}},
+		ReferencedTaskIDs: []int64{5, 3, 7, 3},
+	})
 	if a != b {
 		t.Fatalf("hash should be order+dedup invariant, got a=%s b=%s", a, b)
 	}
 }
 
 func TestCanonicalAgentSaveRequestHash_DifferentBodyDiffers(t *testing.T) {
-	base := canonicalAgentSaveRequestHash(
-		"sess-abc", "Weekly", "chan-1", 1, 42, 1,
-		[]sourceReq{{SourceType: 1, SourceID: "s1"}}, nil,
-	)
+	origin1 := "chan-1"
+	origin2 := "chan-2"
+	baseReq := createAgentSummaryReq{
+		SessionID: "sess-abc", RequestID: "turn-1", Title: "Weekly",
+		OriginChannelID: &origin1, OriginChannelType: 1,
+		AgentMessageID: 42, SnapshotVersion: 1,
+		Sources: []sourceReq{{SourceType: 1, SourceID: "s1"}},
+	}
+	base := canonicalAgentSaveRequestHash("u1", baseReq)
 	// Changing ANY of the identity axes must produce a different hash so a
 	// same-key-different-body retry hits the 409 path.
 	shifts := map[string]string{
-		"session":    canonicalAgentSaveRequestHash("sess-xyz", "Weekly", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
-		"title":      canonicalAgentSaveRequestHash("sess-abc", "Daily", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
-		"channel_id": canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-2", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
-		"channel_tp": canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 2, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
-		"msg_id":     canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 43, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
-		"snap_ver":   canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 42, 2, []sourceReq{{SourceType: 1, SourceID: "s1"}}, nil),
-		"sources":    canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 2, SourceID: "s1"}}, nil),
-		"refs":       canonicalAgentSaveRequestHash("sess-abc", "Weekly", "chan-1", 1, 42, 1, []sourceReq{{SourceType: 1, SourceID: "s1"}}, []int64{99}),
+		"session":    canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.SessionID = "sess-xyz"; return r }()),
+		"request":    canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.RequestID = "turn-2"; return r }()),
+		"title":      canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.Title = "Daily"; return r }()),
+		"channel_id": canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.OriginChannelID = &origin2; return r }()),
+		"channel_tp": canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.OriginChannelType = 2; return r }()),
+		"msg_id":     canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.AgentMessageID = 43; return r }()),
+		"snap_ver":   canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.SnapshotVersion = 2; return r }()),
+		"sources": canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq {
+			r := baseReq
+			r.Sources = []sourceReq{{SourceType: 2, SourceID: "s1"}}
+			return r
+		}()),
+		"participants": canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq {
+			r := baseReq
+			r.Participants = []participantReq{{UserID: "u2"}}
+			return r
+		}()),
+		"refs": canonicalAgentSaveRequestHash("u1", func() createAgentSummaryReq { r := baseReq; r.ReferencedTaskIDs = []int64{99}; return r }()),
 	}
 	for axis, h := range shifts {
 		if h == base {
@@ -86,8 +105,9 @@ func TestCanonicalAgentSaveRequestHash_DifferentBodyDiffers(t *testing.T) {
 func TestCanonicalAgentSaveRequestHash_TitleTrimmed(t *testing.T) {
 	// Whitespace-only title differences should NOT split idempotency
 	// (mirrors bot hash contract on trimmed title/topic).
-	a := canonicalAgentSaveRequestHash("sess", "Weekly", "c", 1, 1, 1, nil, nil)
-	b := canonicalAgentSaveRequestHash("sess", "  Weekly  ", "c", 1, 1, 1, nil, nil)
+	origin := "c"
+	a := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{SessionID: "sess", Title: "Weekly", OriginChannelID: &origin, OriginChannelType: 1, AgentMessageID: 1, SnapshotVersion: 1})
+	b := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{SessionID: "sess", Title: "  Weekly  ", OriginChannelID: &origin, OriginChannelType: 1, AgentMessageID: 1, SnapshotVersion: 1})
 	if a != b {
 		t.Errorf("title whitespace should be trimmed for hashing")
 	}
@@ -98,11 +118,19 @@ func TestCanonicalAgentSaveRequestHash_EmptySourceIDDropped(t *testing.T) {
 	// insert loop does — it too skips empty ids). Client accidentally
 	// sending {source_type:1, source_id:""} on one retry vs skipping it on
 	// the next must replay cleanly.
-	a := canonicalAgentSaveRequestHash("sess", "t", "c", 1, 1, 1,
-		[]sourceReq{{SourceType: 1, SourceID: "real"}}, nil)
-	b := canonicalAgentSaveRequestHash("sess", "t", "c", 1, 1, 1,
-		[]sourceReq{{SourceType: 1, SourceID: ""}, {SourceType: 1, SourceID: "real"}}, nil)
+	origin := "c"
+	a := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{SessionID: "sess", Title: "t", OriginChannelID: &origin, OriginChannelType: 1, AgentMessageID: 1, SnapshotVersion: 1, Sources: []sourceReq{{SourceType: 1, SourceID: "real"}}})
+	b := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{SessionID: "sess", Title: "t", OriginChannelID: &origin, OriginChannelType: 1, AgentMessageID: 1, SnapshotVersion: 1, Sources: []sourceReq{{SourceType: 1, SourceID: ""}, {SourceType: 1, SourceID: "real"}}})
 	if a != b {
 		t.Errorf("empty source id should be dropped, got a=%s b=%s", a, b)
+	}
+}
+
+func TestCanonicalAgentSaveRequestHash_ImplicitOriginDiffersFromExplicitEmpty(t *testing.T) {
+	empty := ""
+	implicit := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{SessionID: "sess"})
+	explicit := canonicalAgentSaveRequestHash("u1", createAgentSummaryReq{SessionID: "sess", OriginChannelID: &empty})
+	if implicit == explicit {
+		t.Fatal("implicit origin and explicitly empty origin must hash differently")
 	}
 }

--- a/internal/api/handler/agent_summary_test.go
+++ b/internal/api/handler/agent_summary_test.go
@@ -32,11 +32,13 @@ func setupAgentSummaryTestDB(t *testing.T) *gorm.DB {
 	// Auto-migrate all tables needed by CreateAgentSummary
 	if err := db.AutoMigrate(
 		&model.AgentMessage{},
+		&model.AgentMessageEvidence{},
 		&model.SummaryTask{},
 		&model.SummarySource{},
 		&model.SummaryParticipant{},
 		&model.SummaryResult{},
 		&model.PersonalResult{},
+		&model.SummaryAgentSaveIdempotency{},
 	); err != nil {
 		t.Fatalf("failed to migrate: %v", err)
 	}

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -495,18 +495,19 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		return
 	}
 
-	// SUM-BE1: gate the schedule-create path through the shared validator so
-	// the title cap and (via TargetScheduledWorkflow) the schedule-payload
-	// presence check run in the same place personal/team/agent paths use.
-	// The deep schedule-shape checks (ValidateIntervalForWrite / ValidateRunTime
-	// / ValidateScheduleAnchors) still run below unchanged — the shared
-	// validator only widens the top of the funnel.
-	if bizE := service.ValidateSnapshotScope(userID, service.SnapshotScopeInput{
-		Title:        req.Title,
-		Sources:      snapshotSourcesFromReq(req.Sources),
-		Participants: snapshotParticipantsFromReq(req.Participants),
-		Schedule:     snapshotScheduleFromReq(req),
-	}, service.TargetScheduledWorkflow); bizE != nil {
+	// SUM-BE1 (revised per SUM-9): call the shared validator with the ACTUAL
+	// model.SnapshotScope + the recurrence primitives the deep schedule
+	// checks below consume. No parallel DTO. Deep recurrence / anchor /
+	// run-time / day-of-week / day-of-month / time-range-type checks still
+	// run below via service.ValidateInterval* etc. — the shared validator
+	// only widens the top of the funnel with actor + title cap + "at least
+	// one of cron_expr / interval_days / interval_months" presence.
+	if bizE := service.ValidateScheduledWorkflow(
+		userID,
+		req.Title,
+		scheduleScopeFromReq(req),
+		req.CronExpr, req.IntervalDays, req.IntervalMonths,
+	); bizE != nil {
 		bizErr(c, bizE)
 		return
 	}

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -495,8 +495,19 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		return
 	}
 
-	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
+	// SUM-BE1: gate the schedule-create path through the shared validator so
+	// the title cap and (via TargetScheduledWorkflow) the schedule-payload
+	// presence check run in the same place personal/team/agent paths use.
+	// The deep schedule-shape checks (ValidateIntervalForWrite / ValidateRunTime
+	// / ValidateScheduleAnchors) still run below unchanged — the shared
+	// validator only widens the top of the funnel.
+	if bizE := service.ValidateSnapshotScope(userID, service.SnapshotScopeInput{
+		Title:        req.Title,
+		Sources:      snapshotSourcesFromReq(req.Sources),
+		Participants: snapshotParticipantsFromReq(req.Participants),
+		Schedule:     snapshotScheduleFromReq(req),
+	}, service.TargetScheduledWorkflow); bizE != nil {
+		bizErr(c, bizE)
 		return
 	}
 	generationInstruction, err := normalizeScheduleGenerationInstruction(req.GenerationInstruction)

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -506,7 +506,6 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		userID,
 		req.Title,
 		scheduleScopeFromReq(req),
-		req.CronExpr, req.IntervalDays, req.IntervalMonths,
 	); bizE != nil {
 		bizErr(c, bizE)
 		return

--- a/internal/api/handler/schedule.go
+++ b/internal/api/handler/schedule.go
@@ -495,17 +495,13 @@ func (h *ScheduleHandler) CreateSchedule(c *gin.Context) {
 		return
 	}
 
-	// SUM-BE1 (revised per SUM-9): call the shared validator with the ACTUAL
-	// model.SnapshotScope + the recurrence primitives the deep schedule
-	// checks below consume. No parallel DTO. Deep recurrence / anchor /
-	// run-time / day-of-week / day-of-month / time-range-type checks still
-	// run below via service.ValidateInterval* etc. — the shared validator
-	// only widens the top of the funnel with actor + title cap + "at least
-	// one of cron_expr / interval_days / interval_months" presence.
+	// SUM-BE1 (revised per SUM-9): the shared schedule validator owns the
+	// actor/title gates. Deep recurrence / anchor / run-time / day-of-week /
+	// day-of-month / time-range-type checks still run below via the existing
+	// service validators.
 	if bizE := service.ValidateScheduledWorkflow(
 		userID,
 		req.Title,
-		scheduleScopeFromReq(req),
 	); bizE != nil {
 		bizErr(c, bizE)
 		return

--- a/internal/api/handler/schedule_scope_preservation_test.go
+++ b/internal/api/handler/schedule_scope_preservation_test.go
@@ -1,0 +1,273 @@
+//go:build cgo
+
+package handler
+
+// schedule_scope_preservation_test.go — SUM-BE1 regression per SUM-9 P1-3.
+//
+// This suite drives the real handler.CreateSchedule + handler.UpdateSchedule
+// endpoints (in-memory sqlite via the same harness used by
+// schedule_behavior_test.go) and asserts that every schedule field the
+// createScheduleReq carries survives the round trip, AND that a field-level
+// patch through UpdateSchedule does not zero any field the caller did not
+// send. The SUM-9 review specifically rejected the previous "only-read
+// helper does not mutate the pointer" style test as not covering the
+// handler / persistence / patch path.
+//
+// CGO tag matches every other handler test in this repo — the in-memory
+// sqlite driver github.com/mattn/go-sqlite3 requires cgo.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// fullScheduleReqBody is the shape createScheduleReq exposes on the wire.
+// Kept as a helper so both create + update tests share the same field set.
+func fullScheduleReqBody(taskID int64) map[string]interface{} {
+	return map[string]interface{}{
+		"title":                  "weekly review",
+		"generation_instruction": "focus on delayed items",
+		"cron_expr":              "",
+		"interval_days":          7,
+		"interval_months":        0,
+		"run_time":               "09:30",
+		"day_of_week":            3,
+		"day_of_month":           0,
+		"time_range_type":        2,
+		"sources": []map[string]interface{}{
+			{"source_type": 1, "source_id": "grp_a"},
+			{"source_type": 1, "source_id": "grp_b"},
+		},
+		"participants": []map[string]interface{}{
+			{"user_id": "creator1"},
+		},
+		"confirm_policy": 0, // AUTO
+		"scope":          "task",
+		"task_id":        taskID,
+	}
+}
+
+// TestCreateSchedule_PersistsEveryField creates a schedule with every
+// createScheduleReq field non-zero and asserts the persisted row keeps them
+// all. This is the "no zero-fill on create" invariant SUM-9 P1-3 asked for.
+func TestCreateSchedule_PersistsEveryField(t *testing.T) {
+	db := newScheduleTestDB(t)
+	r := newScheduleTestRouter(db)
+
+	taskID := seedScheduleTask(t, db, "TSK-CREATE-FULL", "space1", "creator1")
+
+	body := fullScheduleReqBody(taskID)
+	w := scheduleReq(t, r, "creator1", "space1", http.MethodPost, "/api/v1/summary-schedules", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateSchedule http=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Pull the row and assert every field lines up with what we sent.
+	var got model.SummarySchedule
+	if err := db.Where("space_id = ? AND creator_id = ?", "space1", "creator1").
+		Order("id DESC").First(&got).Error; err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+
+	if got.Title != "weekly review" {
+		t.Errorf("Title: got %q", got.Title)
+	}
+	if got.GenerationInstruction != "focus on delayed items" {
+		t.Errorf("GenerationInstruction: got %q", got.GenerationInstruction)
+	}
+	if got.CronExpr != "" {
+		t.Errorf("CronExpr: expected empty, got %q", got.CronExpr)
+	}
+	if got.IntervalDays != 7 {
+		t.Errorf("IntervalDays: got %d", got.IntervalDays)
+	}
+	if got.IntervalMonths != 0 {
+		t.Errorf("IntervalMonths: got %d", got.IntervalMonths)
+	}
+	if got.RunTime != "09:30" {
+		t.Errorf("RunTime: got %q", got.RunTime)
+	}
+	if got.DayOfWeek != 3 {
+		t.Errorf("DayOfWeek: got %d", got.DayOfWeek)
+	}
+	if got.DayOfMonth != 0 {
+		t.Errorf("DayOfMonth: got %d", got.DayOfMonth)
+	}
+	if got.TimeRangeType != 2 {
+		t.Errorf("TimeRangeType: got %d", got.TimeRangeType)
+	}
+	if len(got.SourceConfig) == 0 {
+		t.Errorf("SourceConfig empty; expected the 2 sources we sent to persist")
+	}
+	// SourceConfig is JSON; decode to a slice and assert both source ids
+	// made it through.
+	var sources []map[string]interface{}
+	if err := json.Unmarshal(got.SourceConfig, &sources); err != nil {
+		t.Fatalf("SourceConfig not valid JSON: %v (%s)", err, string(got.SourceConfig))
+	}
+	if len(sources) != 2 {
+		t.Errorf("SourceConfig len: got %d want 2", len(sources))
+	}
+	if len(got.ParticipantConfig) == 0 {
+		t.Errorf("ParticipantConfig empty; expected creator1 to persist")
+	}
+	if got.ConfirmPolicy != model.SchedConfirmAuto {
+		t.Errorf("ConfirmPolicy: got %d want AUTO(%d)", got.ConfirmPolicy, model.SchedConfirmAuto)
+	}
+	if got.SummaryMode != model.ModeByPerson {
+		t.Errorf("SummaryMode: got %d want ModeByPerson", got.SummaryMode)
+	}
+	if got.IsActive != 1 {
+		t.Errorf("IsActive: got %d want 1", got.IsActive)
+	}
+	if got.NextRunAt == nil {
+		t.Errorf("NextRunAt not populated")
+	}
+
+	// The task must have been bound to this schedule (TaskID -> schedule_id
+	// coupling).
+	var task model.SummaryTask
+	if err := db.First(&task, taskID).Error; err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if task.ScheduleID == nil || *task.ScheduleID != got.ID {
+		var got0 int64
+		if task.ScheduleID != nil {
+			got0 = *task.ScheduleID
+		}
+		t.Errorf("task.ScheduleID: got %d want %d", got0, got.ID)
+	}
+}
+
+// TestUpdateSchedule_TitleOnlyPatch_DoesNotZeroOtherFields is the SUM-9
+// requirement literally: send an update that only sets Title, then assert
+// every other field the caller did NOT send retains its prior value. This
+// is the "field-level patch does not clear unshown fields" invariant.
+func TestUpdateSchedule_TitleOnlyPatch_DoesNotZeroOtherFields(t *testing.T) {
+	db := newScheduleTestDB(t)
+	r := newScheduleTestRouter(db)
+
+	taskID := seedScheduleTask(t, db, "TSK-PATCH-1", "space1", "creator1")
+	create := fullScheduleReqBody(taskID)
+	w := scheduleReq(t, r, "creator1", "space1", http.MethodPost, "/api/v1/summary-schedules", create)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateSchedule http=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var before model.SummarySchedule
+	if err := db.Where("space_id = ? AND creator_id = ?", "space1", "creator1").
+		Order("id DESC").First(&before).Error; err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+
+	// Title-only patch.
+	patch := map[string]interface{}{"title": "renamed schedule"}
+	w = scheduleReq(t, r, "creator1", "space1", http.MethodPut,
+		"/api/v1/summary-schedules/"+sid(before.ID), patch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateSchedule http=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var after model.SummarySchedule
+	if err := db.First(&after, before.ID).Error; err != nil {
+		t.Fatalf("reload schedule: %v", err)
+	}
+
+	// Title changed.
+	if after.Title != "renamed schedule" {
+		t.Errorf("Title patch failed: %q", after.Title)
+	}
+	// Every other user-facing field preserved.
+	if after.GenerationInstruction != before.GenerationInstruction {
+		t.Errorf("GenerationInstruction zeroed: before=%q after=%q",
+			before.GenerationInstruction, after.GenerationInstruction)
+	}
+	if after.CronExpr != before.CronExpr {
+		t.Errorf("CronExpr zeroed: before=%q after=%q", before.CronExpr, after.CronExpr)
+	}
+	if after.IntervalDays != before.IntervalDays {
+		t.Errorf("IntervalDays zeroed: before=%d after=%d", before.IntervalDays, after.IntervalDays)
+	}
+	if after.IntervalMonths != before.IntervalMonths {
+		t.Errorf("IntervalMonths zeroed: before=%d after=%d", before.IntervalMonths, after.IntervalMonths)
+	}
+	if after.RunTime != before.RunTime {
+		t.Errorf("RunTime zeroed: before=%q after=%q", before.RunTime, after.RunTime)
+	}
+	if after.DayOfWeek != before.DayOfWeek {
+		t.Errorf("DayOfWeek zeroed: before=%d after=%d", before.DayOfWeek, after.DayOfWeek)
+	}
+	if after.DayOfMonth != before.DayOfMonth {
+		t.Errorf("DayOfMonth zeroed: before=%d after=%d", before.DayOfMonth, after.DayOfMonth)
+	}
+	if after.TimeRangeType != before.TimeRangeType {
+		t.Errorf("TimeRangeType zeroed: before=%d after=%d", before.TimeRangeType, after.TimeRangeType)
+	}
+	if string(after.SourceConfig) != string(before.SourceConfig) {
+		t.Errorf("SourceConfig zeroed:\n  before=%s\n   after=%s",
+			string(before.SourceConfig), string(after.SourceConfig))
+	}
+	if string(after.ParticipantConfig) != string(before.ParticipantConfig) {
+		t.Errorf("ParticipantConfig zeroed:\n  before=%s\n   after=%s",
+			string(before.ParticipantConfig), string(after.ParticipantConfig))
+	}
+	if after.ConfirmPolicy != before.ConfirmPolicy {
+		t.Errorf("ConfirmPolicy zeroed: before=%d after=%d", before.ConfirmPolicy, after.ConfirmPolicy)
+	}
+	if after.SummaryMode != before.SummaryMode {
+		t.Errorf("SummaryMode zeroed: before=%d after=%d", before.SummaryMode, after.SummaryMode)
+	}
+}
+
+// TestUpdateSchedule_GenerationInstructionOnly is a companion to the
+// title-only case: the instruction path has its own normalize step (see
+// normalizeScheduleGenerationInstruction in schedule.go) and used to be
+// prone to writing an empty string on any patch. Assert it round-trips and
+// leaves everything else alone.
+func TestUpdateSchedule_GenerationInstructionOnly(t *testing.T) {
+	db := newScheduleTestDB(t)
+	r := newScheduleTestRouter(db)
+
+	taskID := seedScheduleTask(t, db, "TSK-PATCH-2", "space1", "creator1")
+	w := scheduleReq(t, r, "creator1", "space1", http.MethodPost, "/api/v1/summary-schedules",
+		fullScheduleReqBody(taskID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateSchedule http=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var before model.SummarySchedule
+	if err := db.Where("space_id = ? AND creator_id = ?", "space1", "creator1").
+		Order("id DESC").First(&before).Error; err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+
+	patch := map[string]interface{}{"generation_instruction": "focus on incidents only"}
+	w = scheduleReq(t, r, "creator1", "space1", http.MethodPut,
+		"/api/v1/summary-schedules/"+sid(before.ID), patch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateSchedule http=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var after model.SummarySchedule
+	if err := db.First(&after, before.ID).Error; err != nil {
+		t.Fatalf("reload schedule: %v", err)
+	}
+
+	if after.GenerationInstruction != "focus on incidents only" {
+		t.Errorf("instruction patch failed: %q", after.GenerationInstruction)
+	}
+	if after.Title != before.Title {
+		t.Errorf("Title zeroed by instruction-only patch: before=%q after=%q", before.Title, after.Title)
+	}
+	if after.IntervalDays != before.IntervalDays || after.RunTime != before.RunTime ||
+		after.DayOfWeek != before.DayOfWeek || after.TimeRangeType != before.TimeRangeType {
+		t.Errorf("recurrence fields zeroed by instruction-only patch:\n  before=%+v\n   after=%+v", before, after)
+	}
+	if string(after.SourceConfig) != string(before.SourceConfig) ||
+		string(after.ParticipantConfig) != string(before.ParticipantConfig) {
+		t.Errorf("source/participant configs zeroed by instruction-only patch")
+	}
+}

--- a/internal/api/handler/snapshot_scope_input.go
+++ b/internal/api/handler/snapshot_scope_input.go
@@ -1,0 +1,66 @@
+package handler
+
+// snapshot_scope_input.go — SUM-BE1 helper glue.
+//
+// The shared service.ValidateSnapshotScope validator takes its own
+// SourceInput / ParticipantInput / ScheduleInput types so it can live in
+// internal/service/ without a cycle back into internal/api/handler/. This
+// file provides the tiny converters + one init() that wires the runtime
+// pipeline.DefaultTimeRangeDays global into the validator's getter, so a
+// single boot-time change to DEFAULT_TIME_RANGE_DAYS still bounds new
+// summaries the same way the old inline check did.
+
+import (
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+)
+
+func init() {
+	// Wire the pipeline runtime global into the shared validator so a
+	// config-driven DEFAULT_TIME_RANGE_DAYS change is honoured on every
+	// request without either package importing the other for a value.
+	service.SetTimeRangeMaxDaysGetter(func() int { return pipeline.DefaultTimeRangeDays })
+}
+
+// snapshotSourcesFromReq converts the handler-side sourceReq slice into the
+// validator's SourceInput slice. Nil in -> nil out so the validator's empty
+// / count-cap checks stay literal.
+func snapshotSourcesFromReq(in []sourceReq) []service.SourceInput {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]service.SourceInput, len(in))
+	for i, s := range in {
+		out[i] = service.SourceInput{SourceType: s.SourceType, SourceID: s.SourceID}
+	}
+	return out
+}
+
+// snapshotParticipantsFromReq mirrors snapshotSourcesFromReq for participants.
+// Empty in -> nil out so validators keying off len(...) == 0 continue to
+// behave as they did on the pre-refactor req.Participants slice.
+func snapshotParticipantsFromReq(in []participantReq) []service.ParticipantInput {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]service.ParticipantInput, len(in))
+	for i, p := range in {
+		out[i] = service.ParticipantInput{UserID: p.UserID, UserName: p.UserName}
+	}
+	return out
+}
+
+// snapshotScheduleFromReq converts createScheduleReq's schedule fields into
+// the validator's ScheduleInput. It never nil-returns because the CreateSchedule
+// handler always has a full schedule shape at hand.
+func snapshotScheduleFromReq(req createScheduleReq) *service.ScheduleInput {
+	return &service.ScheduleInput{
+		CronExpr:       req.CronExpr,
+		IntervalDays:   req.IntervalDays,
+		IntervalMonths: req.IntervalMonths,
+		RunTime:        req.RunTime,
+		DayOfWeek:      req.DayOfWeek,
+		DayOfMonth:     req.DayOfMonth,
+		TimeRangeType:  req.TimeRangeType,
+	}
+}

--- a/internal/api/handler/snapshot_scope_input.go
+++ b/internal/api/handler/snapshot_scope_input.go
@@ -1,66 +1,48 @@
 package handler
 
-// snapshot_scope_input.go — SUM-BE1 helper glue.
+// snapshot_scope_input.go — SUM-BE1 helper: build the shared
+// model.SnapshotScope used by service.ValidatePersonalWorkflow /
+// ValidateScheduledWorkflow from the handler request structs.
 //
-// The shared service.ValidateSnapshotScope validator takes its own
-// SourceInput / ParticipantInput / ScheduleInput types so it can live in
-// internal/service/ without a cycle back into internal/api/handler/. This
-// file provides the tiny converters + one init() that wires the runtime
-// pipeline.DefaultTimeRangeDays global into the validator's getter, so a
-// single boot-time change to DEFAULT_TIME_RANGE_DAYS still bounds new
-// summaries the same way the old inline check did.
+// Revised per SUM-9: the previous parallel SnapshotScopeInput /
+// SourceInput / ParticipantInput / ScheduleInput mirror types are gone.
+// The shared validator now consumes model.SnapshotScope directly, so this
+// file only has the small extractor that turns []sourceReq into
+// []string channel IDs for the scope. Everything else the validator
+// needs (title, topic, source count, origin channel, time range,
+// participant count, schedule recurrence primitives) is passed as
+// plain arguments; no converter layer.
 
 import (
-	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
-	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 )
 
-func init() {
-	// Wire the pipeline runtime global into the shared validator so a
-	// config-driven DEFAULT_TIME_RANGE_DAYS change is honoured on every
-	// request without either package importing the other for a value.
-	service.SetTimeRangeMaxDaysGetter(func() int { return pipeline.DefaultTimeRangeDays })
-}
-
-// snapshotSourcesFromReq converts the handler-side sourceReq slice into the
-// validator's SourceInput slice. Nil in -> nil out so the validator's empty
-// / count-cap checks stay literal.
-func snapshotSourcesFromReq(in []sourceReq) []service.SourceInput {
+// channelIDsFromSources projects a slice of sourceReq into the channel_ids
+// slice model.SnapshotScope carries. Empty input -> nil (matches the shape
+// SnapshotScope stores when no sources were supplied).
+func channelIDsFromSources(in []sourceReq) []string {
 	if len(in) == 0 {
 		return nil
 	}
-	out := make([]service.SourceInput, len(in))
-	for i, s := range in {
-		out[i] = service.SourceInput{SourceType: s.SourceType, SourceID: s.SourceID}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s.SourceID != "" {
+			out = append(out, s.SourceID)
+		}
 	}
 	return out
 }
 
-// snapshotParticipantsFromReq mirrors snapshotSourcesFromReq for participants.
-// Empty in -> nil out so validators keying off len(...) == 0 continue to
-// behave as they did on the pre-refactor req.Participants slice.
-func snapshotParticipantsFromReq(in []participantReq) []service.ParticipantInput {
-	if len(in) == 0 {
-		return nil
+// scheduleScopeFromReq builds the shared model.SnapshotScope for a schedule
+// create request. Schedule requests carry sources but no explicit time_range
+// on the wire (time range is derived from time_range_type at run time), so
+// the scope carries ChannelIDs only and leaves TimeRange zero-valued.
+func scheduleScopeFromReq(req createScheduleReq) model.SnapshotScope {
+	return model.SnapshotScope{
+		ChannelIDs: channelIDsFromSources(req.Sources),
 	}
-	out := make([]service.ParticipantInput, len(in))
-	for i, p := range in {
-		out[i] = service.ParticipantInput{UserID: p.UserID, UserName: p.UserName}
-	}
-	return out
 }
 
-// snapshotScheduleFromReq converts createScheduleReq's schedule fields into
-// the validator's ScheduleInput. It never nil-returns because the CreateSchedule
-// handler always has a full schedule shape at hand.
-func snapshotScheduleFromReq(req createScheduleReq) *service.ScheduleInput {
-	return &service.ScheduleInput{
-		CronExpr:       req.CronExpr,
-		IntervalDays:   req.IntervalDays,
-		IntervalMonths: req.IntervalMonths,
-		RunTime:        req.RunTime,
-		DayOfWeek:      req.DayOfWeek,
-		DayOfMonth:     req.DayOfMonth,
-		TimeRangeType:  req.TimeRangeType,
-	}
-}
+// Explicit references so build tools do not flag helpers as unused when only
+// one call site is active in a given build tag configuration.
+var _ = model.SnapshotScope{}

--- a/internal/api/handler/snapshot_scope_input.go
+++ b/internal/api/handler/snapshot_scope_input.go
@@ -1,21 +1,15 @@
 package handler
 
 // snapshot_scope_input.go — SUM-BE1 helper: build the shared
-// model.SnapshotScope used by service.ValidatePersonalWorkflow /
-// ValidateScheduledWorkflow from the handler request structs.
+// model.SnapshotScope used by service.ValidatePersonalWorkflow from the
+// handler request structs.
 //
 // Revised per SUM-9: the previous parallel SnapshotScopeInput /
 // SourceInput / ParticipantInput / ScheduleInput mirror types are gone.
 // The shared validator now consumes model.SnapshotScope directly, so this
 // file only has the small extractor that turns []sourceReq into
 // []string channel IDs for the scope. Everything else the validator
-// needs (title, topic, source count, origin channel, time range,
-// participant count, schedule recurrence primitives) is passed as
-// plain arguments; no converter layer.
-
-import (
-	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
-)
+// needs is passed as plain arguments; no converter layer.
 
 // channelIDsFromSources projects a slice of sourceReq into the channel_ids
 // slice model.SnapshotScope carries. Empty input -> nil (matches the shape
@@ -32,17 +26,3 @@ func channelIDsFromSources(in []sourceReq) []string {
 	}
 	return out
 }
-
-// scheduleScopeFromReq builds the shared model.SnapshotScope for a schedule
-// create request. Schedule requests carry sources but no explicit time_range
-// on the wire (time range is derived from time_range_type at run time), so
-// the scope carries ChannelIDs only and leaves TimeRange zero-valued.
-func scheduleScopeFromReq(req createScheduleReq) model.SnapshotScope {
-	return model.SnapshotScope{
-		ChannelIDs: channelIDsFromSources(req.Sources),
-	}
-}
-
-// Explicit references so build tools do not flag helpers as unused when only
-// one call site is active in a given build tag configuration.
-var _ = model.SnapshotScope{}

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -372,6 +372,7 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 		scope,
 		len(req.Sources),
 		req.OriginChannelID, req.OriginChannelType,
+		explicitTimeRange,
 		validatorStart, validatorEnd,
 		maxDays,
 	); bizE != nil {

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -347,23 +347,34 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 		timeStart = timeEnd.Add(-time.Duration(maxDays) * 24 * time.Hour)
 	}
 
-	// SUM-BE1: replace the previously inline title / topic / origin-channel /
-	// time-range / source-count / scope-signal checks with the shared
-	// service.ValidateSnapshotScope so scheduled / agent-generation /
-	// agent-save paths in the same PR series reuse the same gate.
-	scopeInput := service.SnapshotScopeInput{
-		Title:             req.Title,
-		Topic:             req.Topic,
-		Sources:           snapshotSourcesFromReq(req.Sources),
-		Participants:      snapshotParticipantsFromReq(req.Participants),
-		OriginChannelID:   req.OriginChannelID,
-		OriginChannelType: req.OriginChannelType,
+	// SUM-BE1 (revised per SUM-9): call the shared validator with the ACTUAL
+	// model.SnapshotScope the pipeline downstream will use. ChannelIDs come
+	// from req.Sources (post-origin-channel autofill above); TimeRange
+	// carries the caller-supplied range (only when explicit, so the default
+	// server-computed range still passes untouched). No parallel DTO — the
+	// shared model.SnapshotScope is the validation input.
+	scope := model.SnapshotScope{
+		ChannelIDs: channelIDsFromSources(req.Sources),
 	}
 	if explicitTimeRange {
-		scopeInput.TimeStart = timeStart
-		scopeInput.TimeEnd = timeEnd
+		scope.TimeRange = model.TimeRangeJSON{
+			Start: timeStart.Format(time.RFC3339),
+			End:   timeEnd.Format(time.RFC3339),
+		}
 	}
-	if bizE := service.ValidateSnapshotScope(effectiveUID, scopeInput, service.TargetPersonalWorkflow); bizE != nil {
+	var validatorStart, validatorEnd time.Time
+	if explicitTimeRange {
+		validatorStart, validatorEnd = timeStart, timeEnd
+	}
+	if bizE := service.ValidatePersonalWorkflow(
+		effectiveUID,
+		req.Title, req.Topic,
+		scope,
+		len(req.Sources),
+		req.OriginChannelID, req.OriginChannelType,
+		validatorStart, validatorEnd,
+		maxDays,
+	); bizE != nil {
 		bizErr(c, bizE)
 		return
 	}

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -367,7 +367,7 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 		validatorStart, validatorEnd = timeStart, timeEnd
 	}
 	if bizE := service.ValidatePersonalWorkflow(
-		effectiveUID,
+		userID,
 		req.Title, req.Topic,
 		scope,
 		len(req.Sources),
@@ -389,13 +389,6 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 	if len(req.Sources) > 0 {
 		sourceList = req.Sources
 	}
-	// Preserve the public API contract: the cap applies to submitted entries,
-	// before duplicate rows are collapsed for persistence.
-	if len(sourceList) > maxSourceCount {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40003, Message: fmt.Sprintf("信息来源不能超过%d个", maxSourceCount)})
-		return
-	}
-
 	// R10: dedup by (source_type, source_id) before insert.
 	// uk_summary_source_task_type_id (migration 20260814-01) would turn a
 	// duplicate client input into a 500; the create endpoint previously

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -320,40 +320,26 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 		effectiveUID = userID
 	}
 
-	// Validate
-	if utf8.RuneCountInString(req.Title) > maxSummaryTopicRunes {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "title 不能超过 2300 字符"})
-		return
-	}
-	if utf8.RuneCountInString(req.Topic) > maxSummaryTopicRunes {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "topic 不能超过 2300 字符"})
-		return
-	}
-	if req.OriginChannelID != "" && (req.OriginChannelType < model.OriginChannelGroup || req.OriginChannelType > model.OriginChannelDM) {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set"})
-		return
-	}
-	if req.OriginChannelID == "" && req.OriginChannelType != 0 {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "origin_channel_id is required when origin_channel_type is set"})
-		return
-	}
+	// Auto-fill sources from origin_channel BEFORE validation so the
+	// scope-signal check sees the expanded source list. Note this runs even
+	// when origin_channel_type is out of range — the shared validator below
+	// still rejects the malformed origin_channel_type before any DB write.
 	if len(req.Sources) == 0 && req.OriginChannelID != "" && req.OriginChannelType >= model.OriginChannelGroup && req.OriginChannelType <= model.OriginChannelDM {
 		req.Sources = []sourceReq{{
 			SourceType: req.OriginChannelType,
 			SourceID:   req.OriginChannelID,
 		}}
 	}
-	if len(req.Sources) == 0 && req.Topic == "" && req.TimeRange == nil {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40001, Message: "至少提供 sources、topic 或 time_range 之一"})
-		return
-	}
 
-	summaryMode := model.ModeByPerson
-
-	// Resolve time range
+	// Resolve time range up-front so the shared validator sees the caller's
+	// intended range. Only pass a real range into the validator when the
+	// caller sent one — leaving TimeStart/TimeEnd zero on scopeInput keeps
+	// the pre-refactor behaviour where the server-computed default range
+	// never triggered the span check.
 	maxDays := pipeline.DefaultTimeRangeDays
 	var timeStart, timeEnd time.Time
-	if req.TimeRange != nil {
+	explicitTimeRange := req.TimeRange != nil
+	if explicitTimeRange {
 		timeStart = req.TimeRange.Start
 		timeEnd = req.TimeRange.End
 	} else {
@@ -361,10 +347,28 @@ func (h *TaskHandler) CreateSummary(c *gin.Context) {
 		timeStart = timeEnd.Add(-time.Duration(maxDays) * 24 * time.Hour)
 	}
 
-	if timeEnd.Sub(timeStart) > time.Duration(maxDays)*24*time.Hour {
-		c.JSON(http.StatusBadRequest, apiResponse{Code: 40002, Message: fmt.Sprintf("时间范围不能超过%d天", maxDays)})
+	// SUM-BE1: replace the previously inline title / topic / origin-channel /
+	// time-range / source-count / scope-signal checks with the shared
+	// service.ValidateSnapshotScope so scheduled / agent-generation /
+	// agent-save paths in the same PR series reuse the same gate.
+	scopeInput := service.SnapshotScopeInput{
+		Title:             req.Title,
+		Topic:             req.Topic,
+		Sources:           snapshotSourcesFromReq(req.Sources),
+		Participants:      snapshotParticipantsFromReq(req.Participants),
+		OriginChannelID:   req.OriginChannelID,
+		OriginChannelType: req.OriginChannelType,
+	}
+	if explicitTimeRange {
+		scopeInput.TimeStart = timeStart
+		scopeInput.TimeEnd = timeEnd
+	}
+	if bizE := service.ValidateSnapshotScope(effectiveUID, scopeInput, service.TargetPersonalWorkflow); bizE != nil {
+		bizErr(c, bizE)
 		return
 	}
+
+	summaryMode := model.ModeByPerson
 
 	// Resolve sources: use user-specified sources directly.
 	// When no sources are specified, the pipeline Layer 3 (NarrowByTopic)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -161,6 +161,15 @@ type SummaryTask struct {
 	// trigger_type=agent summaries where the user picked one or more existing
 	// summaries as reference material via the chat UI.
 	ReferencedTaskIDs *string `gorm:"column:referenced_task_ids;type:text" json:"-"`
+	// AgentSessionID / AgentMessageID / SnapshotVersion are the safe-save
+	// audit trail for trigger_type=Agent tasks (SUM-BE2). They record the
+	// exact assistant reply and snapshot version the client confirmed at
+	// save time, so a reviewer or the future Refine pipeline can trace which
+	// draft became this summary. Non-agent tasks leave them at the zero
+	// value; the migration (20260810-01) backfills existing rows likewise.
+	AgentSessionID  string `gorm:"column:agent_session_id;type:varchar(128);not null;default:'';index:idx_summary_task_agent_session" json:"agent_session_id,omitempty"`
+	AgentMessageID  int64  `gorm:"column:agent_message_id;not null;default:0" json:"agent_message_id,omitempty"`
+	SnapshotVersion int    `gorm:"column:snapshot_version;type:int;not null;default:0" json:"snapshot_version,omitempty"`
 }
 
 // SummaryBotCreateIdempotency binds one bot request key to the task created
@@ -185,6 +194,25 @@ type SummaryBotCreateIdempotency struct {
 }
 
 func (SummaryBotCreateIdempotency) TableName() string { return "summary_bot_create_idempotency" }
+
+// SummaryAgentSaveIdempotency is the Agent-save analogue of
+// SummaryBotCreateIdempotency (see above): one (space_id, user_id,
+// idempotency_key) tuple binds to exactly one saved task_id. Same
+// same-key-same-body-replay / same-key-different-body-409 contract; the only
+// axis change is the actor — Agent save is user-owned, not bot-owned, so the
+// unique index uses user_id where the bot table uses bot_id (see migration
+// 20260810-01-agent-draft-save.sql).
+type SummaryAgentSaveIdempotency struct {
+	ID             int64     `gorm:"primaryKey;autoIncrement"`
+	SpaceID        string    `gorm:"column:space_id;type:varchar(64);not null;uniqueIndex:uk_agent_save_idempotency"`
+	UserID         string    `gorm:"column:user_id;type:varchar(64);not null;uniqueIndex:uk_agent_save_idempotency"`
+	IdempotencyKey string    `gorm:"column:idempotency_key;type:varchar(128);not null;uniqueIndex:uk_agent_save_idempotency"`
+	RequestHash    string    `gorm:"column:request_hash;type:char(64);not null;default:''"`
+	TaskID         int64     `gorm:"column:task_id;not null"`
+	CreatedAt      time.Time `gorm:"column:created_at;not null"`
+}
+
+func (SummaryAgentSaveIdempotency) TableName() string { return "summary_agent_save_idempotency" }
 
 // EffectiveTopic keeps existing tasks compatible while new tasks persist the
 // complete summary instruction separately from the display title.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -163,10 +163,10 @@ type SummaryTask struct {
 	ReferencedTaskIDs *string `gorm:"column:referenced_task_ids;type:text" json:"-"`
 	// AgentSessionID / AgentMessageID / SnapshotVersion are the safe-save
 	// audit trail for trigger_type=Agent tasks (SUM-BE2). They record the
-	// exact assistant reply and snapshot version the client confirmed at
-	// save time, so a reviewer or the future Refine pipeline can trace which
-	// draft became this summary. Non-agent tasks leave them at the zero
-	// value; the migration (20260810-01) backfills existing rows likewise.
+	// exact assistant reply and client-declared snapshot version at save time,
+	// so a reviewer can trace which draft became this summary. Legacy clients
+	// leave SnapshotVersion at 0 even though snapshot_json uses the v1 envelope;
+	// non-agent tasks leave all three fields at their zero values.
 	AgentSessionID  string `gorm:"column:agent_session_id;type:varchar(128);not null;default:'';index:idx_summary_task_agent_session" json:"agent_session_id,omitempty"`
 	AgentMessageID  int64  `gorm:"column:agent_message_id;not null;default:0" json:"agent_message_id,omitempty"`
 	SnapshotVersion int    `gorm:"column:snapshot_version;type:int;not null;default:0" json:"snapshot_version,omitempty"`

--- a/internal/service/snapshot_validator.go
+++ b/internal/service/snapshot_validator.go
@@ -1,27 +1,29 @@
-// Package service — shared SnapshotScope validator.
+// Package service — shared SnapshotScope validator (SUM-BE1, revised per SUM-9).
 //
-// This file implements the SUM-BE1 refactor from the "Unified Smart Summary"
-// design: pull the inline validation that used to sit in the
-// `handler.TaskHandler.CreateSummary` request path into a reusable service
-// that every summary entry point calls before it creates rows, so the traditional
-// personal / traditional team / scheduled / agent-generation / agent-save
-// paths all evaluate the same scope, permission and shape checks.
+// Design constraints (unified-smart-summary-design.md section 5 / 7):
 //
-// Design constraints preserved verbatim (see unified-smart-summary-design.md
-// section 5 and section 7.1):
+//   - Use model.SnapshotScope as the shared validator input. Do NOT introduce
+//     any parallel Scope-mirror types or converter layers — reviewers on SUM-9
+//     called that out as decoration-only.
+//   - Every declared target must have a real production call site AND real
+//     enforcement. Targets that BE-1 cannot legitimately wire (team_workflow,
+//     agent_generation) are intentionally NOT exposed here; the design lists
+//     them but the traditional-team and agent-generation endpoints belong to
+//     BE-2 / FE-2 and will land the target APIs alongside their handlers.
+//   - "actor" is not just a log breadcrumb: an unauthenticated caller must be
+//     rejected up-front (401), otherwise the validator would be a soft gate
+//     downstream code cannot rely on.
+//   - No mutable process-level globals for limits / max-days: values are
+//     passed in explicitly so parallel tests and future concurrent config
+//     changes cannot race.
+//   - Error codes and messages match handler.CreateSummary's pre-refactor
+//     inline checks bit-for-bit so router-facing responses stay identical
+//     and existing regression tests (task_limit_test.go, etc.) keep passing.
 //
-//   - Reuse model.SnapshotScope. Do NOT invent a parallel SummaryScope type.
-//   - Do not new-write zero-value Schedule fields — validation must be a
-//     read-only gate; Schedule field preservation is the caller's job and this
-//     validator only *checks* the schedule input it is given.
-//   - Traditional personal / team behavior must not regress. Every existing
-//     bad-input error message and business code from CreateSummary is preserved
-//     bit-for-bit here so the router-facing responses stay identical.
-//   - personal_processor / meta_processor are not touched — they still run off
-//     the SummaryTask row the handler creates after validation passes.
-//
-// The validator is intentionally free of gorm / gin / net-http coupling so that
-// unit tests can exercise every branch without spinning a router or a DB.
+// This file exports three focused functions — one per BE-1 production entry
+// point — instead of a single string-target switch. That makes the reviewed
+// "does the caller actually enforce this?" check trivial: the compiler
+// answers it (each function must be called somewhere or dead-code lint fires).
 package service
 
 import (
@@ -33,333 +35,183 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 )
 
-// ScopeValidationTarget names one of the five real execution targets that the
-// unified design (section 2.3, section 5.1) recognises. Values are stable
-// string identifiers (not iota-integers) so log lines and error breadcrumbs
-// stay readable when they surface in production.
-type ScopeValidationTarget string
-
+// Base caps applied by every entry point. These are const rather than package
+// variables because callers should never be able to override them at runtime —
+// the SUM-9 review flagged the previous exported setter as a race risk.
 const (
-	// TargetPersonalWorkflow: traditional single-person workflow via
-	// handler.CreateSummary -> worker -> personal_processor.
-	TargetPersonalWorkflow ScopeValidationTarget = "personal_workflow"
-	// TargetTeamWorkflow: traditional multi-person workflow (personal+meta).
-	TargetTeamWorkflow ScopeValidationTarget = "team_workflow"
-	// TargetScheduledWorkflow: creating / updating a summary_schedule row.
-	TargetScheduledWorkflow ScopeValidationTarget = "scheduled_workflow"
-	// TargetAgentGeneration: the agent is about to run a generation turn and
-	// needs the same scope-level gates the traditional path already has.
-	TargetAgentGeneration ScopeValidationTarget = "agent_generation"
-	// TargetAgentSave: user clicked "save as official summary" on an agent
-	// draft — the CreateAgentSummary handler is about to persist rows.
-	TargetAgentSave ScopeValidationTarget = "agent_save"
+	// MaxSummaryTitleRunes bounds every user-supplied title / topic string.
+	// Matches handler.maxSummaryTopicRunes (which stays const there).
+	MaxSummaryTitleRunes = 2300
+	// MaxSummarySourceCount bounds len(sources). Matches handler.maxSourceCount.
+	MaxSummarySourceCount = 30
 )
 
-// SnapshotScopeInput is the union of every field the shared validator needs.
-// It carries the request-time view of what the caller is about to write —
-// intentionally wider than model.SnapshotScope (the storage struct) because
-// validation covers upstream fields the storage snapshot does not persist
-// (topic, participants, sources with types, schedule).
-//
-// The Scope field embeds model.SnapshotScope directly rather than duplicating
-// ChannelIDs / ChannelNames / TimeRange, honouring section 7.2 "reuse
-// SnapshotScope, not new SummaryScope".
-type SnapshotScopeInput struct {
-	// Title is the request-provided task/schedule title.
-	Title string
-	// Topic is the free-text requirement (design section 4.1 / section 5.2
-	// "requirement/topic available").
-	Topic string
-	// Scope is the shared SnapshotScope carrying channel_ids / channel_names /
-	// time_range. TimeRange strings on this struct are informational; the
-	// validator uses TimeStart / TimeEnd below when present so we can enforce
-	// the range-in-days rule with real time.Time values instead of parsing
-	// RFC3339 twice.
-	Scope model.SnapshotScope
-	// TimeStart / TimeEnd override Scope.TimeRange when both are non-zero. If
-	// both are zero the caller has not chosen a range yet and the validator
-	// falls back to "range not required at input time" behaviour (matching
-	// CreateSummary's pre-refactor auto-fill: end=now, start=now-maxDays).
-	TimeStart time.Time
-	TimeEnd   time.Time
-	// Sources carries the caller's source list (source_type + source_id). The
-	// slice may be empty when the caller lets the pipeline auto-narrow.
-	Sources []SourceInput
-	// Participants carries the caller-provided participant user ids (empty ->
-	// creator-only, matching CreateSummary's auto-fill).
-	Participants []ParticipantInput
-	// OriginChannelID / OriginChannelType mirror the createSummaryReq fields
-	// that used to be range-checked inline.
-	OriginChannelID   string
-	OriginChannelType int
-	// Schedule, if non-nil, activates schedule-target checks and also causes
-	// personal/team-target checks to reject invalid schedules pinned onto the
-	// same request (e.g. an Agent-assisted traditional create that carries a
-	// stale schedule payload from the UI). The validator never mutates the
-	// pointee — Schedule field preservation is the caller's responsibility.
-	Schedule *ScheduleInput
-	// AgentSave carries the extra bits CreateAgentSummary needs so
-	// TargetAgentSave can run the "message belongs to this session" gate the
-	// design (section 5.2 agent_save) prescribes.
-	AgentSave *AgentSaveInput
-}
-
-// SourceInput mirrors handler.sourceReq without importing the handler package.
-type SourceInput struct {
-	SourceType int
-	SourceID   string
-}
-
-// ParticipantInput mirrors handler.participantReq without importing it.
-type ParticipantInput struct {
-	UserID   string
-	UserName string
-}
-
-// ScheduleInput carries every schedule field the validator checks. The names
-// mirror model.SummarySchedule / handler.createScheduleReq so callers pass
-// through what they already have.
-type ScheduleInput struct {
-	CronExpr       string
-	IntervalDays   int
-	IntervalMonths int
-	RunTime        string
-	DayOfWeek      int
-	DayOfMonth     int
-	TimeRangeType  int
-}
-
-// AgentSaveInput captures the extra AgentSave-target information: which
-// session / message the caller is about to persist and (optionally) the
-// SnapshotVersion the client last saw. Fields left zero-valued mean "caller
-// wants only the base scope checks".
-type AgentSaveInput struct {
-	SessionID       string
-	AgentMessageID  int64
-	SnapshotVersion int
-	// ContentLen is the length in bytes of the assistant message the caller
-	// intends to save. Empty content is a design-mandated 40004 reject
-	// (section 5.2 agent_save "content valid").
-	ContentLen int
-}
-
-// scopeValidatorLimits centralises the (currently const) upper bounds so the
-// validator does not import the handler package to read them. Kept package-
-// private and set from handler/task.go so a single change site keeps the
-// numbers coherent. The zero-value defaults match the current handler consts:
-//
-//	maxSummaryTopicRunes = 2300
-//	maxSourceCount       = 30
-//
-// pipeline.DefaultTimeRangeDays is a runtime global set from config at boot,
-// so we read it via a getter instead of copying the value.
-type scopeValidatorLimits struct {
-	MaxTopicRunes int
-	MaxSources    int
-	MaxDays       int
-}
-
-// The validator reads limits through this struct so tests can override them
-// without racing on package-globals from unrelated packages.
-var scopeLimits = scopeValidatorLimits{
-	MaxTopicRunes: 2300,
-	MaxSources:    30,
-	MaxDays:       0, // 0 = "use pipeline.DefaultTimeRangeDays via getter"
-}
-
-// timeRangeMaxDaysGetter is populated by handler init() to break the import
-// cycle handler->service->pipeline. The default returns 0 (validator skips
-// the range check), matching pre-refactor behaviour when TimeRange is unset.
-var timeRangeMaxDaysGetter = func() int { return 0 }
-
-// SetTimeRangeMaxDaysGetter lets the handler (or any bootstrapper) wire the
-// pipeline.DefaultTimeRangeDays runtime global into the validator. Must be
-// called before ValidateSnapshotScope; if not called, the range check is a
-// no-op — matching CreateSummary's pre-refactor behaviour when TimeRange is
-// nil (validator only enforces the cap when a range is actually specified).
-func SetTimeRangeMaxDaysGetter(fn func() int) {
-	if fn != nil {
-		timeRangeMaxDaysGetter = fn
+// requireActor rejects callers with no identity. Every entry point runs this
+// first so downstream code can rely on a non-empty actor.
+func requireActor(actor string) *BizError {
+	if actor == "" {
+		return NewBizError(40100, "actor is required", http.StatusUnauthorized)
 	}
+	return nil
 }
 
-// SetScopeValidatorLimits overrides the topic-rune / source-count caps. Meant
-// for tests that need to poke edge cases without maxing out real limits.
-// Passing a non-positive value for a field keeps the previous value.
-func SetScopeValidatorLimits(maxTopicRunes, maxSources int) {
-	if maxTopicRunes > 0 {
-		scopeLimits.MaxTopicRunes = maxTopicRunes
-	}
-	if maxSources > 0 {
-		scopeLimits.MaxSources = maxSources
-	}
-}
-
-// ValidateSnapshotScope runs the target-agnostic base checks plus the
-// target-specific gates described in unified-smart-summary-design.md
-// section 5.2.
-//
-// It returns *BizError on the first failure so callers can `bizErr(c, err)`
-// without translation. `actor` is the invoking user id — currently unused for
-// authz (the callers still hold DB access to check per-channel permissions),
-// but it is carried through so future authz work can slot in without a
-// signature break. Deliberately kept in the signature per section 5.1 spec:
-//
-//	ValidateSnapshotScope(actor, snapshot, target)
-func ValidateSnapshotScope(actor string, input SnapshotScopeInput, target ScopeValidationTarget) *BizError {
-	// _ = actor: reserved for future per-user authz; see doc comment.
-	_ = actor
-
-	// --- base checks (apply to every target) ---
-	// Order below preserves the exact sequence used by CreateSummary so the
-	// first-error contract is regression-safe.
-
-	if utf8.RuneCountInString(input.Title) > scopeLimits.MaxTopicRunes {
+// validateTitleAndTopic runs the two rune-cap checks shared by every entry
+// point. Message strings match the pre-refactor inline checks bit-for-bit.
+func validateTitleAndTopic(title, topic string) *BizError {
+	if utf8.RuneCountInString(title) > MaxSummaryTitleRunes {
 		return NewBizError(40001, "title 不能超过 2300 字符", http.StatusBadRequest)
 	}
-	if utf8.RuneCountInString(input.Topic) > scopeLimits.MaxTopicRunes {
+	if utf8.RuneCountInString(topic) > MaxSummaryTitleRunes {
 		return NewBizError(40001, "topic 不能超过 2300 字符", http.StatusBadRequest)
 	}
-	// origin_channel_id / origin_channel_type must move together and stay
-	// inside the 1..3 application-layer enum (see model.OriginChannelGroup /
-	// Thread / DM in model/model.go).
-	if input.OriginChannelID != "" && (input.OriginChannelType < model.OriginChannelGroup || input.OriginChannelType > model.OriginChannelDM) {
+	return nil
+}
+
+// validateOriginChannel checks the (id, type) coupling used by traditional and
+// agent-save paths. Both fields either move together, or both are unset.
+// application-layer type range is 1..3 (see model.OriginChannelGroup / DM).
+func validateOriginChannel(originChannelID string, originChannelType int) *BizError {
+	if originChannelID != "" && (originChannelType < model.OriginChannelGroup || originChannelType > model.OriginChannelDM) {
 		return NewBizError(40001, "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set", http.StatusBadRequest)
 	}
-	if input.OriginChannelID == "" && input.OriginChannelType != 0 {
+	if originChannelID == "" && originChannelType != 0 {
 		return NewBizError(40001, "origin_channel_id is required when origin_channel_type is set", http.StatusBadRequest)
 	}
+	return nil
+}
 
-	// Time-range span cap. Only enforced when the caller supplied both endpoints
-	// (matches CreateSummary's pre-refactor behaviour of only bounding an
-	// explicit req.TimeRange and letting the default range through untouched).
-	if maxDays := effectiveMaxDays(); maxDays > 0 && !input.TimeStart.IsZero() && !input.TimeEnd.IsZero() {
-		if input.TimeEnd.Sub(input.TimeStart) > time.Duration(maxDays)*24*time.Hour {
+// scopeHasSignal returns true when the shared SnapshotScope carries at least
+// one of channel ids or a time range — i.e. the caller narrowed the summary
+// in *some* way. Empty ChannelIDs AND empty TimeRange with no topic hint at
+// the caller-site is the classic "at least one of sources/topic/time_range"
+// failure the traditional path has always rejected.
+func scopeHasSignal(scope model.SnapshotScope) bool {
+	if len(scope.ChannelIDs) > 0 {
+		return true
+	}
+	if scope.TimeRange.Start != "" || scope.TimeRange.End != "" {
+		return true
+	}
+	return false
+}
+
+// ValidatePersonalWorkflow is called by handler.CreateSummary before it
+// creates any row. Every argument is either data the handler already has in
+// hand (no converter needed) or the shared model.SnapshotScope built from
+// req.Sources + req.TimeRange in one place.
+//
+// Parameters
+//
+//   - actor:  the invoking user id; empty ⇒ 401.
+//   - title:  createSummaryReq.Title
+//   - topic:  createSummaryReq.Topic
+//   - scope:  model.SnapshotScope actually built from the request; this is
+//     what the validator gates on, NOT a parallel DTO.
+//   - sourceCount:      len(req.Sources) — the count cap is target-specific.
+//   - originChannelID / originChannelType: raw request fields.
+//   - explicitTimeStart / explicitTimeEnd: the caller-supplied range (zero
+//     values ⇒ caller let the server compute a default range and
+//     wants the span cap skipped, matching pre-refactor behaviour).
+//   - maxDays: pipeline.DefaultTimeRangeDays passed explicitly so the
+//     validator has no runtime dependency on a mutable global.
+func ValidatePersonalWorkflow(
+	actor, title, topic string,
+	scope model.SnapshotScope,
+	sourceCount int,
+	originChannelID string, originChannelType int,
+	explicitTimeStart, explicitTimeEnd time.Time,
+	maxDays int,
+) *BizError {
+	if err := requireActor(actor); err != nil {
+		return err
+	}
+	if err := validateTitleAndTopic(title, topic); err != nil {
+		return err
+	}
+	if err := validateOriginChannel(originChannelID, originChannelType); err != nil {
+		return err
+	}
+	if maxDays > 0 && !explicitTimeStart.IsZero() && !explicitTimeEnd.IsZero() {
+		if explicitTimeEnd.Sub(explicitTimeStart) > time.Duration(maxDays)*24*time.Hour {
 			return NewBizError(40002, fmt.Sprintf("时间范围不能超过%d天", maxDays), http.StatusBadRequest)
 		}
 	}
-
-	// Sources count cap.
-	if len(input.Sources) > scopeLimits.MaxSources {
-		return NewBizError(40003, fmt.Sprintf("信息来源不能超过%d个", scopeLimits.MaxSources), http.StatusBadRequest)
+	if sourceCount > MaxSummarySourceCount {
+		return NewBizError(40003, fmt.Sprintf("信息来源不能超过%d个", MaxSummarySourceCount), http.StatusBadRequest)
 	}
-
-	// --- target-specific gates ---
-	switch target {
-	case TargetPersonalWorkflow:
-		return validatePersonalWorkflow(input)
-	case TargetTeamWorkflow:
-		return validateTeamWorkflow(input)
-	case TargetScheduledWorkflow:
-		return validateScheduledWorkflow(input)
-	case TargetAgentGeneration:
-		return validateAgentGeneration(input)
-	case TargetAgentSave:
-		return validateAgentSave(input)
-	default:
-		// An unknown target is a programmer error, but we prefer a graceful
-		// 400 over a panic so a runtime mistake does not 500 users.
-		return NewBizError(40000, fmt.Sprintf("unknown validation target: %q", target), http.StatusBadRequest)
-	}
-}
-
-// effectiveMaxDays picks the configured MaxDays (test override) or falls
-// back to the pipeline runtime global via the getter.
-func effectiveMaxDays() int {
-	if scopeLimits.MaxDays > 0 {
-		return scopeLimits.MaxDays
-	}
-	return timeRangeMaxDaysGetter()
-}
-
-// validatePersonalWorkflow: CreateSummary's canonical "traditional single-person"
-// path — the caller must provide at least one of sources/topic/time_range so the
-// personal_processor has something to narrow on.
-func validatePersonalWorkflow(input SnapshotScopeInput) *BizError {
-	if hasNoScopeSignal(input) {
+	// Scope-signal gate — either the shared scope carries a signal, or the
+	// caller provided a topic. This is the "at least one of sources/topic/
+	// time_range" contract the traditional path has always enforced.
+	if !scopeHasSignal(scope) && topic == "" {
 		return NewBizError(40001, "至少提供 sources、topic 或 time_range 之一", http.StatusBadRequest)
 	}
 	return nil
 }
 
-// validateTeamWorkflow: the multi-person traditional path shares personal's
-// scope-signal requirement (still needs channels or topic or a range) and adds
-// a participants-must-be-non-empty rule the design (section 5.2 team_workflow)
-// calls out. The traditional handler still owns the participant-dedup /
-// creator-included transformation; the validator only refuses payloads that
-// are structurally missing a collaboration target.
-func validateTeamWorkflow(input SnapshotScopeInput) *BizError {
-	if hasNoScopeSignal(input) {
-		return NewBizError(40001, "至少提供 sources、topic 或 time_range 之一", http.StatusBadRequest)
+// ValidateScheduledWorkflow is called by handler.CreateSchedule. The deep
+// recurrence / anchor / run-time / day-of-week / day-of-month / time-range-
+// type checks stay in the existing service.ValidateInterval* / ValidateRunTime
+// / ValidateScheduleAnchors / ValidateTimeRangeType helpers — this function
+// runs the shared base cap and the "recurrence must be non-empty" invariant
+// (design section 4.1: Schedule payload must be actually delivered, not
+// zero-filled by an accidental patch).
+//
+// scope carries channel ids (from req.Sources) and time range (from
+// req.TimeRange or the schedule's time_range_type). Handlers build it once
+// and pass it in — same model.SnapshotScope as the other paths.
+func ValidateScheduledWorkflow(
+	actor, title string,
+	scope model.SnapshotScope,
+	cronExpr string, intervalDays, intervalMonths int,
+) *BizError {
+	if err := requireActor(actor); err != nil {
+		return err
 	}
-	if len(input.Participants) == 0 {
-		return NewBizError(40001, "team_workflow 需要至少一个参与者", http.StatusBadRequest)
+	if err := validateTitleAndTopic(title, ""); err != nil {
+		return err
 	}
-	return nil
-}
-
-// validateScheduledWorkflow: schedule input must be present. Downstream
-// service.ValidateInterval*/ValidateRunTime already own the deep schedule-shape
-// checks; here we only guarantee the Schedule payload was actually delivered
-// (no zero-value Patch — see section 4.1 / section 7.6 "Schedule 不会被 Patch
-// 或新入口写零值").
-func validateScheduledWorkflow(input SnapshotScopeInput) *BizError {
-	if input.Schedule == nil {
-		return NewBizError(40010, "scheduled_workflow requires schedule payload", http.StatusBadRequest)
-	}
-	if input.Schedule.CronExpr == "" && input.Schedule.IntervalDays == 0 && input.Schedule.IntervalMonths == 0 {
+	if cronExpr == "" && intervalDays == 0 && intervalMonths == 0 {
 		return NewBizError(40010, "schedule 必须提供 cron_expr / interval_days / interval_months 之一", http.StatusBadRequest)
 	}
+	// Non-blocking: an entirely empty scope on a schedule is legal in this
+	// repo (Layer 3 auto-narrow picks channels at run time), so we do NOT
+	// insist on a channel/time signal here — the design allows it for
+	// scheduled runs whose scope is intentionally template-shaped.
+	_ = scope
 	return nil
 }
 
-// validateAgentGeneration: before the agent runs a generation turn we want the
-// same "there is something to summarise" gate the traditional path has, so
-// authors cannot get around the check by walking through the agent.
-func validateAgentGeneration(input SnapshotScopeInput) *BizError {
-	if hasNoScopeSignal(input) {
-		return NewBizError(40001, "agent_generation 需要 sources、topic 或 time_range 之一", http.StatusBadRequest)
+// ValidateAgentSave is called by handler.CreateAgentSummary AFTER the
+// server-trusted assistant content has been loaded and preamble-stripped.
+// The handler owns the message ownership / role / session identity DB reads
+// (loadLatestAssistantContent already filters WHERE user_id = ? AND
+// session_id = ? AND role = 'assistant'), so this validator focuses on the
+// shape / length checks and leaves the DB-side identity contract with the
+// handler where it can actually be enforced.
+//
+// The design lists Snapshot-version and message-id enforcement under the
+// agent_save target; those DB-driven checks are BE-2 scope (they require new
+// storage-side reads and version columns that BE-1 does not add), so they
+// are NOT declared as parameters here — leaving them as unused fields on a
+// DTO would be exactly the "shell coverage" SUM-9 rejected.
+func ValidateAgentSave(
+	actor, title, sessionID, content string,
+	originChannelID string, originChannelType int,
+) *BizError {
+	if err := requireActor(actor); err != nil {
+		return err
 	}
-	return nil
-}
-
-// validateAgentSave: the design (section 5.2 agent_save) mandates
-// session/message ownership, non-empty content, and Snapshot-version
-// alignment. The handler still owns the DB reads (message ownership +
-// freshness), so this checks the *shape* of what the caller says it is about
-// to save.
-func validateAgentSave(input SnapshotScopeInput) *BizError {
-	if input.AgentSave == nil {
-		return NewBizError(40000, "agent_save 需要 agent_save 信息", http.StatusBadRequest)
+	if err := validateTitleAndTopic(title, ""); err != nil {
+		return err
 	}
-	if input.AgentSave.SessionID == "" {
+	if err := validateOriginChannel(originChannelID, originChannelType); err != nil {
+		return err
+	}
+	if sessionID == "" {
 		return NewBizError(40000, "agent_save session_id 不能为空", http.StatusBadRequest)
 	}
-	if input.AgentSave.ContentLen == 0 {
-		// Matches CreateAgentSummary's 40004 for "session 无有效产出".
+	if content == "" {
 		return NewBizError(40004, "session 无有效产出,请先在对话中生成总结再保存", http.StatusBadRequest)
 	}
 	return nil
-}
-
-// hasNoScopeSignal returns true when the input has neither sources nor a topic
-// nor any time range signal. Kept as one place so personal / team / agent
-// generation share the same definition of "empty scope".
-func hasNoScopeSignal(input SnapshotScopeInput) bool {
-	if len(input.Sources) > 0 {
-		return false
-	}
-	if input.Topic != "" {
-		return false
-	}
-	if !input.TimeStart.IsZero() || !input.TimeEnd.IsZero() {
-		return false
-	}
-	// Fall back to the storage-side TimeRange fields for callers that populate
-	// only the model.SnapshotScope (e.g. tests). Non-empty strings on either
-	// side count as a range signal.
-	if input.Scope.TimeRange.Start != "" || input.Scope.TimeRange.End != "" {
-		return false
-	}
-	return true
 }

--- a/internal/service/snapshot_validator.go
+++ b/internal/service/snapshot_validator.go
@@ -1,0 +1,365 @@
+// Package service — shared SnapshotScope validator.
+//
+// This file implements the SUM-BE1 refactor from the "Unified Smart Summary"
+// design: pull the inline validation that used to sit in the
+// `handler.TaskHandler.CreateSummary` request path into a reusable service
+// that every summary entry point calls before it creates rows, so the traditional
+// personal / traditional team / scheduled / agent-generation / agent-save
+// paths all evaluate the same scope, permission and shape checks.
+//
+// Design constraints preserved verbatim (see unified-smart-summary-design.md
+// section 5 and section 7.1):
+//
+//   - Reuse model.SnapshotScope. Do NOT invent a parallel SummaryScope type.
+//   - Do not new-write zero-value Schedule fields — validation must be a
+//     read-only gate; Schedule field preservation is the caller's job and this
+//     validator only *checks* the schedule input it is given.
+//   - Traditional personal / team behavior must not regress. Every existing
+//     bad-input error message and business code from CreateSummary is preserved
+//     bit-for-bit here so the router-facing responses stay identical.
+//   - personal_processor / meta_processor are not touched — they still run off
+//     the SummaryTask row the handler creates after validation passes.
+//
+// The validator is intentionally free of gorm / gin / net-http coupling so that
+// unit tests can exercise every branch without spinning a router or a DB.
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// ScopeValidationTarget names one of the five real execution targets that the
+// unified design (section 2.3, section 5.1) recognises. Values are stable
+// string identifiers (not iota-integers) so log lines and error breadcrumbs
+// stay readable when they surface in production.
+type ScopeValidationTarget string
+
+const (
+	// TargetPersonalWorkflow: traditional single-person workflow via
+	// handler.CreateSummary -> worker -> personal_processor.
+	TargetPersonalWorkflow ScopeValidationTarget = "personal_workflow"
+	// TargetTeamWorkflow: traditional multi-person workflow (personal+meta).
+	TargetTeamWorkflow ScopeValidationTarget = "team_workflow"
+	// TargetScheduledWorkflow: creating / updating a summary_schedule row.
+	TargetScheduledWorkflow ScopeValidationTarget = "scheduled_workflow"
+	// TargetAgentGeneration: the agent is about to run a generation turn and
+	// needs the same scope-level gates the traditional path already has.
+	TargetAgentGeneration ScopeValidationTarget = "agent_generation"
+	// TargetAgentSave: user clicked "save as official summary" on an agent
+	// draft — the CreateAgentSummary handler is about to persist rows.
+	TargetAgentSave ScopeValidationTarget = "agent_save"
+)
+
+// SnapshotScopeInput is the union of every field the shared validator needs.
+// It carries the request-time view of what the caller is about to write —
+// intentionally wider than model.SnapshotScope (the storage struct) because
+// validation covers upstream fields the storage snapshot does not persist
+// (topic, participants, sources with types, schedule).
+//
+// The Scope field embeds model.SnapshotScope directly rather than duplicating
+// ChannelIDs / ChannelNames / TimeRange, honouring section 7.2 "reuse
+// SnapshotScope, not new SummaryScope".
+type SnapshotScopeInput struct {
+	// Title is the request-provided task/schedule title.
+	Title string
+	// Topic is the free-text requirement (design section 4.1 / section 5.2
+	// "requirement/topic available").
+	Topic string
+	// Scope is the shared SnapshotScope carrying channel_ids / channel_names /
+	// time_range. TimeRange strings on this struct are informational; the
+	// validator uses TimeStart / TimeEnd below when present so we can enforce
+	// the range-in-days rule with real time.Time values instead of parsing
+	// RFC3339 twice.
+	Scope model.SnapshotScope
+	// TimeStart / TimeEnd override Scope.TimeRange when both are non-zero. If
+	// both are zero the caller has not chosen a range yet and the validator
+	// falls back to "range not required at input time" behaviour (matching
+	// CreateSummary's pre-refactor auto-fill: end=now, start=now-maxDays).
+	TimeStart time.Time
+	TimeEnd   time.Time
+	// Sources carries the caller's source list (source_type + source_id). The
+	// slice may be empty when the caller lets the pipeline auto-narrow.
+	Sources []SourceInput
+	// Participants carries the caller-provided participant user ids (empty ->
+	// creator-only, matching CreateSummary's auto-fill).
+	Participants []ParticipantInput
+	// OriginChannelID / OriginChannelType mirror the createSummaryReq fields
+	// that used to be range-checked inline.
+	OriginChannelID   string
+	OriginChannelType int
+	// Schedule, if non-nil, activates schedule-target checks and also causes
+	// personal/team-target checks to reject invalid schedules pinned onto the
+	// same request (e.g. an Agent-assisted traditional create that carries a
+	// stale schedule payload from the UI). The validator never mutates the
+	// pointee — Schedule field preservation is the caller's responsibility.
+	Schedule *ScheduleInput
+	// AgentSave carries the extra bits CreateAgentSummary needs so
+	// TargetAgentSave can run the "message belongs to this session" gate the
+	// design (section 5.2 agent_save) prescribes.
+	AgentSave *AgentSaveInput
+}
+
+// SourceInput mirrors handler.sourceReq without importing the handler package.
+type SourceInput struct {
+	SourceType int
+	SourceID   string
+}
+
+// ParticipantInput mirrors handler.participantReq without importing it.
+type ParticipantInput struct {
+	UserID   string
+	UserName string
+}
+
+// ScheduleInput carries every schedule field the validator checks. The names
+// mirror model.SummarySchedule / handler.createScheduleReq so callers pass
+// through what they already have.
+type ScheduleInput struct {
+	CronExpr       string
+	IntervalDays   int
+	IntervalMonths int
+	RunTime        string
+	DayOfWeek      int
+	DayOfMonth     int
+	TimeRangeType  int
+}
+
+// AgentSaveInput captures the extra AgentSave-target information: which
+// session / message the caller is about to persist and (optionally) the
+// SnapshotVersion the client last saw. Fields left zero-valued mean "caller
+// wants only the base scope checks".
+type AgentSaveInput struct {
+	SessionID       string
+	AgentMessageID  int64
+	SnapshotVersion int
+	// ContentLen is the length in bytes of the assistant message the caller
+	// intends to save. Empty content is a design-mandated 40004 reject
+	// (section 5.2 agent_save "content valid").
+	ContentLen int
+}
+
+// scopeValidatorLimits centralises the (currently const) upper bounds so the
+// validator does not import the handler package to read them. Kept package-
+// private and set from handler/task.go so a single change site keeps the
+// numbers coherent. The zero-value defaults match the current handler consts:
+//
+//	maxSummaryTopicRunes = 2300
+//	maxSourceCount       = 30
+//
+// pipeline.DefaultTimeRangeDays is a runtime global set from config at boot,
+// so we read it via a getter instead of copying the value.
+type scopeValidatorLimits struct {
+	MaxTopicRunes int
+	MaxSources    int
+	MaxDays       int
+}
+
+// The validator reads limits through this struct so tests can override them
+// without racing on package-globals from unrelated packages.
+var scopeLimits = scopeValidatorLimits{
+	MaxTopicRunes: 2300,
+	MaxSources:    30,
+	MaxDays:       0, // 0 = "use pipeline.DefaultTimeRangeDays via getter"
+}
+
+// timeRangeMaxDaysGetter is populated by handler init() to break the import
+// cycle handler->service->pipeline. The default returns 0 (validator skips
+// the range check), matching pre-refactor behaviour when TimeRange is unset.
+var timeRangeMaxDaysGetter = func() int { return 0 }
+
+// SetTimeRangeMaxDaysGetter lets the handler (or any bootstrapper) wire the
+// pipeline.DefaultTimeRangeDays runtime global into the validator. Must be
+// called before ValidateSnapshotScope; if not called, the range check is a
+// no-op — matching CreateSummary's pre-refactor behaviour when TimeRange is
+// nil (validator only enforces the cap when a range is actually specified).
+func SetTimeRangeMaxDaysGetter(fn func() int) {
+	if fn != nil {
+		timeRangeMaxDaysGetter = fn
+	}
+}
+
+// SetScopeValidatorLimits overrides the topic-rune / source-count caps. Meant
+// for tests that need to poke edge cases without maxing out real limits.
+// Passing a non-positive value for a field keeps the previous value.
+func SetScopeValidatorLimits(maxTopicRunes, maxSources int) {
+	if maxTopicRunes > 0 {
+		scopeLimits.MaxTopicRunes = maxTopicRunes
+	}
+	if maxSources > 0 {
+		scopeLimits.MaxSources = maxSources
+	}
+}
+
+// ValidateSnapshotScope runs the target-agnostic base checks plus the
+// target-specific gates described in unified-smart-summary-design.md
+// section 5.2.
+//
+// It returns *BizError on the first failure so callers can `bizErr(c, err)`
+// without translation. `actor` is the invoking user id — currently unused for
+// authz (the callers still hold DB access to check per-channel permissions),
+// but it is carried through so future authz work can slot in without a
+// signature break. Deliberately kept in the signature per section 5.1 spec:
+//
+//	ValidateSnapshotScope(actor, snapshot, target)
+func ValidateSnapshotScope(actor string, input SnapshotScopeInput, target ScopeValidationTarget) *BizError {
+	// _ = actor: reserved for future per-user authz; see doc comment.
+	_ = actor
+
+	// --- base checks (apply to every target) ---
+	// Order below preserves the exact sequence used by CreateSummary so the
+	// first-error contract is regression-safe.
+
+	if utf8.RuneCountInString(input.Title) > scopeLimits.MaxTopicRunes {
+		return NewBizError(40001, "title 不能超过 2300 字符", http.StatusBadRequest)
+	}
+	if utf8.RuneCountInString(input.Topic) > scopeLimits.MaxTopicRunes {
+		return NewBizError(40001, "topic 不能超过 2300 字符", http.StatusBadRequest)
+	}
+	// origin_channel_id / origin_channel_type must move together and stay
+	// inside the 1..3 application-layer enum (see model.OriginChannelGroup /
+	// Thread / DM in model/model.go).
+	if input.OriginChannelID != "" && (input.OriginChannelType < model.OriginChannelGroup || input.OriginChannelType > model.OriginChannelDM) {
+		return NewBizError(40001, "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set", http.StatusBadRequest)
+	}
+	if input.OriginChannelID == "" && input.OriginChannelType != 0 {
+		return NewBizError(40001, "origin_channel_id is required when origin_channel_type is set", http.StatusBadRequest)
+	}
+
+	// Time-range span cap. Only enforced when the caller supplied both endpoints
+	// (matches CreateSummary's pre-refactor behaviour of only bounding an
+	// explicit req.TimeRange and letting the default range through untouched).
+	if maxDays := effectiveMaxDays(); maxDays > 0 && !input.TimeStart.IsZero() && !input.TimeEnd.IsZero() {
+		if input.TimeEnd.Sub(input.TimeStart) > time.Duration(maxDays)*24*time.Hour {
+			return NewBizError(40002, fmt.Sprintf("时间范围不能超过%d天", maxDays), http.StatusBadRequest)
+		}
+	}
+
+	// Sources count cap.
+	if len(input.Sources) > scopeLimits.MaxSources {
+		return NewBizError(40003, fmt.Sprintf("信息来源不能超过%d个", scopeLimits.MaxSources), http.StatusBadRequest)
+	}
+
+	// --- target-specific gates ---
+	switch target {
+	case TargetPersonalWorkflow:
+		return validatePersonalWorkflow(input)
+	case TargetTeamWorkflow:
+		return validateTeamWorkflow(input)
+	case TargetScheduledWorkflow:
+		return validateScheduledWorkflow(input)
+	case TargetAgentGeneration:
+		return validateAgentGeneration(input)
+	case TargetAgentSave:
+		return validateAgentSave(input)
+	default:
+		// An unknown target is a programmer error, but we prefer a graceful
+		// 400 over a panic so a runtime mistake does not 500 users.
+		return NewBizError(40000, fmt.Sprintf("unknown validation target: %q", target), http.StatusBadRequest)
+	}
+}
+
+// effectiveMaxDays picks the configured MaxDays (test override) or falls
+// back to the pipeline runtime global via the getter.
+func effectiveMaxDays() int {
+	if scopeLimits.MaxDays > 0 {
+		return scopeLimits.MaxDays
+	}
+	return timeRangeMaxDaysGetter()
+}
+
+// validatePersonalWorkflow: CreateSummary's canonical "traditional single-person"
+// path — the caller must provide at least one of sources/topic/time_range so the
+// personal_processor has something to narrow on.
+func validatePersonalWorkflow(input SnapshotScopeInput) *BizError {
+	if hasNoScopeSignal(input) {
+		return NewBizError(40001, "至少提供 sources、topic 或 time_range 之一", http.StatusBadRequest)
+	}
+	return nil
+}
+
+// validateTeamWorkflow: the multi-person traditional path shares personal's
+// scope-signal requirement (still needs channels or topic or a range) and adds
+// a participants-must-be-non-empty rule the design (section 5.2 team_workflow)
+// calls out. The traditional handler still owns the participant-dedup /
+// creator-included transformation; the validator only refuses payloads that
+// are structurally missing a collaboration target.
+func validateTeamWorkflow(input SnapshotScopeInput) *BizError {
+	if hasNoScopeSignal(input) {
+		return NewBizError(40001, "至少提供 sources、topic 或 time_range 之一", http.StatusBadRequest)
+	}
+	if len(input.Participants) == 0 {
+		return NewBizError(40001, "team_workflow 需要至少一个参与者", http.StatusBadRequest)
+	}
+	return nil
+}
+
+// validateScheduledWorkflow: schedule input must be present. Downstream
+// service.ValidateInterval*/ValidateRunTime already own the deep schedule-shape
+// checks; here we only guarantee the Schedule payload was actually delivered
+// (no zero-value Patch — see section 4.1 / section 7.6 "Schedule 不会被 Patch
+// 或新入口写零值").
+func validateScheduledWorkflow(input SnapshotScopeInput) *BizError {
+	if input.Schedule == nil {
+		return NewBizError(40010, "scheduled_workflow requires schedule payload", http.StatusBadRequest)
+	}
+	if input.Schedule.CronExpr == "" && input.Schedule.IntervalDays == 0 && input.Schedule.IntervalMonths == 0 {
+		return NewBizError(40010, "schedule 必须提供 cron_expr / interval_days / interval_months 之一", http.StatusBadRequest)
+	}
+	return nil
+}
+
+// validateAgentGeneration: before the agent runs a generation turn we want the
+// same "there is something to summarise" gate the traditional path has, so
+// authors cannot get around the check by walking through the agent.
+func validateAgentGeneration(input SnapshotScopeInput) *BizError {
+	if hasNoScopeSignal(input) {
+		return NewBizError(40001, "agent_generation 需要 sources、topic 或 time_range 之一", http.StatusBadRequest)
+	}
+	return nil
+}
+
+// validateAgentSave: the design (section 5.2 agent_save) mandates
+// session/message ownership, non-empty content, and Snapshot-version
+// alignment. The handler still owns the DB reads (message ownership +
+// freshness), so this checks the *shape* of what the caller says it is about
+// to save.
+func validateAgentSave(input SnapshotScopeInput) *BizError {
+	if input.AgentSave == nil {
+		return NewBizError(40000, "agent_save 需要 agent_save 信息", http.StatusBadRequest)
+	}
+	if input.AgentSave.SessionID == "" {
+		return NewBizError(40000, "agent_save session_id 不能为空", http.StatusBadRequest)
+	}
+	if input.AgentSave.ContentLen == 0 {
+		// Matches CreateAgentSummary's 40004 for "session 无有效产出".
+		return NewBizError(40004, "session 无有效产出,请先在对话中生成总结再保存", http.StatusBadRequest)
+	}
+	return nil
+}
+
+// hasNoScopeSignal returns true when the input has neither sources nor a topic
+// nor any time range signal. Kept as one place so personal / team / agent
+// generation share the same definition of "empty scope".
+func hasNoScopeSignal(input SnapshotScopeInput) bool {
+	if len(input.Sources) > 0 {
+		return false
+	}
+	if input.Topic != "" {
+		return false
+	}
+	if !input.TimeStart.IsZero() || !input.TimeEnd.IsZero() {
+		return false
+	}
+	// Fall back to the storage-side TimeRange fields for callers that populate
+	// only the model.SnapshotScope (e.g. tests). Non-empty strings on either
+	// side count as a range signal.
+	if input.Scope.TimeRange.Start != "" || input.Scope.TimeRange.End != "" {
+		return false
+	}
+	return true
+}

--- a/internal/service/snapshot_validator.go
+++ b/internal/service/snapshot_validator.go
@@ -181,22 +181,44 @@ func ValidateScheduledWorkflow(
 	return nil
 }
 
+// AgentSaveExpectedSnapshotVersion is the only snapshot_version an Agent draft
+// save is currently allowed to declare. BE-2 lands the first-generation save
+// path; the future Refine pipeline (BE-3+) will lift this cap once it starts
+// producing snapshot_version=2..N, at which point ValidateAgentSave switches
+// from "must equal 1" to "must equal PersonalResult.snapshot_json version".
+// Declaring the constant here (instead of leaving it a magic number in the
+// handler) keeps the invariant reviewable in one place.
+const AgentSaveExpectedSnapshotVersion = 1
+
 // ValidateAgentSave is called by handler.CreateAgentSummary AFTER the
 // server-trusted assistant content has been loaded and preamble-stripped.
-// The handler owns the message ownership / role / session identity DB reads
-// (loadLatestAssistantContent already filters WHERE user_id = ? AND
-// session_id = ? AND role = 'assistant'), so this validator focuses on the
-// shape / length checks and leaves the DB-side identity contract with the
-// handler where it can actually be enforced.
 //
-// The design lists Snapshot-version and message-id enforcement under the
-// agent_save target; those DB-driven checks are BE-2 scope (they require new
-// storage-side reads and version columns that BE-1 does not add), so they
-// are NOT declared as parameters here — leaving them as unused fields on a
-// DTO would be exactly the "shell coverage" SUM-9 rejected.
+// SUM-BE1 (reviewed under SUM-9) intentionally dropped AgentMessageID /
+// SnapshotVersion from this signature because BE-1 could not persist them —
+// carrying them as unused parameters would have been the exact "shell
+// coverage" the review rejected. SUM-BE2 lands the storage side
+// (summary_task.agent_message_id / agent_session_id / snapshot_version, see
+// migration 20260810-01), so the parameters are now real inputs the caller
+// must fill from server-trusted state and this function enforces them.
+//
+// Message ownership / role / session identity is still the handler's DB job
+// (loadAgentMessageForSave filters WHERE id = ? AND user_id = ? AND
+// session_id = ? AND role = 'assistant' AND tool_calls IS NULL). This
+// function checks the SHAPE contract:
+//
+//   - actor / session_id / content: unchanged from BE-1.
+//   - agentMessageID: must be positive when supplied. Zero is allowed only
+//     when expectedSnapshotVersion is also zero, i.e. the caller is still
+//     on the pre-BE-2 "latest assistant" fallback path (FE-2 will supply
+//     both fields; older FE builds supply neither). Mixing the two —
+//     message id without version or vice versa — is a client bug and 400.
+//   - expectedSnapshotVersion: when the client claims a version, it must
+//     equal AgentSaveExpectedSnapshotVersion (BE-2 only writes v1); any
+//     other value is a stale-draft race and maps to AGENT_DRAFT_STALE.
 func ValidateAgentSave(
 	actor, title, sessionID, content string,
 	originChannelID string, originChannelType int,
+	agentMessageID int64, expectedSnapshotVersion int,
 ) *BizError {
 	if err := requireActor(actor); err != nil {
 		return err
@@ -212,6 +234,21 @@ func ValidateAgentSave(
 	}
 	if content == "" {
 		return NewBizError(40004, "session 无有效产出,请先在对话中生成总结再保存", http.StatusBadRequest)
+	}
+	// Message-id / snapshot-version pairing: either both set (new FE-2 path)
+	// or both zero (legacy pre-BE-2 path). Half-supplied is a client bug.
+	if (agentMessageID > 0) != (expectedSnapshotVersion > 0) {
+		return NewBizError(40001, "agent_message_id 与 snapshot_version 必须同时提供或同时省略", http.StatusBadRequest)
+	}
+	if agentMessageID < 0 {
+		return NewBizError(40001, "agent_message_id 必须为正整数", http.StatusBadRequest)
+	}
+	if expectedSnapshotVersion > 0 && expectedSnapshotVersion != AgentSaveExpectedSnapshotVersion {
+		// AGENT_DRAFT_STALE — client is looking at a snapshot the server never
+		// wrote. Once Refine lands v2+, the caller-supplied version must
+		// match the persisted PersonalResult snapshot version and this hard
+		// equality relaxes into a lookup.
+		return NewBizError(40901, "agent_draft_stale: snapshot 版本已过期,请刷新草稿", http.StatusConflict)
 	}
 	return nil
 }

--- a/internal/service/snapshot_validator.go
+++ b/internal/service/snapshot_validator.go
@@ -109,9 +109,9 @@ func scopeHasSignal(scope model.SnapshotScope) bool {
 //     what the validator gates on, NOT a parallel DTO.
 //   - sourceCount:      len(req.Sources) — the count cap is target-specific.
 //   - originChannelID / originChannelType: raw request fields.
-//   - explicitTimeStart / explicitTimeEnd: the caller-supplied range (zero
-//     values ⇒ caller let the server compute a default range and
-//     wants the span cap skipped, matching pre-refactor behaviour).
+//   - explicitTimeRange: whether the caller supplied time_range at all.
+//   - explicitTimeStart / explicitTimeEnd: the caller-supplied endpoints;
+//     when explicitTimeRange is true both must be non-zero.
 //   - maxDays: pipeline.DefaultTimeRangeDays passed explicitly so the
 //     validator has no runtime dependency on a mutable global.
 func ValidatePersonalWorkflow(
@@ -119,6 +119,7 @@ func ValidatePersonalWorkflow(
 	scope model.SnapshotScope,
 	sourceCount int,
 	originChannelID string, originChannelType int,
+	explicitTimeRange bool,
 	explicitTimeStart, explicitTimeEnd time.Time,
 	maxDays int,
 ) *BizError {
@@ -131,7 +132,10 @@ func ValidatePersonalWorkflow(
 	if err := validateOriginChannel(originChannelID, originChannelType); err != nil {
 		return err
 	}
-	if maxDays > 0 && !explicitTimeStart.IsZero() && !explicitTimeEnd.IsZero() {
+	if explicitTimeRange && (explicitTimeStart.IsZero() || explicitTimeEnd.IsZero()) {
+		return NewBizError(40002, "time_range.start 和 time_range.end 必须同时提供", http.StatusBadRequest)
+	}
+	if explicitTimeRange && maxDays > 0 {
 		if explicitTimeEnd.Sub(explicitTimeStart) > time.Duration(maxDays)*24*time.Hour {
 			return NewBizError(40002, fmt.Sprintf("时间范围不能超过%d天", maxDays), http.StatusBadRequest)
 		}
@@ -162,16 +166,12 @@ func ValidatePersonalWorkflow(
 func ValidateScheduledWorkflow(
 	actor, title string,
 	scope model.SnapshotScope,
-	cronExpr string, intervalDays, intervalMonths int,
 ) *BizError {
 	if err := requireActor(actor); err != nil {
 		return err
 	}
 	if err := validateTitleAndTopic(title, ""); err != nil {
 		return err
-	}
-	if cronExpr == "" && intervalDays == 0 && intervalMonths == 0 {
-		return NewBizError(40010, "schedule 必须提供 cron_expr / interval_days / interval_months 之一", http.StatusBadRequest)
 	}
 	// Non-blocking: an entirely empty scope on a schedule is legal in this
 	// repo (Layer 3 auto-narrow picks channels at run time), so we do NOT
@@ -242,6 +242,9 @@ func ValidateAgentSave(
 	}
 	if agentMessageID < 0 {
 		return NewBizError(40001, "agent_message_id 必须为正整数", http.StatusBadRequest)
+	}
+	if expectedSnapshotVersion < 0 {
+		return NewBizError(40001, "snapshot_version 必须为正整数", http.StatusBadRequest)
 	}
 	if expectedSnapshotVersion > 0 && expectedSnapshotVersion != AgentSaveExpectedSnapshotVersion {
 		// AGENT_DRAFT_STALE — client is looking at a snapshot the server never

--- a/internal/service/snapshot_validator.go
+++ b/internal/service/snapshot_validator.go
@@ -152,32 +152,18 @@ func ValidatePersonalWorkflow(
 	return nil
 }
 
-// ValidateScheduledWorkflow is called by handler.CreateSchedule. The deep
-// recurrence / anchor / run-time / day-of-week / day-of-month / time-range-
-// type checks stay in the existing service.ValidateInterval* / ValidateRunTime
-// / ValidateScheduleAnchors / ValidateTimeRangeType helpers — this function
-// runs the shared base cap and the "recurrence must be non-empty" invariant
-// (design section 4.1: Schedule payload must be actually delivered, not
-// zero-filled by an accidental patch).
-//
-// scope carries channel ids (from req.Sources) and time range (from
-// req.TimeRange or the schedule's time_range_type). Handlers build it once
-// and pass it in — same model.SnapshotScope as the other paths.
-func ValidateScheduledWorkflow(
-	actor, title string,
-	scope model.SnapshotScope,
-) *BizError {
+// ValidateScheduledWorkflow is called by handler.CreateSchedule. It enforces
+// the shared actor and title gates. Deep recurrence / anchor / run-time /
+// day-of-week / day-of-month / time-range-type checks remain in the existing
+// ValidateInterval* / ValidateRunTime / ValidateScheduleAnchors /
+// ValidateTimeRangeType helpers called immediately afterwards.
+func ValidateScheduledWorkflow(actor, title string) *BizError {
 	if err := requireActor(actor); err != nil {
 		return err
 	}
 	if err := validateTitleAndTopic(title, ""); err != nil {
 		return err
 	}
-	// Non-blocking: an entirely empty scope on a schedule is legal in this
-	// repo (Layer 3 auto-narrow picks channels at run time), so we do NOT
-	// insist on a channel/time signal here — the design allows it for
-	// scheduled runs whose scope is intentionally template-shaped.
-	_ = scope
 	return nil
 }
 

--- a/internal/service/snapshot_validator_test.go
+++ b/internal/service/snapshot_validator_test.go
@@ -44,7 +44,7 @@ func TestValidateScheduledWorkflow_ActorRequired(t *testing.T) {
 }
 
 func TestValidateAgentSave_ActorRequired(t *testing.T) {
-	err := ValidateAgentSave("", "title", "sess1", "hi", "", 0)
+	err := ValidateAgentSave("", "title", "sess1", "hi", "", 0, 0, 0)
 	if err == nil || err.Code != 40100 {
 		t.Fatalf("expected 40100 for empty actor on agent_save, got %v", err)
 	}
@@ -267,12 +267,12 @@ func TestValidateScheduledWorkflow_TitleCapEnforced(t *testing.T) {
 
 func TestValidateAgentSave_ContentAndSession(t *testing.T) {
 	// empty session id -> 40000
-	err := ValidateAgentSave("u1", "t", "", "content", "", 0)
+	err := ValidateAgentSave("u1", "t", "", "content", "", 0, 0, 0)
 	if err == nil || err.Code != 40000 {
 		t.Fatalf("expected 40000 for empty session id, got %v", err)
 	}
 	// empty content -> 40004
-	err = ValidateAgentSave("u1", "t", "sess1", "", "", 0)
+	err = ValidateAgentSave("u1", "t", "sess1", "", "", 0, 0, 0)
 	if err == nil || err.Code != 40004 {
 		t.Fatalf("expected 40004 for empty content, got %v", err)
 	}
@@ -280,28 +280,90 @@ func TestValidateAgentSave_ContentAndSession(t *testing.T) {
 		t.Errorf("agent_save empty-content msg mismatch: %q", err.Message)
 	}
 	// valid -> nil
-	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0); err != nil {
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 0, 0); err != nil {
 		t.Errorf("expected nil for valid agent_save, got %v", err)
 	}
 }
 
 func TestValidateAgentSave_OriginCoupling(t *testing.T) {
 	// origin_channel_type out of range with id -> 40001
-	err := ValidateAgentSave("u1", "t", "sess1", "hello", "grp1", 99)
+	err := ValidateAgentSave("u1", "t", "sess1", "hello", "grp1", 99, 0, 0)
 	if err == nil || err.Code != 40001 {
 		t.Fatalf("expected 40001, got %v", err)
 	}
 	// type without id -> 40001
-	err = ValidateAgentSave("u1", "t", "sess1", "hello", "", 2)
+	err = ValidateAgentSave("u1", "t", "sess1", "hello", "", 2, 0, 0)
 	if err == nil || err.Code != 40001 {
 		t.Fatalf("expected 40001, got %v", err)
 	}
 	// both zero -> nil
-	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0); err != nil {
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 0, 0); err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}
 	// coupled correctly -> nil
-	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "grp1", 1); err != nil {
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "grp1", 1, 0, 0); err != nil {
 		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+// ---------------------------- agent_save (BE-2 additions) ---------------
+//
+// BE-2 extends the signature with agent_message_id + expected_snapshot_version
+// so the caller can supply the trusted draft reference the design (section
+// 6.5) requires. The tests below cover the four invariants the validator now
+// enforces at the shape level; DB-side ownership / role / session-identity
+// checks stay in the handler (loadAgentMessageForSave) and are exercised by
+// the handler cgo tests.
+
+func TestValidateAgentSave_MessageIDAndSnapshotVersionMustBePaired(t *testing.T) {
+	// message id without version -> 40001
+	err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 42, 0)
+	if err == nil || err.Code != 40001 {
+		t.Fatalf("expected 40001 for msg_id without version, got %v", err)
+	}
+	// version without message id -> 40001
+	err = ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 0, 1)
+	if err == nil || err.Code != 40001 {
+		t.Fatalf("expected 40001 for version without msg_id, got %v", err)
+	}
+	// both zero (legacy) -> nil
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 0, 0); err != nil {
+		t.Errorf("expected nil for both-zero legacy path, got %v", err)
+	}
+	// both set correctly (v1 == AgentSaveExpectedSnapshotVersion) -> nil
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 42, AgentSaveExpectedSnapshotVersion); err != nil {
+		t.Errorf("expected nil for paired msg_id+v1, got %v", err)
+	}
+}
+
+func TestValidateAgentSave_NegativeMessageIDRejected(t *testing.T) {
+	err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, -1, 0)
+	if err == nil || err.Code != 40001 {
+		t.Fatalf("expected 40001 for negative msg_id, got %v", err)
+	}
+}
+
+func TestValidateAgentSave_SnapshotVersionMustBeV1(t *testing.T) {
+	// version 2 while BE-2 only writes v1 -> AGENT_DRAFT_STALE (40901 / 409)
+	err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 42, 2)
+	if err == nil {
+		t.Fatalf("expected error for version=2, got nil")
+	}
+	if err.Code != 40901 {
+		t.Errorf("expected AGENT_DRAFT_STALE code 40901, got %d", err.Code)
+	}
+	if err.HTTPStatus != 409 {
+		t.Errorf("expected HTTP 409 for stale draft, got %d", err.HTTPStatus)
+	}
+	// version 1 -> nil
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 42, AgentSaveExpectedSnapshotVersion); err != nil {
+		t.Errorf("expected nil for v=%d, got %v", AgentSaveExpectedSnapshotVersion, err)
+	}
+}
+
+func TestValidateAgentSave_ActorStillRequiredWithNewParams(t *testing.T) {
+	err := ValidateAgentSave("", "t", "sess1", "hello", "", 0, 42, 1)
+	if err == nil || err.Code != 40100 {
+		t.Fatalf("expected 40100 for empty actor even with paired msg_id, got %v", err)
 	}
 }

--- a/internal/service/snapshot_validator_test.go
+++ b/internal/service/snapshot_validator_test.go
@@ -1,13 +1,12 @@
 package service
 
-// snapshot_validator_test.go — SUM-BE1 shared validator regression tests.
-//
-// These tests intentionally do NOT touch gorm / gin / any DB. They exercise
-// service.ValidateSnapshotScope directly so every target-specific gate and
-// every base check has a first-class assertion that survives future
-// refactors. CGO-backed SQLite integration tests (see
-// internal/api/handler/task_limit_test.go) continue to cover the end-to-end
-// HTTP shape.
+// snapshot_validator_test.go — SUM-BE1 shared validator tests (revised per
+// SUM-9). These tests exercise each of the three exported entry points
+// (ValidatePersonalWorkflow / ValidateScheduledWorkflow / ValidateAgentSave)
+// directly, with no gorm / gin / DB coupling. handler-level regression tests
+// that exercise Schedule field preservation across create + patch live in
+// internal/api/handler/schedule_scope_preservation_test.go (CGO-gated,
+// matching every other handler test in this repo).
 
 import (
 	"strings"
@@ -17,98 +16,126 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 )
 
-// resetValidatorGlobals restores the package-level tunables the tests touch.
-// t.Cleanup keeps the test's state changes local so no ordering coupling
-// leaks between tests.
-func resetValidatorGlobals(t *testing.T) {
-	t.Helper()
-	prevLimits := scopeLimits
-	prevGetter := timeRangeMaxDaysGetter
-	t.Cleanup(func() {
-		scopeLimits = prevLimits
-		timeRangeMaxDaysGetter = prevGetter
-	})
-}
+// ------------------------------ actor gate ------------------------------
 
-// TestValidateSnapshotScope_UnknownTarget verifies that a caller passing a
-// misspelled target gets a graceful 40000 rather than a panic. This is the
-// only branch that returns 40000 for a non-shape reason so it is worth an
-// explicit assertion.
-func TestValidateSnapshotScope_UnknownTarget(t *testing.T) {
-	resetValidatorGlobals(t)
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{Topic: "x"}, ScopeValidationTarget("nope"))
-	if err == nil {
-		t.Fatalf("expected error for unknown target, got nil")
-	}
-	if err.Code != 40000 {
-		t.Errorf("unknown target: expected 40000, got %d (%s)", err.Code, err.Message)
+func TestValidatePersonalWorkflow_ActorRequired(t *testing.T) {
+	err := ValidatePersonalWorkflow(
+		"", "title", "topic",
+		model.SnapshotScope{ChannelIDs: []string{"grp1"}},
+		1,
+		"", 0,
+		time.Time{}, time.Time{},
+		31,
+	)
+	if err == nil || err.Code != 40100 || err.HTTPStatus != 401 {
+		t.Fatalf("expected 40100/401 for empty actor, got %v", err)
 	}
 }
 
-// TestValidateSnapshotScope_BaseChecks_ApplyToEveryTarget covers the base
-// gates (title/topic rune caps, origin-channel coupling, source count) with
-// one representative target each so the base branches never regress.
-func TestValidateSnapshotScope_BaseChecks_ApplyToEveryTarget(t *testing.T) {
-	resetValidatorGlobals(t)
+func TestValidateScheduledWorkflow_ActorRequired(t *testing.T) {
+	err := ValidateScheduledWorkflow(
+		"", "daily",
+		model.SnapshotScope{},
+		"", 1, 0,
+	)
+	if err == nil || err.Code != 40100 {
+		t.Fatalf("expected 40100 for empty actor on schedule, got %v", err)
+	}
+}
 
-	tooLong := strings.Repeat("总", 2301)
+func TestValidateAgentSave_ActorRequired(t *testing.T) {
+	err := ValidateAgentSave("", "title", "sess1", "hi", "", 0)
+	if err == nil || err.Code != 40100 {
+		t.Fatalf("expected 40100 for empty actor on agent_save, got %v", err)
+	}
+}
+
+// ------------------------------ base checks -----------------------------
+
+func TestValidatePersonalWorkflow_BaseChecks(t *testing.T) {
+	tooLong := strings.Repeat("总", MaxSummaryTitleRunes+1)
 
 	tests := []struct {
 		name     string
-		input    SnapshotScopeInput
-		target   ScopeValidationTarget
+		title    string
+		topic    string
+		scope    model.SnapshotScope
+		srcCount int
+		origID   string
+		origType int
+		start    time.Time
+		end      time.Time
+		maxDays  int
 		wantCode int
 		wantMsg  string
 	}{
 		{
-			name:     "title over 2300 runes rejected",
-			input:    SnapshotScopeInput{Title: tooLong, Topic: "x"},
-			target:   TargetPersonalWorkflow,
-			wantCode: 40001,
-			wantMsg:  "title 不能超过 2300 字符",
+			name:  "title over 2300 runes rejected",
+			title: tooLong, topic: "x",
+			scope:    model.SnapshotScope{},
+			maxDays:  31,
+			wantCode: 40001, wantMsg: "title 不能超过 2300 字符",
 		},
 		{
-			name:     "topic over 2300 runes rejected",
-			input:    SnapshotScopeInput{Topic: tooLong},
-			target:   TargetPersonalWorkflow,
-			wantCode: 40001,
-			wantMsg:  "topic 不能超过 2300 字符",
+			name:  "topic over 2300 runes rejected",
+			title: "t", topic: tooLong,
+			scope:    model.SnapshotScope{},
+			maxDays:  31,
+			wantCode: 40001, wantMsg: "topic 不能超过 2300 字符",
 		},
 		{
-			name: "origin_channel_id set but type out of range",
-			input: SnapshotScopeInput{
-				Topic:             "x",
-				OriginChannelID:   "grp1",
-				OriginChannelType: 99,
-			},
-			target:   TargetPersonalWorkflow,
-			wantCode: 40001,
-			wantMsg:  "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set",
+			name:  "origin_channel_id set but type out of range",
+			title: "t", topic: "x",
+			scope:  model.SnapshotScope{},
+			origID: "grp1", origType: 99,
+			maxDays:  31,
+			wantCode: 40001, wantMsg: "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set",
 		},
 		{
-			name: "origin_channel_type set but no id",
-			input: SnapshotScopeInput{
-				Topic:             "x",
-				OriginChannelType: 1,
-			},
-			target:   TargetPersonalWorkflow,
-			wantCode: 40001,
-			wantMsg:  "origin_channel_id is required when origin_channel_type is set",
+			name:  "origin_channel_type set but no id",
+			title: "t", topic: "x",
+			scope:    model.SnapshotScope{},
+			origType: 1,
+			maxDays:  31,
+			wantCode: 40001, wantMsg: "origin_channel_id is required when origin_channel_type is set",
 		},
 		{
-			name: "sources over max count",
-			input: SnapshotScopeInput{
-				Sources: manyValidSources(31),
-			},
-			target:   TargetPersonalWorkflow,
-			wantCode: 40003,
-			wantMsg:  "信息来源不能超过30个",
+			name:  "sources over max count",
+			title: "t", topic: "x",
+			scope:    model.SnapshotScope{},
+			srcCount: MaxSummarySourceCount + 1,
+			maxDays:  31,
+			wantCode: 40003, wantMsg: "信息来源不能超过30个",
+		},
+		{
+			name:  "time range over cap",
+			title: "t", topic: "x",
+			scope:    model.SnapshotScope{ChannelIDs: []string{"g1"}},
+			start:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), // ~59 days > 31
+			maxDays:  31,
+			wantCode: 40002, wantMsg: "时间范围不能超过31天",
+		},
+		{
+			name:  "scope has no signal, no topic, no time range",
+			title: "t", topic: "",
+			scope:    model.SnapshotScope{},
+			maxDays:  31,
+			wantCode: 40001, wantMsg: "至少提供 sources、topic 或 time_range 之一",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ValidateSnapshotScope("user1", tc.input, tc.target)
+			got := ValidatePersonalWorkflow(
+				"u1",
+				tc.title, tc.topic,
+				tc.scope,
+				tc.srcCount,
+				tc.origID, tc.origType,
+				tc.start, tc.end,
+				tc.maxDays,
+			)
 			if got == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -122,250 +149,159 @@ func TestValidateSnapshotScope_BaseChecks_ApplyToEveryTarget(t *testing.T) {
 	}
 }
 
-// TestValidateSnapshotScope_TimeRangeSpanCap covers the 40002 "时间范围不能超过N天"
-// path — the caller supplies an explicit range that exceeds the pipeline
-// runtime cap. When the caller omits TimeStart/TimeEnd the check is a no-op,
-// matching the pre-refactor behaviour where a nil TimeRange never tripped
-// the span check.
-func TestValidateSnapshotScope_TimeRangeSpanCap(t *testing.T) {
-	resetValidatorGlobals(t)
-
-	// Simulate pipeline.DefaultTimeRangeDays = 31.
-	SetTimeRangeMaxDaysGetter(func() int { return 31 })
-
-	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	longEnd := start.Add(40 * 24 * time.Hour) // 40 days > 31
-	shortEnd := start.Add(10 * 24 * time.Hour)
-
-	// Range too long: rejected 40002.
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Topic:     "x",
-		TimeStart: start,
-		TimeEnd:   longEnd,
-	}, TargetPersonalWorkflow)
-	if err == nil {
-		t.Fatalf("expected 40002 for 40-day range against 31-day cap, got nil")
+// TestValidatePersonalWorkflow_SignalSources verifies the three shapes that
+// satisfy the scope-signal gate: channel_ids in the shared scope, topic
+// string, or an explicit time range on the scope.
+func TestValidatePersonalWorkflow_SignalSources(t *testing.T) {
+	cases := []struct {
+		name  string
+		topic string
+		scope model.SnapshotScope
+		start time.Time
+		end   time.Time
+	}{
+		{
+			name:  "channel_ids in scope alone",
+			scope: model.SnapshotScope{ChannelIDs: []string{"g1"}},
+		},
+		{
+			name:  "topic alone",
+			topic: "hello",
+			scope: model.SnapshotScope{},
+		},
+		{
+			name: "time range in scope alone",
+			scope: model.SnapshotScope{
+				TimeRange: model.TimeRangeJSON{Start: "2026-01-01T00:00:00Z", End: "2026-01-02T00:00:00Z"},
+			},
+		},
+		{
+			name:  "explicit time endpoints alone (no scope signal, no topic)",
+			scope: model.SnapshotScope{},
+			start: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		},
 	}
-	if err.Code != 40002 {
-		t.Errorf("code: want 40002 got %d (%s)", err.Code, err.Message)
-	}
-	if !strings.Contains(err.Message, "时间范围不能超过31天") {
-		t.Errorf("msg: want to contain \"时间范围不能超过31天\", got %q", err.Message)
-	}
-
-	// Range within cap: accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Topic:     "x",
-		TimeStart: start,
-		TimeEnd:   shortEnd,
-	}, TargetPersonalWorkflow); err != nil {
-		t.Errorf("expected no error for 10-day range, got %v", err)
-	}
-
-	// No range supplied: check is a no-op (topic alone satisfies scope signal).
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Topic: "x",
-	}, TargetPersonalWorkflow); err != nil {
-		t.Errorf("expected no error when time range is absent, got %v", err)
-	}
-}
-
-// TestValidateSnapshotScope_PersonalWorkflow_ScopeSignal preserves the
-// pre-refactor "至少提供 sources、topic 或 time_range 之一" contract.
-func TestValidateSnapshotScope_PersonalWorkflow_ScopeSignal(t *testing.T) {
-	resetValidatorGlobals(t)
-
-	// Empty scope signal: rejected 40001.
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Title: "t",
-	}, TargetPersonalWorkflow)
-	if err == nil {
-		t.Fatalf("expected 40001 for empty scope signal, got nil")
-	}
-	if err.Code != 40001 {
-		t.Errorf("code: want 40001 got %d (%s)", err.Code, err.Message)
-	}
-	if err.Message != "至少提供 sources、topic 或 time_range 之一" {
-		t.Errorf("msg: unexpected %q", err.Message)
-	}
-
-	// Topic alone: accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{Topic: "x"}, TargetPersonalWorkflow); err != nil {
-		t.Errorf("topic alone should pass, got %v", err)
-	}
-	// Sources alone: accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Sources: []SourceInput{{SourceType: 1, SourceID: "grp1"}},
-	}, TargetPersonalWorkflow); err != nil {
-		t.Errorf("sources alone should pass, got %v", err)
-	}
-	// TimeStart alone (as a time signal): accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		TimeStart: time.Now().Add(-time.Hour),
-	}, TargetPersonalWorkflow); err != nil {
-		t.Errorf("time signal alone should pass, got %v", err)
-	}
-	// TimeRange strings alone (test-only path): accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Scope: model.SnapshotScope{TimeRange: model.TimeRangeJSON{Start: "2026-01-01T00:00:00Z"}},
-	}, TargetPersonalWorkflow); err != nil {
-		t.Errorf("time-range Scope signal alone should pass, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The "explicit time endpoints alone" case relies on scope-signal
+			// being satisfied by the caller providing a time range on the
+			// shared scope. Populate the scope's TimeRange to reflect what
+			// handler.CreateSummary does today.
+			scope := tc.scope
+			if !tc.start.IsZero() {
+				scope.TimeRange = model.TimeRangeJSON{
+					Start: tc.start.Format(time.RFC3339),
+					End:   tc.end.Format(time.RFC3339),
+				}
+			}
+			err := ValidatePersonalWorkflow(
+				"u1", "title", tc.topic,
+				scope, 0, "", 0,
+				tc.start, tc.end,
+				31,
+			)
+			if err != nil {
+				t.Errorf("expected nil, got %v", err)
+			}
+		})
 	}
 }
 
-// TestValidateSnapshotScope_TeamWorkflow_ParticipantsRequired exercises the
-// team-target-only rule that a payload without participants is not a
-// legitimate team workflow.
-func TestValidateSnapshotScope_TeamWorkflow_ParticipantsRequired(t *testing.T) {
-	resetValidatorGlobals(t)
-
-	// Scope signal present, but no participants: team-target rejects.
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Topic:        "team weekly",
-		Participants: nil,
-	}, TargetTeamWorkflow)
-	if err == nil {
-		t.Fatalf("expected team-target rejection for zero participants, got nil")
-	}
-	if err.Code != 40001 || err.Message != "team_workflow 需要至少一个参与者" {
-		t.Errorf("unexpected error: code=%d msg=%q", err.Code, err.Message)
-	}
-
-	// With one participant: accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Topic:        "team weekly",
-		Participants: []ParticipantInput{{UserID: "u1"}},
-	}, TargetTeamWorkflow); err != nil {
-		t.Errorf("team-target with 1 participant should pass, got %v", err)
+// TestValidatePersonalWorkflow_NoTimeRangeSpanCapWhenAbsent guarantees the
+// pre-refactor behaviour: when the caller does NOT provide an explicit
+// range (both endpoints zero), the validator does not enforce the cap.
+// This is why CreateSummary's default range (end=now, start=now-maxDays)
+// still passes for topic-only payloads.
+func TestValidatePersonalWorkflow_NoTimeRangeSpanCapWhenAbsent(t *testing.T) {
+	err := ValidatePersonalWorkflow(
+		"u1", "t", "topic",
+		model.SnapshotScope{},
+		0, "", 0,
+		time.Time{}, time.Time{},
+		31,
+	)
+	if err != nil {
+		t.Errorf("expected nil when no explicit range and topic supplied, got %v", err)
 	}
 }
 
-// TestValidateSnapshotScope_ScheduledWorkflow_SchedulePayloadRequired covers
-// section 4.1 / 7.6: schedule fields must be present when the caller declares
-// a scheduled_workflow target. A nil Schedule pointer signals a caller that
-// forgot to plumb schedule through — a common regression risk in the design
-// (patching zero-value Schedule fields).
-func TestValidateSnapshotScope_ScheduledWorkflow_SchedulePayloadRequired(t *testing.T) {
-	resetValidatorGlobals(t)
+// ------------------------- scheduled_workflow ---------------------------
 
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Title:    "daily",
-		Schedule: nil,
-	}, TargetScheduledWorkflow)
-	if err == nil {
-		t.Fatalf("expected 40010 when Schedule is nil, got nil")
-	}
-	if err.Code != 40010 {
-		t.Errorf("code: want 40010 got %d (%s)", err.Code, err.Message)
-	}
-
-	// Present but empty recurrence -> still rejected.
-	err = ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Title:    "daily",
-		Schedule: &ScheduleInput{},
-	}, TargetScheduledWorkflow)
+func TestValidateScheduledWorkflow_RecurrenceRequired(t *testing.T) {
+	err := ValidateScheduledWorkflow(
+		"u1", "daily",
+		model.SnapshotScope{},
+		"", 0, 0,
+	)
 	if err == nil || err.Code != 40010 {
-		t.Errorf("expected 40010 for empty recurrence, got %v", err)
+		t.Fatalf("expected 40010 for empty recurrence, got %v", err)
 	}
 
-	// Full Schedule payload with interval_days: accepted.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Title:    "daily",
-		Schedule: &ScheduleInput{IntervalDays: 1, RunTime: "09:00", TimeRangeType: 2},
-	}, TargetScheduledWorkflow); err != nil {
-		t.Errorf("full schedule should pass, got %v", err)
+	// interval_days > 0 passes.
+	if err := ValidateScheduledWorkflow("u1", "daily", model.SnapshotScope{}, "", 1, 0); err != nil {
+		t.Errorf("interval_days=1 should pass, got %v", err)
 	}
-}
-
-// TestValidateSnapshotScope_ScheduledWorkflow_PreservesEveryScheduleField
-// asserts that every field the validator was given on the Schedule pointer
-// makes it through untouched. Section 7.6 mandates the input Schedule must
-// not be mutated on either the success or failure path — a validator that
-// silently zeroed a field would be the exact regression this test guards.
-func TestValidateSnapshotScope_ScheduledWorkflow_PreservesEveryScheduleField(t *testing.T) {
-	resetValidatorGlobals(t)
-
-	// Deliberately non-zero on every field so a zeroing bug pops immediately.
-	full := ScheduleInput{
-		CronExpr:       "0 9 * * *",
-		IntervalDays:   7,
-		IntervalMonths: 0,
-		RunTime:        "09:30",
-		DayOfWeek:      3,
-		DayOfMonth:     15,
-		TimeRangeType:  2,
+	// cron_expr passes.
+	if err := ValidateScheduledWorkflow("u1", "daily", model.SnapshotScope{}, "0 9 * * *", 0, 0); err != nil {
+		t.Errorf("cron_expr should pass, got %v", err)
 	}
-	before := full // struct copy for post-call comparison
-
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		Title:    "weekly",
-		Schedule: &full,
-	}, TargetScheduledWorkflow); err != nil {
-		t.Fatalf("full schedule should pass, got %v", err)
-	}
-
-	if full != before {
-		t.Errorf("validator mutated schedule payload\n  before: %+v\n   after: %+v", before, full)
+	// interval_months passes.
+	if err := ValidateScheduledWorkflow("u1", "monthly", model.SnapshotScope{}, "", 0, 1); err != nil {
+		t.Errorf("interval_months=1 should pass, got %v", err)
 	}
 }
 
-// TestValidateSnapshotScope_AgentGeneration_ScopeSignal — the agent-generation
-// target reuses the "at least one signal" rule so authors cannot walk around
-// the traditional path's gate by going through the agent.
-func TestValidateSnapshotScope_AgentGeneration_ScopeSignal(t *testing.T) {
-	resetValidatorGlobals(t)
-
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{Title: "t"}, TargetAgentGeneration)
-	if err == nil || err.Code != 40001 {
-		t.Errorf("expected 40001 for empty scope signal on agent_generation, got %v", err)
-	}
-
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{Topic: "x"}, TargetAgentGeneration); err != nil {
-		t.Errorf("topic alone should pass agent_generation, got %v", err)
+func TestValidateScheduledWorkflow_TitleCapEnforced(t *testing.T) {
+	err := ValidateScheduledWorkflow(
+		"u1", strings.Repeat("总", MaxSummaryTitleRunes+1),
+		model.SnapshotScope{},
+		"", 1, 0,
+	)
+	if err == nil || err.Code != 40001 || err.Message != "title 不能超过 2300 字符" {
+		t.Fatalf("expected 40001 title over cap, got %v", err)
 	}
 }
 
-// TestValidateSnapshotScope_AgentSave_ShapeChecks covers session_id / content
-// rules for the agent-save target.
-func TestValidateSnapshotScope_AgentSave_ShapeChecks(t *testing.T) {
-	resetValidatorGlobals(t)
+// ---------------------------- agent_save --------------------------------
 
-	// Missing AgentSave payload: 40000.
-	err := ValidateSnapshotScope("user1", SnapshotScopeInput{}, TargetAgentSave)
+func TestValidateAgentSave_ContentAndSession(t *testing.T) {
+	// empty session id -> 40000
+	err := ValidateAgentSave("u1", "t", "", "content", "", 0)
 	if err == nil || err.Code != 40000 {
-		t.Errorf("expected 40000 for missing AgentSave, got %v", err)
+		t.Fatalf("expected 40000 for empty session id, got %v", err)
 	}
-
-	// Empty session id: 40000.
-	err = ValidateSnapshotScope("user1", SnapshotScopeInput{
-		AgentSave: &AgentSaveInput{},
-	}, TargetAgentSave)
-	if err == nil || err.Code != 40000 {
-		t.Errorf("expected 40000 for empty session id, got %v", err)
-	}
-
-	// Empty content: 40004.
-	err = ValidateSnapshotScope("user1", SnapshotScopeInput{
-		AgentSave: &AgentSaveInput{SessionID: "s1", ContentLen: 0},
-	}, TargetAgentSave)
+	// empty content -> 40004
+	err = ValidateAgentSave("u1", "t", "sess1", "", "", 0)
 	if err == nil || err.Code != 40004 {
-		t.Errorf("expected 40004 for empty content, got %v", err)
+		t.Fatalf("expected 40004 for empty content, got %v", err)
 	}
-
-	// All good.
-	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
-		AgentSave: &AgentSaveInput{SessionID: "s1", ContentLen: 128},
-	}, TargetAgentSave); err != nil {
-		t.Errorf("full agent_save payload should pass, got %v", err)
+	if err.Message != "session 无有效产出,请先在对话中生成总结再保存" {
+		t.Errorf("agent_save empty-content msg mismatch: %q", err.Message)
+	}
+	// valid -> nil
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0); err != nil {
+		t.Errorf("expected nil for valid agent_save, got %v", err)
 	}
 }
 
-// manyValidSources returns n structurally-valid SourceInput records — used to
-// exercise the source-count cap without stubbing the whole handler stack.
-func manyValidSources(n int) []SourceInput {
-	out := make([]SourceInput, n)
-	for i := range out {
-		out[i] = SourceInput{SourceType: 1, SourceID: "grp"}
+func TestValidateAgentSave_OriginCoupling(t *testing.T) {
+	// origin_channel_type out of range with id -> 40001
+	err := ValidateAgentSave("u1", "t", "sess1", "hello", "grp1", 99)
+	if err == nil || err.Code != 40001 {
+		t.Fatalf("expected 40001, got %v", err)
 	}
-	return out
+	// type without id -> 40001
+	err = ValidateAgentSave("u1", "t", "sess1", "hello", "", 2)
+	if err == nil || err.Code != 40001 {
+		t.Fatalf("expected 40001, got %v", err)
+	}
+	// both zero -> nil
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	// coupled correctly -> nil
+	if err := ValidateAgentSave("u1", "t", "sess1", "hello", "grp1", 1); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
 }

--- a/internal/service/snapshot_validator_test.go
+++ b/internal/service/snapshot_validator_test.go
@@ -1,0 +1,371 @@
+package service
+
+// snapshot_validator_test.go — SUM-BE1 shared validator regression tests.
+//
+// These tests intentionally do NOT touch gorm / gin / any DB. They exercise
+// service.ValidateSnapshotScope directly so every target-specific gate and
+// every base check has a first-class assertion that survives future
+// refactors. CGO-backed SQLite integration tests (see
+// internal/api/handler/task_limit_test.go) continue to cover the end-to-end
+// HTTP shape.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// resetValidatorGlobals restores the package-level tunables the tests touch.
+// t.Cleanup keeps the test's state changes local so no ordering coupling
+// leaks between tests.
+func resetValidatorGlobals(t *testing.T) {
+	t.Helper()
+	prevLimits := scopeLimits
+	prevGetter := timeRangeMaxDaysGetter
+	t.Cleanup(func() {
+		scopeLimits = prevLimits
+		timeRangeMaxDaysGetter = prevGetter
+	})
+}
+
+// TestValidateSnapshotScope_UnknownTarget verifies that a caller passing a
+// misspelled target gets a graceful 40000 rather than a panic. This is the
+// only branch that returns 40000 for a non-shape reason so it is worth an
+// explicit assertion.
+func TestValidateSnapshotScope_UnknownTarget(t *testing.T) {
+	resetValidatorGlobals(t)
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{Topic: "x"}, ScopeValidationTarget("nope"))
+	if err == nil {
+		t.Fatalf("expected error for unknown target, got nil")
+	}
+	if err.Code != 40000 {
+		t.Errorf("unknown target: expected 40000, got %d (%s)", err.Code, err.Message)
+	}
+}
+
+// TestValidateSnapshotScope_BaseChecks_ApplyToEveryTarget covers the base
+// gates (title/topic rune caps, origin-channel coupling, source count) with
+// one representative target each so the base branches never regress.
+func TestValidateSnapshotScope_BaseChecks_ApplyToEveryTarget(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	tooLong := strings.Repeat("总", 2301)
+
+	tests := []struct {
+		name     string
+		input    SnapshotScopeInput
+		target   ScopeValidationTarget
+		wantCode int
+		wantMsg  string
+	}{
+		{
+			name:     "title over 2300 runes rejected",
+			input:    SnapshotScopeInput{Title: tooLong, Topic: "x"},
+			target:   TargetPersonalWorkflow,
+			wantCode: 40001,
+			wantMsg:  "title 不能超过 2300 字符",
+		},
+		{
+			name:     "topic over 2300 runes rejected",
+			input:    SnapshotScopeInput{Topic: tooLong},
+			target:   TargetPersonalWorkflow,
+			wantCode: 40001,
+			wantMsg:  "topic 不能超过 2300 字符",
+		},
+		{
+			name: "origin_channel_id set but type out of range",
+			input: SnapshotScopeInput{
+				Topic:             "x",
+				OriginChannelID:   "grp1",
+				OriginChannelType: 99,
+			},
+			target:   TargetPersonalWorkflow,
+			wantCode: 40001,
+			wantMsg:  "origin_channel_type must be 1, 2, or 3 when origin_channel_id is set",
+		},
+		{
+			name: "origin_channel_type set but no id",
+			input: SnapshotScopeInput{
+				Topic:             "x",
+				OriginChannelType: 1,
+			},
+			target:   TargetPersonalWorkflow,
+			wantCode: 40001,
+			wantMsg:  "origin_channel_id is required when origin_channel_type is set",
+		},
+		{
+			name: "sources over max count",
+			input: SnapshotScopeInput{
+				Sources: manyValidSources(31),
+			},
+			target:   TargetPersonalWorkflow,
+			wantCode: 40003,
+			wantMsg:  "信息来源不能超过30个",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidateSnapshotScope("user1", tc.input, tc.target)
+			if got == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if got.Code != tc.wantCode {
+				t.Errorf("code: want %d got %d (%s)", tc.wantCode, got.Code, got.Message)
+			}
+			if got.Message != tc.wantMsg {
+				t.Errorf("msg:\n  want %q\n   got %q", tc.wantMsg, got.Message)
+			}
+		})
+	}
+}
+
+// TestValidateSnapshotScope_TimeRangeSpanCap covers the 40002 "时间范围不能超过N天"
+// path — the caller supplies an explicit range that exceeds the pipeline
+// runtime cap. When the caller omits TimeStart/TimeEnd the check is a no-op,
+// matching the pre-refactor behaviour where a nil TimeRange never tripped
+// the span check.
+func TestValidateSnapshotScope_TimeRangeSpanCap(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	// Simulate pipeline.DefaultTimeRangeDays = 31.
+	SetTimeRangeMaxDaysGetter(func() int { return 31 })
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	longEnd := start.Add(40 * 24 * time.Hour) // 40 days > 31
+	shortEnd := start.Add(10 * 24 * time.Hour)
+
+	// Range too long: rejected 40002.
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Topic:     "x",
+		TimeStart: start,
+		TimeEnd:   longEnd,
+	}, TargetPersonalWorkflow)
+	if err == nil {
+		t.Fatalf("expected 40002 for 40-day range against 31-day cap, got nil")
+	}
+	if err.Code != 40002 {
+		t.Errorf("code: want 40002 got %d (%s)", err.Code, err.Message)
+	}
+	if !strings.Contains(err.Message, "时间范围不能超过31天") {
+		t.Errorf("msg: want to contain \"时间范围不能超过31天\", got %q", err.Message)
+	}
+
+	// Range within cap: accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Topic:     "x",
+		TimeStart: start,
+		TimeEnd:   shortEnd,
+	}, TargetPersonalWorkflow); err != nil {
+		t.Errorf("expected no error for 10-day range, got %v", err)
+	}
+
+	// No range supplied: check is a no-op (topic alone satisfies scope signal).
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Topic: "x",
+	}, TargetPersonalWorkflow); err != nil {
+		t.Errorf("expected no error when time range is absent, got %v", err)
+	}
+}
+
+// TestValidateSnapshotScope_PersonalWorkflow_ScopeSignal preserves the
+// pre-refactor "至少提供 sources、topic 或 time_range 之一" contract.
+func TestValidateSnapshotScope_PersonalWorkflow_ScopeSignal(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	// Empty scope signal: rejected 40001.
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Title: "t",
+	}, TargetPersonalWorkflow)
+	if err == nil {
+		t.Fatalf("expected 40001 for empty scope signal, got nil")
+	}
+	if err.Code != 40001 {
+		t.Errorf("code: want 40001 got %d (%s)", err.Code, err.Message)
+	}
+	if err.Message != "至少提供 sources、topic 或 time_range 之一" {
+		t.Errorf("msg: unexpected %q", err.Message)
+	}
+
+	// Topic alone: accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{Topic: "x"}, TargetPersonalWorkflow); err != nil {
+		t.Errorf("topic alone should pass, got %v", err)
+	}
+	// Sources alone: accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Sources: []SourceInput{{SourceType: 1, SourceID: "grp1"}},
+	}, TargetPersonalWorkflow); err != nil {
+		t.Errorf("sources alone should pass, got %v", err)
+	}
+	// TimeStart alone (as a time signal): accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		TimeStart: time.Now().Add(-time.Hour),
+	}, TargetPersonalWorkflow); err != nil {
+		t.Errorf("time signal alone should pass, got %v", err)
+	}
+	// TimeRange strings alone (test-only path): accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Scope: model.SnapshotScope{TimeRange: model.TimeRangeJSON{Start: "2026-01-01T00:00:00Z"}},
+	}, TargetPersonalWorkflow); err != nil {
+		t.Errorf("time-range Scope signal alone should pass, got %v", err)
+	}
+}
+
+// TestValidateSnapshotScope_TeamWorkflow_ParticipantsRequired exercises the
+// team-target-only rule that a payload without participants is not a
+// legitimate team workflow.
+func TestValidateSnapshotScope_TeamWorkflow_ParticipantsRequired(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	// Scope signal present, but no participants: team-target rejects.
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Topic:        "team weekly",
+		Participants: nil,
+	}, TargetTeamWorkflow)
+	if err == nil {
+		t.Fatalf("expected team-target rejection for zero participants, got nil")
+	}
+	if err.Code != 40001 || err.Message != "team_workflow 需要至少一个参与者" {
+		t.Errorf("unexpected error: code=%d msg=%q", err.Code, err.Message)
+	}
+
+	// With one participant: accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Topic:        "team weekly",
+		Participants: []ParticipantInput{{UserID: "u1"}},
+	}, TargetTeamWorkflow); err != nil {
+		t.Errorf("team-target with 1 participant should pass, got %v", err)
+	}
+}
+
+// TestValidateSnapshotScope_ScheduledWorkflow_SchedulePayloadRequired covers
+// section 4.1 / 7.6: schedule fields must be present when the caller declares
+// a scheduled_workflow target. A nil Schedule pointer signals a caller that
+// forgot to plumb schedule through — a common regression risk in the design
+// (patching zero-value Schedule fields).
+func TestValidateSnapshotScope_ScheduledWorkflow_SchedulePayloadRequired(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Title:    "daily",
+		Schedule: nil,
+	}, TargetScheduledWorkflow)
+	if err == nil {
+		t.Fatalf("expected 40010 when Schedule is nil, got nil")
+	}
+	if err.Code != 40010 {
+		t.Errorf("code: want 40010 got %d (%s)", err.Code, err.Message)
+	}
+
+	// Present but empty recurrence -> still rejected.
+	err = ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Title:    "daily",
+		Schedule: &ScheduleInput{},
+	}, TargetScheduledWorkflow)
+	if err == nil || err.Code != 40010 {
+		t.Errorf("expected 40010 for empty recurrence, got %v", err)
+	}
+
+	// Full Schedule payload with interval_days: accepted.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Title:    "daily",
+		Schedule: &ScheduleInput{IntervalDays: 1, RunTime: "09:00", TimeRangeType: 2},
+	}, TargetScheduledWorkflow); err != nil {
+		t.Errorf("full schedule should pass, got %v", err)
+	}
+}
+
+// TestValidateSnapshotScope_ScheduledWorkflow_PreservesEveryScheduleField
+// asserts that every field the validator was given on the Schedule pointer
+// makes it through untouched. Section 7.6 mandates the input Schedule must
+// not be mutated on either the success or failure path — a validator that
+// silently zeroed a field would be the exact regression this test guards.
+func TestValidateSnapshotScope_ScheduledWorkflow_PreservesEveryScheduleField(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	// Deliberately non-zero on every field so a zeroing bug pops immediately.
+	full := ScheduleInput{
+		CronExpr:       "0 9 * * *",
+		IntervalDays:   7,
+		IntervalMonths: 0,
+		RunTime:        "09:30",
+		DayOfWeek:      3,
+		DayOfMonth:     15,
+		TimeRangeType:  2,
+	}
+	before := full // struct copy for post-call comparison
+
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		Title:    "weekly",
+		Schedule: &full,
+	}, TargetScheduledWorkflow); err != nil {
+		t.Fatalf("full schedule should pass, got %v", err)
+	}
+
+	if full != before {
+		t.Errorf("validator mutated schedule payload\n  before: %+v\n   after: %+v", before, full)
+	}
+}
+
+// TestValidateSnapshotScope_AgentGeneration_ScopeSignal — the agent-generation
+// target reuses the "at least one signal" rule so authors cannot walk around
+// the traditional path's gate by going through the agent.
+func TestValidateSnapshotScope_AgentGeneration_ScopeSignal(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{Title: "t"}, TargetAgentGeneration)
+	if err == nil || err.Code != 40001 {
+		t.Errorf("expected 40001 for empty scope signal on agent_generation, got %v", err)
+	}
+
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{Topic: "x"}, TargetAgentGeneration); err != nil {
+		t.Errorf("topic alone should pass agent_generation, got %v", err)
+	}
+}
+
+// TestValidateSnapshotScope_AgentSave_ShapeChecks covers session_id / content
+// rules for the agent-save target.
+func TestValidateSnapshotScope_AgentSave_ShapeChecks(t *testing.T) {
+	resetValidatorGlobals(t)
+
+	// Missing AgentSave payload: 40000.
+	err := ValidateSnapshotScope("user1", SnapshotScopeInput{}, TargetAgentSave)
+	if err == nil || err.Code != 40000 {
+		t.Errorf("expected 40000 for missing AgentSave, got %v", err)
+	}
+
+	// Empty session id: 40000.
+	err = ValidateSnapshotScope("user1", SnapshotScopeInput{
+		AgentSave: &AgentSaveInput{},
+	}, TargetAgentSave)
+	if err == nil || err.Code != 40000 {
+		t.Errorf("expected 40000 for empty session id, got %v", err)
+	}
+
+	// Empty content: 40004.
+	err = ValidateSnapshotScope("user1", SnapshotScopeInput{
+		AgentSave: &AgentSaveInput{SessionID: "s1", ContentLen: 0},
+	}, TargetAgentSave)
+	if err == nil || err.Code != 40004 {
+		t.Errorf("expected 40004 for empty content, got %v", err)
+	}
+
+	// All good.
+	if err := ValidateSnapshotScope("user1", SnapshotScopeInput{
+		AgentSave: &AgentSaveInput{SessionID: "s1", ContentLen: 128},
+	}, TargetAgentSave); err != nil {
+		t.Errorf("full agent_save payload should pass, got %v", err)
+	}
+}
+
+// manyValidSources returns n structurally-valid SourceInput records — used to
+// exercise the source-count cap without stubbing the whole handler stack.
+func manyValidSources(n int) []SourceInput {
+	out := make([]SourceInput, n)
+	for i := range out {
+		out[i] = SourceInput{SourceType: 1, SourceID: "grp"}
+	}
+	return out
+}

--- a/internal/service/snapshot_validator_test.go
+++ b/internal/service/snapshot_validator_test.go
@@ -36,7 +36,6 @@ func TestValidatePersonalWorkflow_ActorRequired(t *testing.T) {
 func TestValidateScheduledWorkflow_ActorRequired(t *testing.T) {
 	err := ValidateScheduledWorkflow(
 		"", "daily",
-		model.SnapshotScope{},
 	)
 	if err == nil || err.Code != 40100 {
 		t.Fatalf("expected 40100 for empty actor on schedule, got %v", err)
@@ -245,7 +244,6 @@ func TestValidatePersonalWorkflow_NoTimeRangeSpanCapWhenAbsent(t *testing.T) {
 func TestValidateScheduledWorkflow_TitleCapEnforced(t *testing.T) {
 	err := ValidateScheduledWorkflow(
 		"u1", strings.Repeat("总", MaxSummaryTitleRunes+1),
-		model.SnapshotScope{},
 	)
 	if err == nil || err.Code != 40001 || err.Message != "title 不能超过 2300 字符" {
 		t.Fatalf("expected 40001 title over cap, got %v", err)

--- a/internal/service/snapshot_validator_test.go
+++ b/internal/service/snapshot_validator_test.go
@@ -24,6 +24,7 @@ func TestValidatePersonalWorkflow_ActorRequired(t *testing.T) {
 		model.SnapshotScope{ChannelIDs: []string{"grp1"}},
 		1,
 		"", 0,
+		false,
 		time.Time{}, time.Time{},
 		31,
 	)
@@ -36,7 +37,6 @@ func TestValidateScheduledWorkflow_ActorRequired(t *testing.T) {
 	err := ValidateScheduledWorkflow(
 		"", "daily",
 		model.SnapshotScope{},
-		"", 1, 0,
 	)
 	if err == nil || err.Code != 40100 {
 		t.Fatalf("expected 40100 for empty actor on schedule, got %v", err)
@@ -63,6 +63,7 @@ func TestValidatePersonalWorkflow_BaseChecks(t *testing.T) {
 		srcCount int
 		origID   string
 		origType int
+		explicit bool
 		start    time.Time
 		end      time.Time
 		maxDays  int
@@ -113,8 +114,18 @@ func TestValidatePersonalWorkflow_BaseChecks(t *testing.T) {
 			scope:    model.SnapshotScope{ChannelIDs: []string{"g1"}},
 			start:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 			end:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), // ~59 days > 31
+			explicit: true,
 			maxDays:  31,
 			wantCode: 40002, wantMsg: "时间范围不能超过31天",
+		},
+		{
+			name:  "half-open time range rejected",
+			title: "t", topic: "x",
+			scope:    model.SnapshotScope{TimeRange: model.TimeRangeJSON{End: "2026-03-01T00:00:00Z"}},
+			explicit: true,
+			end:      time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			maxDays:  31,
+			wantCode: 40002, wantMsg: "time_range.start 和 time_range.end 必须同时提供",
 		},
 		{
 			name:  "scope has no signal, no topic, no time range",
@@ -133,6 +144,7 @@ func TestValidatePersonalWorkflow_BaseChecks(t *testing.T) {
 				tc.scope,
 				tc.srcCount,
 				tc.origID, tc.origType,
+				tc.explicit,
 				tc.start, tc.end,
 				tc.maxDays,
 			)
@@ -198,6 +210,7 @@ func TestValidatePersonalWorkflow_SignalSources(t *testing.T) {
 			err := ValidatePersonalWorkflow(
 				"u1", "title", tc.topic,
 				scope, 0, "", 0,
+				!tc.start.IsZero() || !tc.end.IsZero(),
 				tc.start, tc.end,
 				31,
 			)
@@ -218,6 +231,7 @@ func TestValidatePersonalWorkflow_NoTimeRangeSpanCapWhenAbsent(t *testing.T) {
 		"u1", "t", "topic",
 		model.SnapshotScope{},
 		0, "", 0,
+		false,
 		time.Time{}, time.Time{},
 		31,
 	)
@@ -228,35 +242,10 @@ func TestValidatePersonalWorkflow_NoTimeRangeSpanCapWhenAbsent(t *testing.T) {
 
 // ------------------------- scheduled_workflow ---------------------------
 
-func TestValidateScheduledWorkflow_RecurrenceRequired(t *testing.T) {
-	err := ValidateScheduledWorkflow(
-		"u1", "daily",
-		model.SnapshotScope{},
-		"", 0, 0,
-	)
-	if err == nil || err.Code != 40010 {
-		t.Fatalf("expected 40010 for empty recurrence, got %v", err)
-	}
-
-	// interval_days > 0 passes.
-	if err := ValidateScheduledWorkflow("u1", "daily", model.SnapshotScope{}, "", 1, 0); err != nil {
-		t.Errorf("interval_days=1 should pass, got %v", err)
-	}
-	// cron_expr passes.
-	if err := ValidateScheduledWorkflow("u1", "daily", model.SnapshotScope{}, "0 9 * * *", 0, 0); err != nil {
-		t.Errorf("cron_expr should pass, got %v", err)
-	}
-	// interval_months passes.
-	if err := ValidateScheduledWorkflow("u1", "monthly", model.SnapshotScope{}, "", 0, 1); err != nil {
-		t.Errorf("interval_months=1 should pass, got %v", err)
-	}
-}
-
 func TestValidateScheduledWorkflow_TitleCapEnforced(t *testing.T) {
 	err := ValidateScheduledWorkflow(
 		"u1", strings.Repeat("总", MaxSummaryTitleRunes+1),
 		model.SnapshotScope{},
-		"", 1, 0,
 	)
 	if err == nil || err.Code != 40001 || err.Message != "title 不能超过 2300 字符" {
 		t.Fatalf("expected 40001 title over cap, got %v", err)
@@ -340,6 +329,13 @@ func TestValidateAgentSave_NegativeMessageIDRejected(t *testing.T) {
 	err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, -1, 0)
 	if err == nil || err.Code != 40001 {
 		t.Fatalf("expected 40001 for negative msg_id, got %v", err)
+	}
+}
+
+func TestValidateAgentSave_NegativeSnapshotVersionRejected(t *testing.T) {
+	err := ValidateAgentSave("u1", "t", "sess1", "hello", "", 0, 0, -1)
+	if err == nil || err.Code != 40001 {
+		t.Fatalf("expected 40001 for negative snapshot_version, got %v", err)
 	}
 }
 

--- a/migrations/sql/20260810-01-agent-draft-save.sql
+++ b/migrations/sql/20260810-01-agent-draft-save.sql
@@ -1,0 +1,54 @@
+-- +migrate Up
+--
+-- SUM-BE2 (Agent 草稿与安全落库) — schema for the trusted, idempotent
+-- Agent draft save path.
+--
+-- Two orthogonal additions:
+--
+-- 1. Record which Agent chat + which assistant message + which snapshot
+--    version produced each Agent-created summary. This is what SUM-9 flagged
+--    as missing when the shared validator dropped AgentMessageID /
+--    SnapshotVersion for lack of storage columns; BE-2 owns that storage.
+--
+--    The columns are nullable + default-empty so existing rows (bot / task /
+--    scheduled paths) stay valid, and the Agent write path fills them
+--    explicitly. They are read by SUM-10 review and by the future Refine
+--    pipeline (parent_snapshot_version lookup).
+--
+-- 2. A dedicated idempotency table for Agent save, shaped after
+--    summary_bot_create_idempotency (see 20260728-01) so the on-conflict
+--    replay contract is identical: same key + same body => replay, same key
+--    + different body => HTTP 409 with the original task_id. Space + user +
+--    key is the unique tuple (Agent save is user-owned, not bot-owned).
+
+ALTER TABLE summary_task
+    ADD COLUMN agent_session_id VARCHAR(128) NOT NULL DEFAULT ''
+    COMMENT 'agent chat session that produced this summary; empty for non-agent tasks (SUM-BE2)',
+    ADD COLUMN agent_message_id BIGINT NOT NULL DEFAULT 0
+    COMMENT 'agent_message.id of the assistant reply saved as this summary; 0 for non-agent tasks (SUM-BE2)',
+    ADD COLUMN snapshot_version INT NOT NULL DEFAULT 0
+    COMMENT 'snapshot version the client confirmed on save; matches personal_result.snapshot_json.snapshot_version (SUM-BE2)';
+
+CREATE INDEX idx_summary_task_agent_session
+    ON summary_task (agent_session_id);
+
+CREATE TABLE summary_agent_save_idempotency (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    space_id VARCHAR(64) NOT NULL,
+    user_id VARCHAR(64) NOT NULL,
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_hash CHAR(64) NOT NULL DEFAULT '',
+    task_id BIGINT NOT NULL,
+    created_at DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_agent_save_idempotency (space_id, user_id, idempotency_key),
+    KEY idx_agent_save_idempotency_task (task_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- +migrate Down
+DROP TABLE IF EXISTS summary_agent_save_idempotency;
+DROP INDEX idx_summary_task_agent_session ON summary_task;
+ALTER TABLE summary_task
+    DROP COLUMN snapshot_version,
+    DROP COLUMN agent_message_id,
+    DROP COLUMN agent_session_id;

--- a/migrations/sql/20260810-01-agent-draft-save.sql
+++ b/migrations/sql/20260810-01-agent-draft-save.sql
@@ -27,7 +27,7 @@ ALTER TABLE summary_task
     ADD COLUMN agent_message_id BIGINT NOT NULL DEFAULT 0
     COMMENT 'agent_message.id of the assistant reply saved as this summary; 0 for non-agent tasks (SUM-BE2)',
     ADD COLUMN snapshot_version INT NOT NULL DEFAULT 0
-    COMMENT 'snapshot version the client confirmed on save; matches personal_result.snapshot_json.snapshot_version (SUM-BE2)';
+    COMMENT 'client-declared snapshot version confirmed on save; 0 denotes the legacy save path (SUM-BE2)';
 
 CREATE INDEX idx_summary_task_agent_session
     ON summary_task (agent_session_id);


### PR DESCRIPTION
## What

Agent 保存的**可信、幂等落库**底座（SUM-BE1 + SUM-9 P1 + SUM-BE2）。

- **SUM-BE1**：抽取共享 SnapshotScope validator，消除重复校验。
- **SUM-9 P1**：真实覆盖生产 handler，移除并行 DTO，修补回归。
- **SUM-BE2**：
  1. **可信消息引用**：按 `(id, user_id, session_id, role='assistant', tool_calls IS NULL)` 校验 `agent_message_id`。
  2. **幂等绑定**：新增 `summary_agent_save_idempotency`，键为 `(space_id, user_id, idempotency_key)`；同 key 同请求重放，同 key 异请求返回 409。
  3. **规范请求哈希**：覆盖 `session_id`、`request_id`、`agent_message_id`、`snapshot_version`、`title`、origin、sources、participants、`referenced_task_ids`。sources/participants 归一化为集合；`referenced_task_ids` 保留顺序，因为首项决定 origin/citation 继承。
  4. **并发安全**：不再依赖 MySQL 的 `RowsAffected` 判断唯一键冲突，改为事务内锁定回读 binding；草稿被并发请求删除时再次查询 binding 并重放。
  5. `summary_task` 新增审计列 `agent_session_id / agent_message_id / snapshot_version`。

## API behavior notes

- binding 指向已删除任务时返回 `409 / 40009`，并携带 `reason=deleted_summary`。
- 同一幂等 key 对应不同请求体时返回 `409 / 40009`，并携带 `reason=request_mismatch` 与 `recovery_action=open_existing_summary`。
- 空/单边 `time_range` 现在返回 40002；仅包含空 `source_id` 且无 topic/time_range 的请求现在返回 40001。这两项是对原先无效输入的收紧。
- 空白 title 会进入自动标题生成逻辑。

## Migration

`migrations/sql/20260810-01-agent-draft-save.sql`：新增审计列、索引和 Agent 保存幂等表。

## Verification

- `CGO_ENABLED=1 LIBRARY_PATH=/home/mlamp/.local/lib go test ./internal/...`
- `LIBRARY_PATH=/home/mlamp/.local/lib go vet ./...`
- `git diff --check`

以上均通过。
