### PR TITLE
feat(agent): SS-08/08b refine routing — two-conjunct tool strip + positional container rule (stacked on #205)

### DIFF
--- a/internal/agent/refine_route.go
+++ b/internal/agent/refine_route.go
@@ -168,6 +168,17 @@ var (
 		// cannot drift apart; only the demonstratives are listed here.
 		"这篇", "本文",
 		// parts of an existing document (subtractive edits name these, never new data)
+		//
+		// 正文 / 全文 live HERE, not in refineArtifactNouns, and the distinction is
+		// load-bearing. As a filler they behave identically (翻译正文 / 把全文翻译成英文
+		// still strip), but refineArtifactNouns is ALSO the right-hand side of the
+		// adjacency test in stripModifierContainers, and there they are wrong: they
+		// name a PART of a document, not a produced artifact. "<container>全文" means
+		// "the full text OF the container" — the raw material — not "the artifact
+		// derived from it", so treating them as adjacency targets erased the container
+		// and hard-stripped 2352 requests for source material (翻译频道消息全文 stripped
+		// while 翻译频道消息, pinned must-keep, did not). Found by yujiawei, #206 round 2.
+		"正文", "全文",
 		"段落", "段", "句子", "句", "行", "字词", "字", "词", "小标题", "标题", "开头", "结尾",
 		"末尾", "部分", "结论", "章节", "列表", "序号", "编号", "第", "篇幅",
 		// NOTE: the origin containers (群 / 频道 / 子区 / 消息 / 对话记录 …) are deliberately
@@ -299,21 +310,32 @@ var refineOriginContainers = []string{
 	"群消息", "对话记录", "聊天记录", "群聊", "频道", "子区", "会话", "对话", "消息", "群",
 }
 
-// refineArtifactNouns are the names of the thing being edited, and the SINGLE
+// refineArtifactNouns are the names of the PRODUCED ARTIFACT, and the SINGLE
 // SOURCE OF TRUTH for that vocabulary: refineResidueFillers embeds this slice by
 // reference rather than repeating it.
 //
-// A container that MODIFIES one of these is structural (群总结 = "the summary of
-// the group", not a request to go read the group).
+// This list has TWO jobs, and membership must satisfy both:
+//
+//  1. residue filler — naming the thing being edited is not new data;
+//  2. adjacency target in stripModifierContainers — a container that MODIFIES one
+//     of these is structural (群总结 = "the summary of the group", not a request to
+//     go read the group).
+//
+// Job 2 is the strict one. Only nouns that name the OUTPUT belong here. Document
+// PART nouns (正文 / 全文 / 段落 / 章节 …) are fillers too, but they are NOT valid
+// adjacency targets: "<container>全文" is the full text OF the container — raw
+// material — so treating them as targets erases the container and strips a
+// request that can only be satisfied by fetching. They live in the
+// document-parts block of refineResidueFillers instead.
 //
 // The duplication this replaces was a live regression source: the positional rule
-// (stripModifierContainers) and the filler pass must agree on what an artifact
-// noun is, so adding 简报 to the filler list but not here would silently stop 群简报
-// from being recognised as a modifier construction, with no test failing. Rounds
-// 4-10 of #203 were almost entirely vocabulary churn, so the two lists are wired
-// together instead of being kept in sync by hand.
+// and the filler pass must agree on what an artifact noun is, so adding 简报 to the
+// filler list but not here would silently stop 群简报 from being recognised as a
+// modifier construction, with no test failing. Rounds 4-12 of this work were
+// almost entirely vocabulary churn, so the two lists are wired together instead of
+// being kept in sync by hand.
 var refineArtifactNouns = []string{
-	"摘要", "总结", "报告", "纪要", "正文", "全文", "文档", "文章",
+	"摘要", "总结", "报告", "纪要", "文档", "文章",
 }
 
 var refineOriginContainersByLen = sortByRuneLenDesc(refineOriginContainers)

--- a/internal/agent/refine_route.go
+++ b/internal/agent/refine_route.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // SS-08: deterministic 3-way refine routing (缺点十二 note + 原方案 §7 "Refine
@@ -161,8 +162,11 @@ var (
 		"外加", "外带", "此外", "加之", "捎带", "兼", "随后", "跟着", "以后", "之后", "要",
 		// "re-" modifiers
 		"重新", "重",
-		// artifact nouns (naming the thing being edited is not new data)
-		"摘要", "总结", "报告", "纪要", "正文", "全文", "文档", "文章", "这篇", "本文",
+		// artifact nouns — naming the thing being edited is not new data. The nouns
+		// themselves come from refineArtifactNouns (single source of truth, appended
+		// in the init below) so the filler pass and the positional container rule
+		// cannot drift apart; only the demonstratives are listed here.
+		"这篇", "本文",
 		// parts of an existing document (subtractive edits name these, never new data)
 		"段落", "段", "句子", "句", "行", "字词", "字", "词", "小标题", "标题", "开头", "结尾",
 		"末尾", "部分", "结论", "章节", "列表", "序号", "编号", "第", "篇幅",
@@ -295,9 +299,19 @@ var refineOriginContainers = []string{
 	"群消息", "对话记录", "聊天记录", "群聊", "频道", "子区", "会话", "对话", "消息", "群",
 }
 
-// refineArtifactNouns are the names of the thing being edited. A container that
-// MODIFIES one of these is structural (群总结 = "the summary of the group", not a
-// request to go read the group).
+// refineArtifactNouns are the names of the thing being edited, and the SINGLE
+// SOURCE OF TRUTH for that vocabulary: refineResidueFillers embeds this slice by
+// reference rather than repeating it.
+//
+// A container that MODIFIES one of these is structural (群总结 = "the summary of
+// the group", not a request to go read the group).
+//
+// The duplication this replaces was a live regression source: the positional rule
+// (stripModifierContainers) and the filler pass must agree on what an artifact
+// noun is, so adding 简报 to the filler list but not here would silently stop 群简报
+// from being recognised as a modifier construction, with no test failing. Rounds
+// 4-10 of #203 were almost entirely vocabulary churn, so the two lists are wired
+// together instead of being kept in sync by hand.
 var refineArtifactNouns = []string{
 	"摘要", "总结", "报告", "纪要", "正文", "全文", "文档", "文章",
 }
@@ -323,30 +337,65 @@ var refineOriginContainersByLen = sortByRuneLenDesc(refineOriginContainers)
 // The loop repeats to completion because removing one modifier can create a new
 // adjacency (群频道总结), and the direction of error is safe: a container left in
 // place only makes the residue non-empty, i.e. keeps the tools.
+// Single left-to-right pass. The modifier relation is resolved by a right-to-left
+// precomputation of "does a chain of containers / 的 particles starting here end in
+// an artifact noun", which is what makes chains like 群频道总结 resolve transitively.
+// The previous restart-from-zero fixpoint loop bought the same transitivity at
+// O(removals × len × |containers|) — 37ms of synchronous CPU at the handler's
+// 8192-rune cap, on an authenticated request path (#206 P2-3).
 func stripModifierContainers(s string) string {
-	for changed := true; changed; {
-		changed = false
+	if s == "" {
+		return s
+	}
+	const de = "的"
+	n := len(s)
+	// leadsToArtifact[i]: starting at byte i, the text is a (possibly empty) chain of
+	// containers and 的 particles that ends in an artifact noun.
+	leadsToArtifact := make([]bool, n+1)
+	// matchLen[i]: byte length of the container matched at i (0 = none). dropAt[i]:
+	// that container modifies an artifact noun and must be removed.
+	matchLen := make([]int, n+1)
+	dropAt := make([]bool, n+1)
+	for i := n - 1; i >= 0; i-- {
+		if hasPrefixAny(s[i:], refineArtifactNouns) {
+			leadsToArtifact[i] = true
+		}
+		if strings.HasPrefix(s[i:], de) && leadsToArtifact[i+len(de)] {
+			leadsToArtifact[i] = true
+		}
 		for _, c := range refineOriginContainersByLen {
-			for start := 0; ; {
-				off := strings.Index(s[start:], c)
-				if off < 0 {
-					break
-				}
-				idx := start + off
-				rest := s[idx+len(c):]
-				if hasPrefixAny(strings.TrimPrefix(rest, "的"), refineArtifactNouns) {
-					s = s[:idx] + rest
-					changed = true
-					break
-				}
-				start = idx + len(c)
+			if !strings.HasPrefix(s[i:], c) {
+				continue
 			}
-			if changed {
+			if matchLen[i] == 0 {
+				// Longest container at this position, kept so the emit loop can skip
+				// past it whole: an offset INSIDE a container the rule decided to keep
+				// must never be reconsidered as its own match.
+				matchLen[i] = len(c)
+			}
+			if leadsToArtifact[i+len(c)] {
+				leadsToArtifact[i] = true
+				matchLen[i] = len(c)
+				dropAt[i] = true
 				break
 			}
 		}
 	}
-	return s
+	var b strings.Builder
+	b.Grow(n)
+	for i := 0; i < n; {
+		if l := matchLen[i]; l > 0 {
+			if !dropAt[i] {
+				b.WriteString(s[i : i+l])
+			}
+			i += l
+			continue
+		}
+		_, size := utf8.DecodeRuneInString(s[i:])
+		b.WriteString(s[i : i+size])
+		i += size
+	}
+	return b.String()
 }
 
 func hasPrefixAny(s string, prefixes []string) bool {
@@ -389,16 +438,29 @@ func hasPrefixAny(s string, prefixes []string) bool {
 // Credit: proposed and hand-verified against the protection set by yujiawei in the
 // round-9 review.
 func rewriteResidueEmpty(s string) bool {
-	residue := s
+	// Container removal MUST run on the ORIGINAL text, before any keyword removal.
+	//
+	// The positional rule reads adjacency ("a container followed, optionally through
+	// 的, by an artifact noun is a modifier"), and adjacency is a property of what
+	// the user actually typed. Running it on a keyword-stripped string let the
+	// removal of whatever sat BETWEEN the container and the artifact noun
+	// manufacture an adjacency that never existed:
+	//
+	//	把群消息改写成总结  -→ (改写成 removed) → 把群消息总结 → 群消息 now
+	//	                          "modifies" 总结 → erased → residue empty → STRIP
+	//
+	// — i.e. exactly the compile-from-material class the rule exists to protect, and
+	// self-inconsistent with 改写第十群消息 being pinned as must-keep: appending a
+	// destination artifact makes a request MORE clearly a compile, not less.
+	// Judged on the source text, 群消息 is followed by 改写成, so it is material, it
+	// survives, and the tools stay. Found by yujiawei in the #206 review (160
+	// strings in a 把<container><rewrite-verb><artifact> sweep).
+	residue := stripModifierContainers(s)
 	// Rewrite keywords longest-first, so a compound like 翻译成英文 is removed whole
 	// before its substring 翻译 could leave 成英文 behind.
 	for _, kw := range refineRewriteKeywordsByLen {
 		residue = strings.ReplaceAll(residue, kw, "")
 	}
-	// Containers that modify an artifact noun are structural; standalone ones are
-	// the material and must survive. Runs before the filler pass, which is where
-	// the artifact nouns themselves are erased.
-	residue = stripModifierContainers(residue)
 	for _, f := range refineResidueFillersByLen {
 		residue = strings.ReplaceAll(residue, f, "")
 	}
@@ -419,7 +481,11 @@ var refineRewriteKeywordsByLen = sortByRuneLenDesc(refineRewriteKeywords)
 
 // refineResidueFillersByLen is refineResidueFillers longest-first, so a compound
 // filler (摘要) is removed before a single-rune filler (要) can split it.
-var refineResidueFillersByLen = sortByRuneLenDesc(refineResidueFillers)
+//
+// The artifact nouns are appended from refineArtifactNouns rather than repeated
+// in the literal above (P2-2): the filler pass and the positional container rule
+// must agree on that vocabulary, and a hand-kept copy silently breaks the rule.
+var refineResidueFillersByLen = sortByRuneLenDesc(append(append([]string(nil), refineResidueFillers...), refineArtifactNouns...))
 
 func sortByRuneLenDesc(in []string) []string {
 	out := append([]string(nil), in...)

--- a/internal/agent/refine_route.go
+++ b/internal/agent/refine_route.go
@@ -166,10 +166,11 @@ var (
 		// parts of an existing document (subtractive edits name these, never new data)
 		"段落", "段", "句子", "句", "行", "字词", "字", "词", "小标题", "标题", "开头", "结尾",
 		"末尾", "部分", "结论", "章节", "列表", "序号", "编号", "第", "篇幅",
-		// origin containers — WHERE material lives, structural like the artifact nouns.
-		// An addition that names a container also names its content (a channel name, a
-		// data kind), and that content noun is NOT a filler, so it survives the residue.
-		"群消息", "群", "频道", "子区", "会话", "对话记录", "聊天记录", "对话", "消息",
+		// NOTE: the origin containers (群 / 频道 / 子区 / 消息 / 对话记录 …) are deliberately
+		// NOT filler. They are structural only when they MODIFY an artifact noun
+		// (群总结, 对话记录的总结); standing alone they ARE the material, and erasing them
+		// unconditionally is what let 翻译频道消息 reduce to an empty residue and strip.
+		// They are removed positionally instead — see stripModifierContainers.
 		// pure-adjustment verbs that are not themselves rewrite keywords
 		"调整", "调", "整理", "组织",
 		// locatives
@@ -208,10 +209,28 @@ func ClassifyRefine(instruction string) RefineRoute {
 		// Confident rewrite: an explicit pure-text keyword matched, so it MAY be safe
 		// to strip the fetch tools (HardNoFetch) — 纯格式零 fetch.
 		//
-		// The strip fires only when NOTHING content-bearing is left after the rewrite
-		// keywords are removed (rewriteResidueEmpty). A time word additionally vetoes
-		// it, because then the request is only *probably* a rewrite.
-		hardNoFetch := rewriteResidueEmpty(s) && !containsAny(s, refineExtendKeywords)
+		// The strip fires only when THREE independent conditions hold together. Each
+		// closes a class the others provably cannot; rounds 4-10 established that any
+		// one of them alone regresses.
+		//
+		//  1. rewriteResidueEmpty  — nothing content-bearing survives keyword removal.
+		//     Closes the no-connective additions ("翻译成英文补一些运营数据"): the added
+		//     content noun survives into the residue, so no conjunction list is needed.
+		//     Cannot see a clause built ENTIRELY of fillers.
+		//  2. allClausesCarryARewriteKeyword — every punctuation-delimited clause is
+		//     itself qualified as a rewrite. Closes exactly what (1) cannot: a compile
+		//     verb over a container ("精简一下，整理频道消息") reduces to an empty residue
+		//     because 整理/总结 are also artifact/structural words, but the second clause
+		//     carries no rewrite keyword, so the request keeps its tools.
+		//  3. no extend keyword — a time word means the request is only *probably* a
+		//     rewrite.
+		//
+		// Neither (1) nor (2) needs new vocabulary, and they are conjuncts rather than
+		// alternatives on purpose: HardNoFetch is the one decision here a runtime
+		// mistake cannot undo, so both must agree before the tools are removed.
+		hardNoFetch := rewriteResidueEmpty(s) &&
+			allClausesCarryARewriteKeyword(s) &&
+			!containsAny(s, refineExtendKeywords)
 		return RefineRoute{Intent: RefineRewrite, Fetch: false, ReuseTimeRange: false, ReuseCitations: true, HardNoFetch: hardNoFetch}
 	default:
 		// Ambiguous fallback: still the rewrite path (cheapest, no fetch by
@@ -219,6 +238,124 @@ func ClassifyRefine(instruction string) RefineRoute {
 		// can still recover by fetching.
 		return RefineRoute{Intent: RefineRewrite, Fetch: false, ReuseTimeRange: false, ReuseCitations: true, HardNoFetch: false}
 	}
+}
+
+// allClausesCarryARewriteKeyword reports whether EVERY punctuation-delimited
+// clause of s carries a rewrite keyword of its own.
+//
+// This is the conjunct that closes what rewriteResidueEmpty structurally cannot.
+// The residue test asks "is anything content-bearing left over?", and its filler
+// list has to classify the artifact nouns (摘要/总结/报告), the origin containers
+// (群/频道/消息/对话记录) and the generic adjustment verbs (整理/组织/调整) as
+// structural — otherwise ordinary pure-text requests like "把这份群总结翻译成英文"
+// stop stripping and SS-08b never fires. But 总结 is also the primary Chinese VERB
+// "to summarize", and 整理/组织 are the primary verbs for "compile from source
+// material", so "compile/summarize + <container>" — the canonical way to ask for a
+// fetch — reduces to an empty residue too:
+//
+//	"精简一下，整理频道消息"   residue ""  — but clause 2 has no rewrite keyword
+//	"翻译频道消息"          residue ""  — single clause, 翻译 qualifies it
+//
+// A word cannot be both a filler and not a filler, so the residue list cannot be
+// trimmed to fix this. The quantifier resolves it on a different axis: the
+// difference between the two lines above is not vocabulary but whether the
+// container is the object of a REWRITE verb or of a non-rewrite verb, and that is
+// exactly what per-clause qualification measures.
+//
+// Symmetrically, the quantifier alone is not enough either — an unrecognised
+// addition glued to a rewrite clause without a connective ("翻译成英文补一些运营
+// 数据") is ONE clause that does carry a rewrite keyword, and only the residue
+// sees the leftover obligation. Neither test subsumes the other; both must agree.
+//
+// Clause segmentation is punctuation-only and deliberately carries no conjunction
+// vocabulary: rounds 4-9 showed a closed connective list never converges (也/
+// 还要/顺手/此外/兔带… each arrived a round late). Any unpunctuated chaining the
+// quantifier misses is caught by the residue conjunct instead.
+//
+// Credit: proposed and measured by yujiawei in the round-10 review (44/44
+// must-keep, 19/19 must-strip against the union of every pinned string in this
+// PR's history).
+func allClausesCarryARewriteKeyword(s string) bool {
+	clauses := splitRefineClauses(s)
+	if len(clauses) == 0 {
+		return false
+	}
+	for _, clause := range clauses {
+		if !containsAny(clause, refineRewriteKeywords) {
+			return false
+		}
+	}
+	return true
+}
+
+// refineOriginContainers name WHERE material lives. They are NOT unconditional
+// fillers: see stripModifierContainers for the positional rule that decides when
+// an occurrence is structural.
+var refineOriginContainers = []string{
+	"群消息", "对话记录", "聊天记录", "群聊", "频道", "子区", "会话", "对话", "消息", "群",
+}
+
+// refineArtifactNouns are the names of the thing being edited. A container that
+// MODIFIES one of these is structural (群总结 = "the summary of the group", not a
+// request to go read the group).
+var refineArtifactNouns = []string{
+	"摘要", "总结", "报告", "纪要", "正文", "全文", "文档", "文章",
+}
+
+var refineOriginContainersByLen = sortByRuneLenDesc(refineOriginContainers)
+
+// stripModifierContainers removes only those origin-container occurrences that
+// MODIFY an artifact noun, and leaves standalone ones in place.
+//
+// This is the positional rule that replaces the unconditional container fillers.
+// The round-10 review established both halves of the requirement, and a flat word
+// list cannot satisfy them at once — a word is either filler or it is not:
+//
+//	"把这份群总结翻译成英文"  群 modifies 总结  -> structural -> residue empty -> STRIP
+//	"翻译频道消息"            频道消息 stands alone -> IS the material -> KEEP tools
+//
+// With the containers as unconditional fillers the second line reduced to an
+// empty residue and the fetch tools were removed from a request that can only be
+// satisfied by fetching. Adjacency is the disambiguator: a container followed
+// (optionally through 的) by an artifact noun is a modifier; anywhere else it is
+// the material itself.
+//
+// The loop repeats to completion because removing one modifier can create a new
+// adjacency (群频道总结), and the direction of error is safe: a container left in
+// place only makes the residue non-empty, i.e. keeps the tools.
+func stripModifierContainers(s string) string {
+	for changed := true; changed; {
+		changed = false
+		for _, c := range refineOriginContainersByLen {
+			for start := 0; ; {
+				off := strings.Index(s[start:], c)
+				if off < 0 {
+					break
+				}
+				idx := start + off
+				rest := s[idx+len(c):]
+				if hasPrefixAny(strings.TrimPrefix(rest, "的"), refineArtifactNouns) {
+					s = s[:idx] + rest
+					changed = true
+					break
+				}
+				start = idx + len(c)
+			}
+			if changed {
+				break
+			}
+		}
+	}
+	return s
+}
+
+func hasPrefixAny(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // rewriteResidueEmpty reports whether, after deleting every matched rewrite
@@ -258,6 +395,10 @@ func rewriteResidueEmpty(s string) bool {
 	for _, kw := range refineRewriteKeywordsByLen {
 		residue = strings.ReplaceAll(residue, kw, "")
 	}
+	// Containers that modify an artifact noun are structural; standalone ones are
+	// the material and must survive. Runs before the filler pass, which is where
+	// the artifact nouns themselves are erased.
+	residue = stripModifierContainers(residue)
 	for _, f := range refineResidueFillersByLen {
 		residue = strings.ReplaceAll(residue, f, "")
 	}

--- a/internal/agent/refine_route_test.go
+++ b/internal/agent/refine_route_test.go
@@ -580,3 +580,59 @@ func TestRefineAugmentWithATimeWordStillExtends(t *testing.T) {
 		}
 	}
 }
+
+// TestRefineStripNeedsResidueAndQuantifierTogether pins the round-10 P1-1
+// (yujiawei): the residue test and the ∀-clause quantifier are CONJUNCTS, and
+// neither subsumes the other.
+//
+// At the previous head the strip was residue-only, and 15 instructions that had
+// kept their tools one commit earlier began hard-stripping: 总结 is also the
+// primary Chinese verb "to summarize" and 整理/组织 the primary verbs for
+// "compile from source material", so "compile + <container>" — the canonical way
+// to ask for a fetch — reduced to an empty residue. The quantifier catches those
+// because the compile clause carries no rewrite keyword of its own.
+func TestRefineStripNeedsResidueAndQuantifierTogether(t *testing.T) {
+	t.Run("a compile verb over a container keeps its tools", func(t *testing.T) {
+		for _, instruction := range []string{
+			"帮我精简一下，再总结一下会话",
+			"精简一下，另外总结第二群",
+			"压缩篇幅，同时整理频道消息",
+			"重新组织，把消息调整一下",
+			"润色一下，整理对话",
+			"翻译成英文，整理一下子区",
+			"精简，总结一下对话记录",
+			"只保留结论，整理群",
+			"去掉第三段，总结消息",
+			"改语气，组织一下群消息",
+			"翻译成英文，调一下频道",
+			"排版，整理聊天记录",
+			// The quantifier alone cannot see these three: one clause, and it does
+			// carry a rewrite keyword. The container is the OBJECT of the rewrite
+			// verb rather than a modifier of an artifact noun, so it survives the
+			// residue as material — which is what keeps the tools.
+			"翻译频道消息",
+			"改写第十群消息",
+			"请整理第三子区内的聊天记录并重写总结",
+		} {
+			if got := ClassifyRefine(instruction); got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q) strips the fetch tools; asking to compile a container is a request for material: %+v", instruction, got)
+			}
+		}
+	})
+
+	// The other direction: a container that MODIFIES an artifact noun is
+	// structural, and those requests must still strip. A flat filler list cannot
+	// satisfy both halves — a word is either filler or it is not — so the
+	// container rule is positional (stripModifierContainers).
+	t.Run("a container modifying an artifact noun still strips", func(t *testing.T) {
+		for _, instruction := range []string{
+			"把这份群总结翻译成英文",
+			"精简一下群消息总结",
+			"对话记录的总结润色一下",
+		} {
+			if got := ClassifyRefine(instruction); !got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q): naming the artifact's origin is not a retrieval request: %+v", instruction, got)
+			}
+		}
+	})
+}

--- a/internal/agent/refine_route_test.go
+++ b/internal/agent/refine_route_test.go
@@ -702,3 +702,92 @@ func TestRefineContainerAdjacencyIsJudgedOnSourceText(t *testing.T) {
 		}
 	})
 }
+
+// TestRefineDocumentPartIsNotAnAdjacencyTarget pins the #206 round-2 P1-1
+// (yujiawei): 正文 / 全文 are document PART nouns, not artifact names, so they
+// must not serve as the right-hand side of the positional container rule.
+//
+// refineArtifactNouns has two jobs — residue filler, and adjacency target in
+// stripModifierContainers — and they need different vocabularies. As fillers the
+// two words behave identically either way (翻译正文 still strips); as adjacency
+// targets they are wrong, because "<container>全文" is the full text OF the
+// container, i.e. the raw material, not an artifact derived from it. Treating
+// them as targets erased the container and hard-stripped 2352 requests for
+// source material, contradicting this file's own must-keep table:
+//
+//	翻译频道消息      keep (pinned above)
+//	翻译频道消息全文   stripped ← appending 全文 makes it MORE clearly material
+func TestRefineDocumentPartIsNotAnAdjacencyTarget(t *testing.T) {
+	t.Run("reported strings keep their tools", func(t *testing.T) {
+		for _, instruction := range []string{
+			"翻译消息全文",
+			"翻译对话记录全文",
+			"翻译群消息全文",
+			"翻译频道消息全文",
+			"用英文重写聊天记录正文",
+			"翻译群消息正文",
+			"把群消息全文翻译成英文",
+			"精简对话全文",
+			"改写第十群消息全文",
+		} {
+			if got := ClassifyRefine(instruction); got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q): 全文/正文 names a PART of the container, so this asks for the material itself: %+v", instruction, got)
+			}
+		}
+	})
+
+	// A container in front of a document part must never be erased, across the
+	// whole frame space. Pinned as a sweep because three consecutive rounds found
+	// families that example-by-example pinning did not predict.
+	t.Run("<container><part> never strips", func(t *testing.T) {
+		containers := []string{"群消息", "对话记录", "聊天记录", "群聊", "频道", "子区", "会话", "对话", "消息", "群", "频道消息", "子区消息"}
+		parts := []string{"正文", "全文"}
+		verbs := []string{"翻译", "精简", "简化", "缩短", "压缩", "删减", "润色", "排版", "重写", "改写", "提炼", "重新组织", "翻译成英文", "用英文重写"}
+		for _, c := range containers {
+			for _, p := range parts {
+				for _, v := range verbs {
+					for _, instruction := range []string{
+						v + c + p, "把" + c + p + v, "帮我" + v + c + p, v + "一下" + c + p,
+						"请" + v + c + p, v + c + p + "吧", "把" + c + p + v + "成英文",
+					} {
+						if got := ClassifyRefine(instruction); got.HardNoFetch {
+							t.Errorf("ClassifyRefine(%q) strips the fetch tools: %+v", instruction, got)
+						}
+					}
+				}
+			}
+		}
+	})
+
+	// The other direction: with no container in front, a document part is an
+	// ordinary filler and the request is pure text, so it must still strip.
+	t.Run("a bare document part still strips", func(t *testing.T) {
+		for _, instruction := range []string{
+			"翻译正文", "润色一下正文", "把全文翻译成英文", "精简全文",
+		} {
+			if got := ClassifyRefine(instruction); !got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q) is a pure-text edit of the artifact: %+v", instruction, got)
+			}
+		}
+	})
+}
+
+// TestRefineArtifactNounsAreValidAdjacencyTargets covers the half of
+// refineArtifactNouns' contract that nothing tested before (#206 round-2
+// suggestion 2): the single-source-of-truth refactor made that list load-bearing
+// in TWO places, and only the filler half had coverage.
+//
+// Every member must work as an adjacency target — <container><artifact> is a
+// modifier construction and strips — which is exactly the property 正文 / 全文
+// failed. A future addition to this list is only legitimate if it satisfies this.
+func TestRefineArtifactNounsAreValidAdjacencyTargets(t *testing.T) {
+	for _, artifact := range refineArtifactNouns {
+		for _, container := range []string{"群", "频道", "对话记录"} {
+			instruction := "把这份" + container + artifact + "翻译成英文"
+			if got := ClassifyRefine(instruction); !got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q): %q is in refineArtifactNouns, so a container modifying it must be structural: %+v",
+					instruction, artifact, got)
+			}
+		}
+	}
+}

--- a/internal/agent/refine_route_test.go
+++ b/internal/agent/refine_route_test.go
@@ -636,3 +636,69 @@ func TestRefineStripNeedsResidueAndQuantifierTogether(t *testing.T) {
 		}
 	})
 }
+
+// TestRefineContainerAdjacencyIsJudgedOnSourceText pins the #206 P1-1
+// (yujiawei): stripModifierContainers must read adjacency from the ORIGINAL
+// instruction, never from a keyword-stripped intermediate.
+//
+// The positional rule's whole content is "a container followed, optionally
+// through 的, by an artifact noun is a modifier". Adjacency is a property of what
+// the user typed. When the rule ran after keyword removal, deleting whatever sat
+// BETWEEN the container and the artifact noun manufactured an adjacency that
+// never existed — 把群消息改写成总结 became 把群消息总结, the container was erased
+// as "structural", the residue went empty and the tools were removed from a
+// request that can only be satisfied by fetching.
+//
+// It was also self-inconsistent: 改写第十群消息 keeps its tools (pinned above),
+// while appending a destination artifact — which makes the request MORE clearly a
+// compile-from-material, not less — stripped them.
+func TestRefineContainerAdjacencyIsJudgedOnSourceText(t *testing.T) {
+	t.Run("reported strings keep their tools", func(t *testing.T) {
+		for _, instruction := range []string{
+			"把群消息改写成总结",
+			"把聊天记录改写成纪要",
+			"把频道消息改写成报告",
+			"把对话记录改写成摘要",
+			"把子区消息改写成文档",
+			"把群消息换成总结",
+			"帮我把群消息改写成总结",
+		} {
+			if got := ClassifyRefine(instruction); got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q): the container is the OBJECT of the rewrite verb, not a modifier of the artifact — this is a compile-from-material request: %+v", instruction, got)
+			}
+		}
+	})
+
+	// The sweep the review used to find the class. A single miss here means the
+	// ordering regressed, so it is pinned as a whole rather than by example.
+	t.Run("把<container><rewrite-verb><artifact> never strips", func(t *testing.T) {
+		containers := []string{"群消息", "对话记录", "聊天记录", "群聊", "频道", "子区", "会话", "对话"}
+		verbs := []string{"改写成", "换成", "翻译成", "精简成", "压缩成", "提炼成", "重写", "改写"}
+		artifacts := []string{"总结", "摘要", "报告", "纪要", "文档"}
+		for _, c := range containers {
+			for _, v := range verbs {
+				for _, a := range artifacts {
+					instruction := "把" + c + v + a
+					if got := ClassifyRefine(instruction); got.HardNoFetch {
+						t.Errorf("ClassifyRefine(%q) strips the fetch tools: %+v", instruction, got)
+					}
+				}
+			}
+		}
+	})
+
+	// The other direction must survive the reordering: when the container really
+	// IS adjacent to the artifact noun in the source text, it is a modifier and
+	// the request still strips.
+	t.Run("genuine modifiers still strip", func(t *testing.T) {
+		for _, instruction := range []string{
+			"把这份群总结翻译成英文",
+			"精简一下群消息总结",
+			"对话记录的总结润色一下",
+		} {
+			if got := ClassifyRefine(instruction); !got.HardNoFetch {
+				t.Errorf("ClassifyRefine(%q): the container modifies the artifact noun in the source text, so this is pure text: %+v", instruction, got)
+			}
+		}
+	})
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -71,6 +71,17 @@ func NewRunner(client chatter, reg *Registry, pool *Pool, policy Policy) *Runner
 	return &Runner{client: client, reg: reg, pool: pool, policy: policy}
 }
 
+// ToolSchemas exposes the tool schemas this runner will offer the model, so a
+// caller can assert WHICH toolset a runner was built with. SS-08b removes the
+// data-fetching tools for a confident rewrite, and that decision is only
+// observable through the registry the runner ended up holding. Nil-safe.
+func (r *Runner) ToolSchemas() []Tool {
+	if r == nil || r.reg == nil {
+		return nil
+	}
+	return r.reg.Schemas()
+}
+
 // Run 无状态单轮入口：委托 RunWithHistory（history=nil），保持旧签名零回归。
 func (r *Runner) Run(ctx context.Context, system, userInput string) (string, error) {
 	reply, _, err := r.RunWithHistory(ctx, system, nil, userInput)

--- a/internal/agent/summary_v2.go
+++ b/internal/agent/summary_v2.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 )
@@ -38,3 +40,32 @@ func SummaryV2Mode() string {
 
 // SummaryV2Enabled reports whether any non-off mode is active.
 func SummaryV2Enabled() bool { return SummaryV2Mode() != V2ModeOff }
+
+// HardStripEnvVar is the runtime kill switch for the SS-08b tool strip.
+const HardStripEnvVar = "AGENT_SUMMARY_HARD_STRIP"
+
+// RefineHardStripEnabled reports whether a HardNoFetch verdict may be ACTED ON
+// (fetch tools physically removed) rather than merely computed and logged.
+//
+// Default false, and deliberately an ENV read rather than a compile-time const:
+// the strip is the one decision in this contract that a runtime mistake cannot
+// undo — buildRunnerForProfile removes list/narrow/find/peek/fetch/search/filter
+// outright, so a misclassified request for new data becomes impossible to satisfy
+// with no recovery path, and it is silent (fetch_expected=0 on the rewrite path,
+// so the finish gate has nothing to flag). Reverting it must not require a
+// rebuild.
+//
+// It additionally requires mode == on, so `shadow` stays a true observe-only
+// stage: classify + persist + log tools_stripped=, never strip. That is the
+// rollout order this work committed to — measure the false-positive rate on real
+// traffic, then flip — rather than arguing it from a pinned example set. Three
+// consecutive review rounds each found a NEW systematic false-positive family
+// that the pinned suite did not predict, which is the empirical case for keeping
+// the switch off by default.
+func RefineHardStripEnabled() bool {
+	if SummaryV2Mode() != V2ModeOn {
+		return false
+	}
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(HardStripEnvVar)))
+	return err == nil && enabled
+}

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -204,20 +204,19 @@ var refineRewriteToolNames = []string{
 // refineHardStripEnforced decides whether a HardNoFetch verdict is ACTED ON
 // (tools physically removed) or merely computed and logged.
 //
-// It is false in this PR by design. HardNoFetch is the only decision in the V2
+// The core PR landed this false: HardNoFetch is the only decision in the V2
 // contract that a runtime mistake cannot undo — buildRunnerForProfile removes
 // list/narrow/find/peek/fetch/search/filter outright, so a misclassified request
-// for new data becomes impossible to satisfy with no recovery path. The
-// classifier that produces the verdict is still converging (see the SS-08/08b
-// follow-up PR), and the asymmetry is brutal: a false negative costs a few unused
-// tool schemas in the prompt, a false positive costs an unsatisfiable request.
+// for new data becomes impossible to satisfy with no recovery path — and the
+// classifier was still converging.
 //
-// So the route is classified, persisted (fetch_expected) and logged on every
-// refine turn — which is what SS-11 and the finish gate consume — while the
-// physical strip stays off until the classifier's false-positive rate is measured
-// against real traffic rather than argued from examples. Flipping this to true is
-// the single switch that enables SS-08b enforcement.
-const refineHardStripEnforced = false
+// It is true here because the classifier's decision now rests on two independent
+// conjuncts that must agree (rewriteResidueEmpty ∧ allClausesCarryARewriteKeyword,
+// see ClassifyRefine), each closing a class the other provably cannot, plus the
+// positional container rule. The judgement set is pinned in refine_route_test.go:
+// every must-keep string from rounds 4-10 and every must-strip string, both
+// directions, in one suite that any vocabulary change has to pass.
+const refineHardStripEnforced = true
 
 // buildSummaryRegistryWithUID builds the full summary registry with uid injected.
 func (h *AgentChatHandler) buildSummaryRegistryWithUID(uid, sessionID string) (*agent.Registry, error) {

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -444,6 +444,32 @@ func (h *AgentChatHandler) attachToolErrorHook(runner *agent.Runner, userID, run
 	}
 }
 
+// refineStripsFetchTools decides whether THIS turn hands the model the restricted
+// rewrite toolset. It is the single expression behind the SS-08b strip, extracted
+// so the behavioural change is testable and observable rather than being an
+// inline conjunction repeated on the two entry points (#206 P2-1).
+//
+// All three terms are load-bearing: V2 must be on and the turn must be a refine
+// (refineActive), the classifier must have reached a confident-rewrite verdict
+// (HardNoFetch), and enforcement must be enabled (refineHardStripEnforced).
+func refineStripsFetchTools(refineActive bool, route agent.RefineRoute) bool {
+	return refineHardStripEnforced && refineActive && route.HardNoFetch
+}
+
+// logRefineRoute records the route, and marks the turn distinctly when the fetch
+// tools were actually removed.
+//
+// The strip is the one decision here a runtime mistake cannot undo, and it is
+// otherwise invisible: fetch_expected is 0 on the rewrite path, so a wrongly
+// stripped turn cannot surface as PARTIAL/FAILED through the finish gate either
+// (#206 P2-4). This line is what makes the false-positive rate countable in
+// production — grep tools_stripped=true — which is the evidence #205 asked for
+// before enforcement was enabled.
+func logRefineRoute(sessionID string, route agent.RefineRoute, stripped bool) {
+	log.Printf("[agent] refine route session=%s intent=%s fetch=%t hardNoFetch=%t tools_stripped=%t",
+		sessionID, route.Intent, route.Fetch, route.HardNoFetch, stripped)
+}
+
 // refineFetchExpected reports whether the turn will actually gather data, which
 // is what the finish gate's FetchExpected must reflect. It is route.Fetch for a
 // refine turn and always true for a normal summary run. Keying this on
@@ -614,7 +640,7 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 		runner = h.testRunner
 		system = h.testSystem
 	} else {
-		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, refineHardStripEnforced && refineActive && refineRoute.HardNoFetch)
+		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, refineStripsFetchTools(refineActive, refineRoute))
 		if err != nil {
 			log.Printf("[agent] build runner for profile %q: %v", profileName, err)
 			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to initialize agent", Detail: safeErrorDetail(err)})
@@ -668,7 +694,7 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 	// byte-identical. Route was classified once above.
 	if refineActive {
 		system = system + agent.BuildRefineGuidance(refineRoute)
-		log.Printf("[agent] refine route session=%s intent=%s fetch=%t hardNoFetch=%t", req.SessionID, refineRoute.Intent, refineRoute.Fetch, refineRoute.HardNoFetch)
+		logRefineRoute(req.SessionID, refineRoute, refineStripsFetchTools(refineActive, refineRoute))
 	}
 
 	history = agent.TruncateHistory(history, h.window)
@@ -905,7 +931,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 		runner = h.testRunner
 		system = h.testSystem
 	} else {
-		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, refineHardStripEnforced && refineActive && refineRoute.HardNoFetch)
+		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, refineStripsFetchTools(refineActive, refineRoute))
 		if err != nil {
 			log.Printf("[agent] build runner for profile %q: %v", profileName, err)
 			sink := &sseSink{w: c.Writer}
@@ -962,7 +988,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 	// v2-gated → flag-off byte-identical. Route was classified once above.
 	if refineActive {
 		system = system + agent.BuildRefineGuidance(refineRoute)
-		log.Printf("[agent] refine route session=%s intent=%s fetch=%t hardNoFetch=%t", req.SessionID, refineRoute.Intent, refineRoute.Fetch, refineRoute.HardNoFetch)
+		logRefineRoute(req.SessionID, refineRoute, refineStripsFetchTools(refineActive, refineRoute))
 	}
 
 	history = agent.TruncateHistory(history, h.window)

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -196,27 +196,14 @@ var defaultSummaryToolNames = []string{
 // the data-discovery/fetch tools (list/narrow/find/peek/fetch/search/filter) are
 // dropped, leaving only time + local summarize/merge, so a pure rewrite cannot
 // fetch new data. Citations are preserved via borrowCitationsFromReference.
+//
+// Whether a verdict is ACTED ON is decided at runtime by
+// agent.RefineHardStripEnabled (AGENT_SUMMARY_HARD_STRIP, default off); see
+// refineStripsFetchTools.
 var refineRewriteToolNames = []string{
 	"get_current_time", "extract_time_range",
 	"summarize_chunk", "merge_summaries",
 }
-
-// refineHardStripEnforced decides whether a HardNoFetch verdict is ACTED ON
-// (tools physically removed) or merely computed and logged.
-//
-// The core PR landed this false: HardNoFetch is the only decision in the V2
-// contract that a runtime mistake cannot undo — buildRunnerForProfile removes
-// list/narrow/find/peek/fetch/search/filter outright, so a misclassified request
-// for new data becomes impossible to satisfy with no recovery path — and the
-// classifier was still converging.
-//
-// It is true here because the classifier's decision now rests on two independent
-// conjuncts that must agree (rewriteResidueEmpty ∧ allClausesCarryARewriteKeyword,
-// see ClassifyRefine), each closing a class the other provably cannot, plus the
-// positional container rule. The judgement set is pinned in refine_route_test.go:
-// every must-keep string from rounds 4-10 and every must-strip string, both
-// directions, in one suite that any vocabulary change has to pass.
-const refineHardStripEnforced = true
 
 // buildSummaryRegistryWithUID builds the full summary registry with uid injected.
 func (h *AgentChatHandler) buildSummaryRegistryWithUID(uid, sessionID string) (*agent.Registry, error) {
@@ -449,11 +436,23 @@ func (h *AgentChatHandler) attachToolErrorHook(runner *agent.Runner, userID, run
 // so the behavioural change is testable and observable rather than being an
 // inline conjunction repeated on the two entry points (#206 P2-1).
 //
-// All three terms are load-bearing: V2 must be on and the turn must be a refine
-// (refineActive), the classifier must have reached a confident-rewrite verdict
-// (HardNoFetch), and enforcement must be enabled (refineHardStripEnforced).
+// All three terms are load-bearing: enforcement must be enabled at RUNTIME
+// (agent.RefineHardStripEnabled — env-driven, default off, and requires mode==on
+// so `shadow` stays observe-only), the turn must be a refine (refineActive), and
+// the classifier must have reached a confident-rewrite verdict (HardNoFetch).
+//
+// What guards a MISCLASSIFICATION is not the enforcement flag but the classifier
+// itself, and it is worth being precise about which part: for a multi-clause
+// instruction, rewriteResidueEmpty and allClausesCarryARewriteKeyword each close
+// a family the other cannot. For a SINGLE unpunctuated clause — the most common
+// phrasing, and where both of the last two false-positive families lived — the
+// quantifier is satisfied by the very keyword that selected the rewrite branch,
+// so it contributes nothing; there the decision rests entirely on
+// rewriteResidueEmpty plus the positional container rule. That asymmetry is why
+// this flag defaults to off: the single-clause case is guarded by one test, not
+// two, and its false-positive rate is a measurement rather than an argument.
 func refineStripsFetchTools(refineActive bool, route agent.RefineRoute) bool {
-	return refineHardStripEnforced && refineActive && route.HardNoFetch
+	return agent.RefineHardStripEnabled() && refineActive && route.HardNoFetch
 }
 
 // logRefineRoute records the route, and marks the turn distinctly when the fetch
@@ -636,11 +635,18 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 	var runner *agent.Runner
 	var system string
 	var err error
+	// toolsStripped records what was ACTUALLY passed to buildRunnerForProfile, so
+	// the log line below reports the toolset the model really got. Recomputing the
+	// predicate there would claim tools_stripped=true on the injected-runner path,
+	// which keeps its tools — and this line is the sole evidence channel for the
+	// strip's false-positive rate, so it has to be structurally honest.
+	toolsStripped := false
 	if h.testRunner != nil {
 		runner = h.testRunner
 		system = h.testSystem
 	} else {
-		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, refineStripsFetchTools(refineActive, refineRoute))
+		toolsStripped = refineStripsFetchTools(refineActive, refineRoute)
+		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, toolsStripped)
 		if err != nil {
 			log.Printf("[agent] build runner for profile %q: %v", profileName, err)
 			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to initialize agent", Detail: safeErrorDetail(err)})
@@ -694,7 +700,7 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 	// byte-identical. Route was classified once above.
 	if refineActive {
 		system = system + agent.BuildRefineGuidance(refineRoute)
-		logRefineRoute(req.SessionID, refineRoute, refineStripsFetchTools(refineActive, refineRoute))
+		logRefineRoute(req.SessionID, refineRoute, toolsStripped)
 	}
 
 	history = agent.TruncateHistory(history, h.window)
@@ -927,11 +933,14 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 	var runner *agent.Runner
 	var system string
 	var err error
+	// See Chat: log what was actually handed to the runner, not a recomputation.
+	toolsStripped := false
 	if h.testRunner != nil {
 		runner = h.testRunner
 		system = h.testSystem
 	} else {
-		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, refineStripsFetchTools(refineActive, refineRoute))
+		toolsStripped = refineStripsFetchTools(refineActive, refineRoute)
+		runner, system, err = h.buildRunnerForProfile(profileName, uid, req.SessionID, toolsStripped)
 		if err != nil {
 			log.Printf("[agent] build runner for profile %q: %v", profileName, err)
 			sink := &sseSink{w: c.Writer}
@@ -988,7 +997,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 	// v2-gated → flag-off byte-identical. Route was classified once above.
 	if refineActive {
 		system = system + agent.BuildRefineGuidance(refineRoute)
-		logRefineRoute(req.SessionID, refineRoute, refineStripsFetchTools(refineActive, refineRoute))
+		logRefineRoute(req.SessionID, refineRoute, toolsStripped)
 	}
 
 	history = agent.TruncateHistory(history, h.window)

--- a/internal/api/handler/agent_chat_refine_registry_test.go
+++ b/internal/api/handler/agent_chat_refine_registry_test.go
@@ -53,3 +53,58 @@ func TestRefineRewriteRegistryExcludesFetch(t *testing.T) {
 		}
 	}
 }
+
+// TestRefineStripsFetchToolsGatesOnAllThreeTerms pins the #206 P2-1: the strip
+// decision is the behavioural change of this PR and had no test of its own.
+//
+// Nothing asserted that a HardNoFetch=true route actually reaches
+// buildRunnerForProfile with refineNoFetch=true, so an edit to the conjunction —
+// or a revert of refineHardStripEnforced — would have failed no test at all.
+func TestRefineStripsFetchToolsGatesOnAllThreeTerms(t *testing.T) {
+	confident := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: true}
+	soft := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: false}
+	augment := agent.RefineRoute{Intent: agent.RefineAugment, Fetch: true}
+
+	if got := refineStripsFetchTools(true, confident); got != refineHardStripEnforced {
+		t.Errorf("refine + confident rewrite: strip = %v, want %v (the enforcement constant)", got, refineHardStripEnforced)
+	}
+	// Every other combination must keep the tools regardless of the constant.
+	for _, tc := range []struct {
+		name         string
+		refineActive bool
+		route        agent.RefineRoute
+	}{
+		{"not a refine turn", false, confident},
+		{"soft rewrite keeps its tools so a mis-read can recover", true, soft},
+		{"an augment route fetches by definition", true, augment},
+	} {
+		if refineStripsFetchTools(tc.refineActive, tc.route) {
+			t.Errorf("%s: must NOT strip the fetch tools", tc.name)
+		}
+	}
+}
+
+// TestRefineStripReachesTheRunner closes the loop the previous test cannot: that
+// the decision actually changes the toolset the model receives.
+func TestRefineStripReachesTheRunner(t *testing.T) {
+	h := &AgentChatHandler{}
+	confident := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: true}
+
+	stripped, _, err := h.buildRunnerForProfile("summary_refine", "u1", "s1", refineStripsFetchTools(true, confident))
+	if err != nil {
+		t.Fatalf("build stripped runner: %v", err)
+	}
+	kept, _, err := h.buildRunnerForProfile("summary_refine", "u1", "s1", false)
+	if err != nil {
+		t.Fatalf("build full runner: %v", err)
+	}
+
+	strippedHasFetch := schemaNameSet(stripped.ToolSchemas())["fetch_channel"]
+	if strippedHasFetch != !refineHardStripEnforced {
+		t.Errorf("confident-rewrite runner has fetch_channel = %v; with refineHardStripEnforced=%v it must be %v",
+			strippedHasFetch, refineHardStripEnforced, !refineHardStripEnforced)
+	}
+	if !schemaNameSet(kept.ToolSchemas())["fetch_channel"] {
+		t.Error("a non-stripped summary_refine runner must always keep fetch_channel")
+	}
+}

--- a/internal/api/handler/agent_chat_refine_registry_test.go
+++ b/internal/api/handler/agent_chat_refine_registry_test.go
@@ -59,16 +59,17 @@ func TestRefineRewriteRegistryExcludesFetch(t *testing.T) {
 //
 // Nothing asserted that a HardNoFetch=true route actually reaches
 // buildRunnerForProfile with refineNoFetch=true, so an edit to the conjunction —
-// or a revert of refineHardStripEnforced — would have failed no test at all.
+// or a change to the enforcement switch — would have failed no test at all.
 func TestRefineStripsFetchToolsGatesOnAllThreeTerms(t *testing.T) {
 	confident := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: true}
 	soft := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: false}
 	augment := agent.RefineRoute{Intent: agent.RefineAugment, Fetch: true}
 
-	if got := refineStripsFetchTools(true, confident); got != refineHardStripEnforced {
-		t.Errorf("refine + confident rewrite: strip = %v, want %v (the enforcement constant)", got, refineHardStripEnforced)
+	enableHardStrip(t)
+	if !refineStripsFetchTools(true, confident) {
+		t.Error("refine + confident rewrite + enforcement on: must strip the fetch tools")
 	}
-	// Every other combination must keep the tools regardless of the constant.
+	// Every other combination must keep the tools even with enforcement ON.
 	for _, tc := range []struct {
 		name         string
 		refineActive bool
@@ -84,27 +85,70 @@ func TestRefineStripsFetchToolsGatesOnAllThreeTerms(t *testing.T) {
 	}
 }
 
-// TestRefineStripReachesTheRunner closes the loop the previous test cannot: that
-// the decision actually changes the toolset the model receives.
+// TestRefineStripIsOffByDefault pins the rollout contract: enforcement is opt-in
+// at runtime, and `shadow` stays a true observe-only stage (classify + log,
+// never strip). A confident-rewrite verdict is computed identically in every
+// case below — only whether it is ACTED ON changes.
+func TestRefineStripIsOffByDefault(t *testing.T) {
+	confident := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: true}
+
+	for _, tc := range []struct {
+		name, mode, strip string
+	}{
+		{"unset env with v2 on", "on", ""},
+		{"explicitly disabled", "on", "false"},
+		{"malformed value fails safe", "on", "yes-please"},
+		{"shadow is observe-only even when asked to strip", "shadow", "true"},
+		{"off mode never strips", "off", "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_SUMMARY_V2_MODE", tc.mode)
+			t.Setenv(agent.HardStripEnvVar, tc.strip)
+			if refineStripsFetchTools(true, confident) {
+				t.Error("the tool strip must not fire; it is opt-in and requires mode=on")
+			}
+		})
+	}
+}
+
+// enableHardStrip turns enforcement on for one test, restored automatically.
+func enableHardStrip(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENT_SUMMARY_V2_MODE", agent.V2ModeOn)
+	t.Setenv(agent.HardStripEnvVar, "true")
+}
+
+// TestRefineStripReachesTheRunner closes the loop the previous tests cannot:
+// that the decision actually changes the toolset the model receives.
 func TestRefineStripReachesTheRunner(t *testing.T) {
 	h := &AgentChatHandler{}
 	confident := agent.RefineRoute{Intent: agent.RefineRewrite, HardNoFetch: true}
 
+	enableHardStrip(t)
 	stripped, _, err := h.buildRunnerForProfile("summary_refine", "u1", "s1", refineStripsFetchTools(true, confident))
 	if err != nil {
 		t.Fatalf("build stripped runner: %v", err)
 	}
+	if schemaNameSet(stripped.ToolSchemas())["fetch_channel"] {
+		t.Error("enforcement is on and the verdict is a confident rewrite: fetch_channel must be gone")
+	}
+
 	kept, _, err := h.buildRunnerForProfile("summary_refine", "u1", "s1", false)
 	if err != nil {
 		t.Fatalf("build full runner: %v", err)
 	}
-
-	strippedHasFetch := schemaNameSet(stripped.ToolSchemas())["fetch_channel"]
-	if strippedHasFetch != !refineHardStripEnforced {
-		t.Errorf("confident-rewrite runner has fetch_channel = %v; with refineHardStripEnforced=%v it must be %v",
-			strippedHasFetch, refineHardStripEnforced, !refineHardStripEnforced)
-	}
 	if !schemaNameSet(kept.ToolSchemas())["fetch_channel"] {
 		t.Error("a non-stripped summary_refine runner must always keep fetch_channel")
+	}
+
+	// And with enforcement off — the default — the same verdict leaves the
+	// toolset intact, which is what makes the observation window safe.
+	t.Setenv(agent.HardStripEnvVar, "false")
+	observeOnly, _, err := h.buildRunnerForProfile("summary_refine", "u1", "s1", refineStripsFetchTools(true, confident))
+	if err != nil {
+		t.Fatalf("build observe-only runner: %v", err)
+	}
+	if !schemaNameSet(observeOnly.ToolSchemas())["fetch_channel"] {
+		t.Error("with enforcement off the verdict is recorded only; fetch_channel must remain")
 	}
 }


### PR DESCRIPTION
## 目标

改进 SS-08/08b 的 refine 分类器,并把零抓取强制(工具物理裁剪)从编译期常量改为**运行时开关、默认关闭**。

> #205 已合并(`fcafc6f`),本分支已 rebase 到新 main,diff 只含本 PR 自己的改动。

**本 PR 自己的改动是 3 个 commit、6 个文件**(`e419966` → `b22d776` → `5ebe403`):

| 文件 | 内容 |
|---|---|
| `internal/agent/refine_route.go` | 分类器:双合取判据 + 位置化容器规则 |
| `internal/agent/refine_route_test.go` | 双向判例(含多个 sweep) |
| `internal/agent/summary_v2.go` | **新增** `RefineHardStripEnabled()` 运行时开关 |
| `internal/api/handler/agent_chat.go` | 接开关 + `logRefineRoute` |
| `internal/api/handler/agent_chat_refine_registry_test.go` | 开关两态测试 |
| `internal/agent/runner.go` | **新增导出方法** `(*Runner).ToolSchemas()` |

⚠️ 请特别注意后两项:`(*Runner).ToolSchemas()` 是**新增的公开 API**(生产类型上的导出方法,当前唯一消费者是测试),`summary_v2.go` 引入了新的环境变量。这两处不在最初的说明里,感谢 @yujiawei 指出。

### 与 #205 的关系

#205 把 `refineHardStripEnforced` 设为 false —— 路由照常分类、持久化、打日志,但物理裁剪不生效。

本 PR **不再翻这个常量**,而是把它替换成运行时开关 `agent.RefineHardStripEnabled()`:读 `AGENT_SUMMARY_HARD_STRIP`、**默认 false**、格式错误 fail safe,并且额外要求 `mode == on`,让 `shadow` 恢复成真正的观测阶段(分类 + 持久化 + 打 `tools_stripped=` 日志,但不裁剪)。

这正是 #205 里写下的退出条件:**等误判率被真实流量测出来,而不是靠例子论证**。上一版把常量翻成 true 是靠 pin 表论证的,不自洽,已纠正。

## 契约

沿用 #205 的 C1–C3(scope 定义、`fetch_expected` 承诺、失败分级),本 PR 只推进 C4。

### C4. hard strip 的误判方向

- 这是整个 V2 契约里**唯一不可在运行期挽回**的决策:`buildRunnerForProfile` 把 list/narrow/find/peek/fetch/search/filter 整组移除,误判后请求永远无法满足,模型无法自救。
- 误判成本严重不对称:漏摘 = prompt 里多几个没用的工具 schema;错摘 = 请求不可满足。**默认不摘,存疑保留工具。**
- 判据:**残余为空 ∧ 每个标点子句都带改写关键词 ∧ 无时间词**,三者取合取才摘。

## 为什么是合取,而不是换一个更好的单一判据

#203 的 refine 分类器改了 7 轮,每轮都是"换一个更准的测试",每轮都在下一轮被新一族措辞打穿。本 PR 的结论是:**这两个测试各自能关掉对方结构上关不掉的一类,所以它们是合取项,不是备选项。**

**1. `rewriteResidueEmpty`** —— 删掉匹配到的改写关键词和结构性填充词后,是否什么内容性的东西都不剩。

关掉的是**无连接词粘连的添加**:`翻译成英文补一些运营数据`。被加的内容名词会存活到残余里,所以不需要任何连接词表 —— round 4–9 反复证明封闭连接词表不收敛(也/还要/顺手/此外/捎带…每轮迟到一个)。

关不掉的是**整个子句由填充词构成**。因为填充词表必须把产物名词(摘要/总结/报告)、容器名词、通用调整动词(整理/组织/调整)算作结构性,否则 `把这份群总结翻译成英文` 这类纯文本请求就不再裁剪,SS-08b 等于没开。但 `总结` 同时是"summarize"这个动词,`整理`/`组织` 同时是"从素材编纂"的动词 —— 于是 **"编纂动词 + 容器" 这个索取数据的最典型说法,残余也是空的**。

**2. `allClausesCarryARewriteKeyword`** —— 每个标点分隔的子句是否都自带改写关键词。

正好关掉上面那一类:`精简一下，整理频道消息` 的第二个子句不含任何改写关键词,所以保留工具。

关不掉的是**单子句、且确实带改写关键词的粘连添加** —— 也就是残余测试负责的那类。

两者互不包含,所以取合取:这是唯一不可挽回的决策,两个判据必须同时同意才动手。

子句切分只依据标点、**刻意不含任何连接词表**;量词漏掉的无标点粘连,由残余项兜住。

## 容器名词改为位置规则

合取式本身还不够。实测发现另有 3 条(跨模型独立发现,round-10 提及)仍被硬摘:

```
翻译频道消息                        单子句、带改写关键词 → 量词无效
改写第十群消息                      残余为空(容器名词是填充词)→ 残余项无效
请整理第三子区内的聊天记录并重写总结     同上
```

根因:容器名词(群/频道/子区/消息/对话记录…)在原实现里是**无条件**填充词。但它只有在**修饰产物名词**时才是结构性的:

```
把这份群总结翻译成英文    群 修饰 总结      → 结构性 → 残余空 → 裁剪
翻译频道消息             频道消息 独立出现  → 就是素材 → 保留工具
```

一个词不可能既是填充词又不是填充词,所以扁平词表无法同时满足两边 —— 改成位置规则 `stripModifierContainers`:容器名词后面(可跨一个"的")紧跟产物名词才删除,其余位置保留。循环执行到不动点,因为删掉一个修饰语可能产生新的相邻关系(`群频道总结`);方向是安全的 —— 容器被保留只会让残余非空,即保留工具。

## 判例

`TestRefineStripNeedsResidueAndQuantifierTogether` 钉住 15 条 must-keep 回归 + 3 条 must-strip 修饰语案例;`TestRefineContainerAdjacencyIsJudgedOnSourceText` 钉住 round-1 CR 报的 7 条 + 完整的 320 条 sweep。与 rounds 4–9 既有的 must-keep / must-strip 套件并存。任何后续词表改动都必须先跑通这一整套双向判例。

15 条 must-keep 里有 12 条是"编纂动词 + 容器"(量词负责),3 条是单子句容器宾语(位置规则负责)。

## Credit

合取结构由 yujiawei 在 round-10 review 中提出并实测(44/44 must-keep,19/19 must-strip)。容器位置规则是本 PR 追加的 —— 只用合取式时,上述 3 条跨模型案例仍会被硬摘,这里经实测确认。

## 开关与回退

`AGENT_SUMMARY_V2_MODE` off ⇒ 逐字节不变;`ClassifyRefine` 仅在 `refineActive` 之后可达。若需回退强制而保留分类改进,把 `refineHardStripEnforced` 翻回 false 即可,是单个常量。

## 验证

- `CGO_ENABLED=0 go build ./...` 干净
- `CGO_ENABLED=0 go vet ./...` 干净
- `CGO_ENABLED=0 go test ./...` 全绿
- 分类器双向判例:15 条 must-keep 回归 + 3 条 must-strip 修饰语案例,加上 320 条 `把<容器><改写动词><产物>` sweep,全部实测通过(含原有全部套件)



---

## Round-1 CR 修复(commit `b22d776`,原 `1b8813f`)

### P1-1(阻塞)—— 容器相邻性改为在原文上判定

**这是我引入的顺序 bug,reviewer 的分析完全正确。** `stripModifierContainers` 原本跑在改写关键词删除**之后**,于是"删掉夹在容器和产物名词中间的那个关键词"会**制造出原文里不存在的相邻关系**:

```
把群消息改写成总结 → 删掉 改写成 → 把群消息总结 → 群消息 此时"修饰"总结
                  → 被当结构性抹掉 → 残余为空 → 工具被摘
```

这正是本 PR 要保护的"从素材编纂"那一类,而且和我自己 pin 的判例自相矛盾:`改写第十群消息` 保留工具,但补上目的地名词反而被摘 —— 加目的地明明**更**像编纂请求。

改成在原文上判定后,`群消息` 后面跟的是 `改写成` 而不是产物名词,所以它是素材、存活到残余、工具保留。

采用了 reviewer 建议的调序。已 pin:CR 报的 7 条 + 完整 320 条 `把<容器><改写动词><产物>` sweep(8 容器 × 8 动词 × 5 产物),以及原有 3 条真修饰语 must-strip 案例(它们在原文里本来就相邻,不受影响)。

关于"单子句时第二个合取项恒真"的观察 —— 成立,我接受。单子句无标点输入下 `allClausesCarryARewriteKeyword` 确实被选中分支的同一个关键词自动满足,决策实际退化为残余判定 + 容器规则。body 里"两个独立判据必须同时同意"的说法对这一类输入不准确,已在此说明。这也正是为什么 P1-1 那个顺序错误影响面这么大。

### P2-1 —— 裁剪决策提取为 `refineStripsFetchTools()` 并加测试

两个方向都测了:三个条件项各自都是 gate(`TestRefineStripsFetchToolsGatesOnAllThreeTerms`),以及这个决策**确实改变了 runner 拿到的工具集**(`TestRefineStripReachesTheRunner`,经新增的 `Runner.ToolSchemas` 访问器)。之前改内联合取式或回退常量都不会让任何测试失败。

### P2-2 —— `refineArtifactNouns` 成为该词表的单一真源

`refineResidueFillersByLen` 现在按引用追加它,不再由字面量重复一份。位置规则和填充词 pass 必须对"什么是产物名词"达成一致,手工同步会静默失效。

### P2-3 —— `stripModifierContainers` 线性化

改为右到左预计算"从此处开始的容器/的 链是否终结于产物名词",保留了原先 fixpoint 循环的传递性(`群频道总结`),去掉了 O(removals × len × |containers|) 的重启扫描。

### P2-4 —— 路由日志加 `tools_stripped`

`fetch_expected` 在改写路径上是 0,误裁的轮次无法通过 finish gate 暴露,所以日志是唯一信号。现在 grep `tools_stripped=true` 即可统计这个不可逆决策的实际触发率。

### Nit —— 已修正

上面「验证」一节的 "6/6 must-strip" 是笔误,实为 3 条 must-strip 修饰语案例,已改。

感谢 @yujiawei 的 review,尤其是那个 sweep —— 我原先只按单条案例验证,没做组合扫描,所以漏掉了整整一类。



---

## Round-2 CR 修复(commit `5ebe403`,原 `5b4c872`)

### P1-1(阻塞)—— `正文`/`全文` 不再作为相邻性目标

**成立,已修。** `refineArtifactNouns` 承担两个职责 —— 残余填充词、以及 `stripModifierContainers` 里相邻性判定的右侧 —— 这两个职责需要**不同的词表**。

作为填充词,`正文`/`全文` 怎么放都一样(`翻译正文`、`把全文翻译成英文` 仍正确裁剪);作为相邻性目标它们是错的:这两个词命名的是**文档部件**,跟 `段落`/`章节`/`开头` 一家。`<容器>全文` 的意思是"容器的全文",那恰恰是原始素材,不是从容器产出的东西。

结果和上一轮同形,而且和本 PR 自己 pin 的判例直接冲突:
```
翻译频道消息       保留工具(本 PR pin 的 must-keep)
翻译频道消息全文    被硬摘 ← 加"全文"让它更像素材,却翻转了判决
```

采用了你建议的两行移动。已 pin:
- 报告的 9 条原串
- **完整 sweep**:12 容器 × 2 部件 × 14 动词 × 7 框架 = 2352 条,实测 `stripped=0`
- 反向:`翻译正文` / `润色一下正文` / `把全文翻译成英文` / `精简全文` 仍正确裁剪

另外按你的建议 2,新增 `TestRefineArtifactNounsAreValidAdjacencyTargets`,覆盖这个列表**从未被测过的那一半**:每个成员都必须能作为合法的相邻性目标(`<容器><产物>` 构成修饰关系并裁剪)。这正是 `正文`/`全文` 不满足的性质 —— 以后往这个列表里加词,必须先过这一关。

### P2-2(采纳)—— 强制改为运行时开关,默认关闭

**你的升级建议我同意,并且这本来就是 #205 里我自己写下的退出条件。**

`refineHardStripEnforced`(编译期 const,true)已替换为 `agent.RefineHardStripEnabled()`:

- 读 `AGENT_SUMMARY_HARD_STRIP`,**默认 false**
- 格式错误的值 fail safe(不进裁剪路径)
- 额外要求 `mode == on`,所以 **`shadow` 恢复为真正的观测阶段**:分类 + 持久化 + 打 `tools_stripped=` 日志,但绝不裁剪

回滚那个"运行期无法撤销"的决策,现在不需要重新编译和部署了。

关于你说的"三轮不收敛" —— 我认同你的判断:

- 第 10 轮:容器名被当作无条件填充词
- 第 11 轮:相邻性在关键词删除**之后**判定(这条是我引入的)
- 第 12 轮:`正文`/`全文` 被当作相邻性目标

每次修复都正确、最小、改完套件全绿,然后套件又预测不到下一族。这确实说明**词法分类器无法靠往表里加例子,validate 到"不可逆且静默"这种操作所要求的置信度**。所以按你说的把两半解耦:分类器改进(可证明比 #205 更保守)先落地,强制留在开关后面,拿真实流量的 `tools_stripped=` 数据说话。

### P2-1(采纳)—— 文档改正:单子句下量词是恒真的

`refineStripsFetchTools` 的注释已重写,明确说明单子句情况下真正起保护作用的是什么:∀ 量词会被选中改写分支的**同一个关键词**自动满足,所以对这一大类输入(也是最近两个误判族的所在地)它不贡献任何约束,决策实际只靠 `rewriteResidueEmpty` + 位置化容器规则。

这个不对称正是开关默认关闭的理由 —— 单子句路径只有一个判据把关,它的误判率应该是**测量出来的**,不是论证出来的。

### Nit(采纳)—— 日志诚实性

`logRefineRoute` 现在报告**真正传给 `buildRunnerForProfile` 的值**(经局部变量 `toolsStripped`),不再重算谓词。注入 runner 的测试路径不会再出现"日志说裁了、实际没裁"。既然这行日志是误判率的唯一证据通道,它必须在结构上诚实。

### P2-3 / 其余 nit

- `refineSourceNouns` 与 `refineOriginContainers` 的差异属于有意为之(路由 vs 裁剪,方向成本不同),但你说得对,值得加注释防止后续轮次"修错方向"。这条我记下了,可以放本轮或下轮。
- `改写成中文`、`删掉最后一段` 两个假阴性:都倒向保留工具这一安全侧,记录在案。
- `stripModifierContainers` 的字节偏移与 rune 步进混用:当前正确(所有容器常量都是合法 UTF-8,你的 40 万串差分模糊测试也确认了),值得补一行注释固化这个不变量。

## 验证

- `gofmt` 干净,`CGO_ENABLED=0 go vet ./...` 干净
- `CGO_ENABLED=0 go test ./...` 全绿
- P1-1 sweep:2352/2352 保留工具;反向 4 条仍正确裁剪
- 开关两态均有测试:开启时确实裁剪、默认/`shadow`/格式错误时确实不裁剪

## 现状

- #205 已合并(`fcafc6f`),本分支已 rebase 到其上(`git rebase --onto`,零冲突)
- rebase 后重新验证:`CGO_ENABLED=1 go build ./...`、`go test ./internal/...`、`go test -race ./internal/...` 全绿;gofmt 干净;对 main 的 merge 预演 0 冲突
- `check-sprint` 仍红:关联 issue 未挂 Sprint W31,需要有 Board 权限的人手动挂上
