### PR TITLE
perf(agent): Map 阶段有界并发 —— summarize_chunk 串行导致大请求撞破 300s SSE 上限 (AGENT_MAP_CONCURRENCY)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,6 +29,7 @@ All configuration is done via environment variables.
 | `WORKER_LISTEN_ADDR` | Listen address for worker server | No | `0.0.0.0` |
 | `WORKER_MAX_CONCURRENT_TASKS` | Max concurrent worker tasks | No | `20` |
 | `WORKER_MAP_CONCURRENCY` | Concurrency for map-phase LLM calls | No | `5` |
+| `AGENT_MAP_CONCURRENCY` | How many Map-phase chunk summaries ONE `summarize_chunk` tool call runs in parallel (agent path only). Clamped to `[1, 5]`; unset/0/negative resolve to the default. Deliberately separate from `WORKER_MAP_CONCURRENCY`: the agent runner already executes up to 4 tool calls from a single LLM turn concurrently (`agent.NewPool(4)`), so the two knobs MULTIPLY — at the default the ceiling of in-flight Map completions from one user request is 4×3=12, before the LLM client's own 3-attempt retry budget. Set to `1` to take a dedicated serial path identical to the pre-concurrency loop (rollback without redeploying). | No | `3` |
 | `WORKER_POLL_INTERVAL_SECONDS` | Task polling interval in seconds | No | `2` |
 | `WORKER_TASK_LEASE_MINUTES` | Task lease duration in minutes | No | `20` |
 | `WORKER_MAX_RETRY` | Maximum retry attempts for failed tasks | No | `3` |

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
@@ -369,15 +371,9 @@ func SummarizeChunkTool() (Tool, Handler) {
 		// call summarizes toward the user's actual requirements. Empty when V2 is
 		// off / no run / no spec → legacy generic prompt.
 		specGuidance := loadRunSpecGuidance(ctx)
-		var summaries []string
-		for _, chunk := range chunks {
-			summary, processed, oversized, err := summarizeMessagesChunk(ctx, chunk, specGuidance)
-			if err != nil {
-				return "", fmt.Errorf("summarize chunk: %w", err)
-			}
-			summaries = append(summaries, summary)
-			cov.ProcessedCount += processed
-			cov.OversizedMessageCount += oversized
+		summaries, err := summarizeChunksConcurrently(ctx, chunks, specGuidance, &cov)
+		if err != nil {
+			return "", err
 		}
 		cov.DroppedCount = cov.InputCount - cov.ProcessedCount
 		cov.Truncated = cov.DroppedCount > 0
@@ -520,4 +516,120 @@ func assignCitationIndexes(messages []pipeline.Message, citationMap map[string]i
 		kept = append(kept, messages[i])
 	}
 	return kept, manifestMisses
+}
+
+// summarizeChunkFn is the Map call seam. Production always uses
+// summarizeMessagesChunk; tests swap it to drive concurrency/order/error
+// behaviour deterministically without a live LLM. It is only reassigned from
+// tests, before any goroutine starts, so it needs no synchronisation.
+var summarizeChunkFn = summarizeMessagesChunk
+
+// chunkMapOutcome is one Map call's result, held in a slot indexed by chunk
+// position. Every field is written by exactly one goroutine and read only after
+// wg.Wait(), so no field needs synchronisation of its own.
+type chunkMapOutcome struct {
+	summary   string
+	processed int
+	oversized int
+	err       error
+}
+
+// summarizeChunksConcurrently runs the Map phase over chunks with bounded
+// concurrency and returns the summaries in ORIGINAL chunk order, aggregating
+// coverage counters into cov.
+//
+// Why this is not a plain `go` over the old loop body:
+//
+//   - Order. Callers join the summaries into one document and the [n] citation
+//     markers inside them index a frozen manifest, so a completion-ordered
+//     append would reorder the deliverable. Results land in outcomes[i], never
+//     appended, so output order is independent of completion order.
+//   - Coverage counters. The serial loop incremented cov.ProcessedCount /
+//     cov.OversizedMessageCount inside the loop body. Those are plain ints on a
+//     shared struct; incrementing them from N goroutines is a data race and
+//     would silently under-count coverage — the exact class of defect SS-01
+//     exists to prevent. They are accumulated here, after Wait, in index order.
+//   - Error determinism. The serial loop failed on the first chunk by position.
+//     With concurrency, "first error to arrive" varies run to run, so the same
+//     input could surface different errors. This waits for every started
+//     goroutine and reports the LOWEST-INDEX error, preserving the old
+//     behaviour exactly.
+//   - Cancellation. Acquiring the semaphore selects on ctx.Done(): when the
+//     request deadline fires, queued chunks abort immediately instead of
+//     waiting for an in-flight LLM call to release a slot.
+//
+// Concurrency 1 takes a dedicated serial path (see below) rather than a
+// one-permit semaphore, so it is a true rollback switch.
+func summarizeChunksConcurrently(ctx context.Context, chunks [][]map[string]interface{}, specGuidance string, cov *chunkCoverage) ([]string, error) {
+	_, _, _, cfg := GetSummaryDeps()
+	concurrency := cfg.ResolveAgentMapConcurrency()
+
+	// Concurrency 1 is the documented rollback setting, so it must reproduce the
+	// pre-change loop EXACTLY — including dispatch order. A 1-permit semaphore
+	// would still only run one call at a time, but the goroutines race for that
+	// permit, so chunk 3 could be sent to the model before chunk 0. Output order
+	// would survive (indexed slots), but "identical to before" would not: an
+	// operator flipping this to 1 to debug a model-side ordering effect would
+	// still not be running the old code path. Short-circuit instead.
+	if concurrency <= 1 {
+		summaries := make([]string, 0, len(chunks))
+		for i, chunk := range chunks {
+			summary, processed, oversized, err := summarizeChunkFn(ctx, chunk, specGuidance)
+			if err != nil {
+				return nil, fmt.Errorf("summarize chunk %d: %w", i, err)
+			}
+			summaries = append(summaries, summary)
+			cov.ProcessedCount += processed
+			cov.OversizedMessageCount += oversized
+		}
+		return summaries, nil
+	}
+
+	outcomes := make([]chunkMapOutcome, len(chunks))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	start := time.Now()
+	for i, chunk := range chunks {
+		wg.Add(1)
+		go func(idx int, c []map[string]interface{}) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				outcomes[idx] = chunkMapOutcome{err: ctx.Err()}
+				return
+			}
+			defer func() { <-sem }()
+
+			// Re-check after acquiring. select picks uniformly among READY cases,
+			// so a goroutine can win the permit released by a call that just
+			// aborted on cancellation — dispatching a fresh LLM request for a
+			// request the client already gave up on. Without this guard a
+			// cancelled run still burns up to `concurrency` extra completions.
+			if err := ctx.Err(); err != nil {
+				outcomes[idx] = chunkMapOutcome{err: err}
+				return
+			}
+
+			summary, processed, oversized, err := summarizeChunkFn(ctx, c, specGuidance)
+			outcomes[idx] = chunkMapOutcome{summary: summary, processed: processed, oversized: oversized, err: err}
+		}(i, chunk)
+	}
+	wg.Wait()
+
+	log.Printf("[summarize_chunk] map phase: chunks=%d concurrency=%d elapsed=%dms",
+		len(chunks), concurrency, time.Since(start).Milliseconds())
+
+	summaries := make([]string, 0, len(chunks))
+	for i, o := range outcomes {
+		if o.err != nil {
+			// Lowest-index error wins (see doc comment): deterministic across runs.
+			return nil, fmt.Errorf("summarize chunk %d: %w", i, o.err)
+		}
+		summaries = append(summaries, o.summary)
+		cov.ProcessedCount += o.processed
+		cov.OversizedMessageCount += o.oversized
+	}
+	return summaries, nil
 }

--- a/internal/agent/tool_summarize_chunk_concurrency_test.go
+++ b/internal/agent/tool_summarize_chunk_concurrency_test.go
@@ -1,0 +1,268 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+)
+
+// Map-phase concurrency tests. All of them swap summarizeChunkFn, so none of
+// them touches a real LLM; they assert the four properties the concurrent Map
+// path must preserve relative to the previous serial loop: bounded fan-out,
+// original output order, deterministic (lowest-index) error, and prompt
+// cancellation.
+
+// withMapConcurrency installs cfg.AgentMapConcurrency for the duration of a
+// test and restores whatever deps were set before.
+func withMapConcurrency(t *testing.T, n int) {
+	t.Helper()
+	summaryDB, imDB, octoClient, prev := func() (a, b interface{}, c interface{}, cfg config.Config) {
+		defer func() { _ = recover() }() // deps may be unset in a fresh package run
+		db, im, oc, cf := GetSummaryDeps()
+		return db, im, oc, cf
+	}()
+	_ = summaryDB
+	_ = imDB
+	_ = octoClient
+
+	cfg := prev
+	cfg.AgentMapConcurrency = n
+	SetSummaryDeps(nil, nil, nil, cfg)
+	t.Cleanup(func() { SetSummaryDeps(nil, nil, nil, prev) })
+}
+
+// withStubMapCall swaps the Map seam and restores it afterwards.
+func withStubMapCall(t *testing.T, fn func(ctx context.Context, chunk []map[string]interface{}, specGuidance string) (string, int, int, error)) {
+	t.Helper()
+	prev := summarizeChunkFn
+	summarizeChunkFn = fn
+	t.Cleanup(func() { summarizeChunkFn = prev })
+}
+
+func makeChunks(n int) [][]map[string]interface{} {
+	chunks := make([][]map[string]interface{}, n)
+	for i := range chunks {
+		chunks[i] = []map[string]interface{}{{"content": fmt.Sprintf("chunk-%d", i)}}
+	}
+	return chunks
+}
+
+// The semaphore must cap in-flight Map calls at the configured concurrency.
+func TestSummarizeChunksConcurrently_RespectsConcurrencyLimit(t *testing.T) {
+	const concurrency = 3
+	withMapConcurrency(t, concurrency)
+
+	var inFlight, maxInFlight int64
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		cur := atomic.AddInt64(&inFlight, 1)
+		for {
+			old := atomic.LoadInt64(&maxInFlight)
+			if cur <= old || atomic.CompareAndSwapInt64(&maxInFlight, old, cur) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt64(&inFlight, -1)
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(6), "", &cov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 6 {
+		t.Fatalf("got %d summaries, want 6", len(got))
+	}
+	if maxInFlight > concurrency {
+		t.Fatalf("max in-flight Map calls = %d, want <= %d", maxInFlight, concurrency)
+	}
+	if maxInFlight < 2 {
+		t.Fatalf("max in-flight Map calls = %d — calls never overlapped, concurrency is not in effect", maxInFlight)
+	}
+}
+
+// Completion order must not affect output order: the joined document and its
+// [n] citation markers depend on chunk position.
+func TestSummarizeChunksConcurrently_PreservesChunkOrder(t *testing.T) {
+	withMapConcurrency(t, 5)
+
+	// Finish in reverse: the last chunk returns first.
+	const n = 5
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		id := chunk[0]["content"].(string)
+		var idx int
+		if _, err := fmt.Sscanf(id, "chunk-%d", &idx); err != nil {
+			t.Errorf("unexpected chunk payload %q", id)
+		}
+		time.Sleep(time.Duration(n-idx) * 15 * time.Millisecond)
+		return id, 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(n), "", &cov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, s := range got {
+		if want := fmt.Sprintf("chunk-%d", i); s != want {
+			t.Fatalf("summaries[%d] = %q, want %q — completion order leaked into output order", i, s, want)
+		}
+	}
+}
+
+// Coverage counters were incremented inside the old serial loop. Aggregating
+// them concurrently would be a data race and would under-count; assert the
+// totals are exact. Run this one under -race for full value.
+func TestSummarizeChunksConcurrently_AggregatesCoverageExactly(t *testing.T) {
+	withMapConcurrency(t, 4)
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		return "s", 7, 2, nil
+	})
+
+	cov := chunkCoverage{InputCount: 70}
+	if _, err := summarizeChunksConcurrently(context.Background(), makeChunks(10), "", &cov); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cov.ProcessedCount != 70 {
+		t.Fatalf("ProcessedCount = %d, want 70", cov.ProcessedCount)
+	}
+	if cov.OversizedMessageCount != 20 {
+		t.Fatalf("OversizedMessageCount = %d, want 20", cov.OversizedMessageCount)
+	}
+}
+
+// The serial loop failed on the first chunk BY POSITION. With concurrency,
+// "first error to arrive" is nondeterministic, so the lowest index must win.
+func TestSummarizeChunksConcurrently_ReturnsLowestIndexError(t *testing.T) {
+	withMapConcurrency(t, 5)
+
+	errEarly := errors.New("chunk 1 failed")
+	errLate := errors.New("chunk 4 failed")
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		id := chunk[0]["content"].(string)
+		switch id {
+		case "chunk-4":
+			return "", 0, 0, errLate // fails immediately
+		case "chunk-1":
+			time.Sleep(40 * time.Millisecond) // fails last
+			return "", 0, 0, errEarly
+		}
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	_, err := summarizeChunksConcurrently(context.Background(), makeChunks(5), "", &cov)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(err, errEarly) {
+		t.Fatalf("got %v, want the lowest-index error %v — error selection is not deterministic", err, errEarly)
+	}
+}
+
+// A single chunk failure must fail the whole tool: no partial deliverable.
+func TestSummarizeChunksConcurrently_OneFailureFailsAll(t *testing.T) {
+	withMapConcurrency(t, 3)
+	boom := errors.New("boom")
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		if chunk[0]["content"].(string) == "chunk-2" {
+			return "", 0, 0, boom
+		}
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(4), "", &cov)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if got != nil {
+		t.Fatalf("expected no summaries on failure, got %d — partial output must not escape", len(got))
+	}
+}
+
+// Queued chunks must abort on cancellation instead of waiting for an in-flight
+// LLM call to release a semaphore slot.
+func TestSummarizeChunksConcurrently_CancelReleasesQueuedChunks(t *testing.T) {
+	withMapConcurrency(t, 1) // everything after the first chunk queues on the semaphore
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var started sync.WaitGroup
+	started.Add(1)
+	var once sync.Once
+	var calls int64
+
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		atomic.AddInt64(&calls, 1)
+		once.Do(started.Done)
+		<-ctx.Done() // first call blocks until cancellation
+		return "", 0, 0, ctx.Err()
+	})
+
+	done := make(chan struct{})
+	var cov chunkCoverage
+	var err error
+	go func() {
+		_, err = summarizeChunksConcurrently(ctx, makeChunks(8), "", &cov)
+		close(done)
+	}()
+
+	started.Wait()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("summarizeChunksConcurrently did not return after cancellation — queued chunks are not selecting on ctx.Done()")
+	}
+	if err == nil {
+		t.Fatal("expected a cancellation error, got nil")
+	}
+	if n := atomic.LoadInt64(&calls); n > 1 {
+		t.Fatalf("%d Map calls started after cancellation, want 1 — queued chunks should abort at the semaphore", n)
+	}
+}
+
+// Concurrency 1 must behave exactly like the previous serial loop: one call at
+// a time, in order. This is the documented rollback path.
+func TestSummarizeChunksConcurrently_ConcurrencyOneIsSerial(t *testing.T) {
+	withMapConcurrency(t, 1)
+
+	var mu sync.Mutex
+	var order []string
+	var inFlight, maxInFlight int64
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		cur := atomic.AddInt64(&inFlight, 1)
+		if cur > atomic.LoadInt64(&maxInFlight) {
+			atomic.StoreInt64(&maxInFlight, cur)
+		}
+		id := chunk[0]["content"].(string)
+		mu.Lock()
+		order = append(order, id)
+		mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+		atomic.AddInt64(&inFlight, -1)
+		return id, 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(4), "", &cov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if maxInFlight != 1 {
+		t.Fatalf("max in-flight = %d with concurrency 1, want 1", maxInFlight)
+	}
+	for i := range got {
+		if want := fmt.Sprintf("chunk-%d", i); got[i] != want || order[i] != want {
+			t.Fatalf("serial path diverged at %d: got %q order %q, want %q", i, got[i], order[i], want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,13 @@ type Config struct {
 	WorkerInternalPort        string
 	WorkerListenAllInterfaces string
 
+	// AgentMapConcurrency bounds how many Map-phase chunk summaries a single
+	// summarize_chunk tool call runs in parallel (agent path). Deliberately
+	// SEPARATE from WorkerMapConcurrency: the agent path already runs up to 4
+	// tool calls concurrently (agent.NewPool(4) in agent_chat.go), so the two
+	// knobs multiply and must be tuned independently.
+	AgentMapConcurrency int
+
 	// Worker
 	WorkerMaxConcurrent  int
 	WorkerMapConcurrency int
@@ -202,6 +209,8 @@ func Load() *Config {
 
 		WorkerInternalPort:        envStr("WORKER_INTERNAL_PORT", "8082"),
 		WorkerListenAllInterfaces: envStr("WORKER_LISTEN_ADDR", "0.0.0.0"),
+
+		AgentMapConcurrency: envInt("AGENT_MAP_CONCURRENCY", defaultAgentMapConcurrency),
 
 		WorkerMaxConcurrent:        envInt("WORKER_MAX_CONCURRENT_TASKS", 20),
 		WorkerMapConcurrency:       envInt("WORKER_MAP_CONCURRENCY", 5),
@@ -353,6 +362,40 @@ var modelMapThresholds = []modelThreshold{
 }
 
 const defaultMapMaxTokens = 100000
+
+const (
+	// defaultAgentMapConcurrency is the agent Map-phase fan-out default.
+	//
+	// 3, not the worker path's 5: the agent runner executes up to 4 tool calls
+	// from one LLM turn concurrently (agent.NewPool(4)), and each of those can
+	// be a summarize_chunk. The knobs multiply, so the real ceiling of in-flight
+	// Map calls is poolSize * AgentMapConcurrency = 12 at this default — before
+	// the LLM client's own 3-attempt retry budget. The worker path has no such
+	// outer fan-out, which is why its default can be higher.
+	defaultAgentMapConcurrency = 3
+	// maxAgentMapConcurrency caps operator input. Above this the gateway sees
+	// 4*N concurrent completions from a single user request.
+	maxAgentMapConcurrency = 5
+)
+
+// ResolveAgentMapConcurrency returns the effective agent Map fan-out, clamped
+// to [1, maxAgentMapConcurrency].
+//
+// 1 is the serial fallback: it makes the concurrent path byte-equivalent to the
+// pre-change loop (one worker, one in-flight call, same order, same error), so
+// an operator can revert the behaviour with an env var instead of a rollback.
+// Values <= 0 (unset / malformed / explicitly disabled) resolve to the default
+// rather than to 0, which would deadlock a zero-capacity semaphore.
+func (c *Config) ResolveAgentMapConcurrency() int {
+	n := c.AgentMapConcurrency
+	if n <= 0 {
+		n = defaultAgentMapConcurrency
+	}
+	if n > maxAgentMapConcurrency {
+		n = maxAgentMapConcurrency
+	}
+	return n
+}
 
 // ResolveCharsPerTokenCJK returns the CJK chars-per-token ratio.
 // For qwen/deepseek/kimi models, defaults to 2 if not explicitly configured.

--- a/internal/config/config_agent_map_test.go
+++ b/internal/config/config_agent_map_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+// ResolveAgentMapConcurrency guards operator input: the value multiplies with
+// the agent runner's outer tool pool (agent.NewPool(4)), so an unbounded or
+// zero value is not merely odd — 0 would deadlock a zero-capacity semaphore and
+// a large value fans out 4*N concurrent completions from one user request.
+func TestResolveAgentMapConcurrency(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"unset -> default", 0, defaultAgentMapConcurrency},
+		{"negative -> default", -3, defaultAgentMapConcurrency},
+		{"one -> serial rollback path", 1, 1},
+		{"in range -> kept", 4, 4},
+		{"at cap -> kept", maxAgentMapConcurrency, maxAgentMapConcurrency},
+		{"over cap -> clamped", maxAgentMapConcurrency + 10, maxAgentMapConcurrency},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := Config{AgentMapConcurrency: c.in}
+			if got := cfg.ResolveAgentMapConcurrency(); got != c.want {
+				t.Fatalf("ResolveAgentMapConcurrency(%d) = %d, want %d", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// The resolved value must never be 0: summarizeChunksConcurrently sizes a
+// buffered channel with it, and make(chan struct{}, 0) blocks forever.
+func TestResolveAgentMapConcurrency_NeverZero(t *testing.T) {
+	for _, in := range []int{-100, -1, 0} {
+		cfg := Config{AgentMapConcurrency: in}
+		if got := cfg.ResolveAgentMapConcurrency(); got < 1 {
+			t.Fatalf("ResolveAgentMapConcurrency(%d) = %d — a zero-capacity semaphore deadlocks the Map phase", in, got)
+		}
+	}
+}
+
+// The agent knob must stay independent of the worker knob: they apply to
+// different code paths and only the agent one multiplies with a tool pool.
+func TestAgentAndWorkerMapConcurrencyAreIndependent(t *testing.T) {
+	cfg := Config{AgentMapConcurrency: 2, WorkerMapConcurrency: 5}
+	if got := cfg.ResolveAgentMapConcurrency(); got != 2 {
+		t.Fatalf("agent resolve = %d, want 2 (worker value must not leak in)", got)
+	}
+	if cfg.WorkerMapConcurrency != 5 {
+		t.Fatalf("worker value = %d, want 5 (agent resolve must not mutate it)", cfg.WorkerMapConcurrency)
+	}
+}


### PR DESCRIPTION
## 问题

一次 `summarize_chunk` 调用把它的分片**串行**发给 LLM，所以一个大请求要付出每次 Map 调用耗时的**总和**。

实测（1837 条消息、2 个频道）：agent 发出三次 `summarize_chunk`（分片数 3 / 7 / 1），runner 本身把这三次**并发**执行了（`agent.NewPool(4)`），但那个 7 分片的调用光自己就跑了约 140 秒（单次调用 10–27 秒），直接撞破 300 秒的 SSE 请求上限。

worker 路径的 Map 阶段很早就是并发的（`WORKER_MAP_CONCURRENCY`），**只有 agent 路径还是串行**。

## 改动

分片改为在信号量下执行，默认并发 **3**。

### 为什么默认是 3 而不是 5（worker 的默认值）

agent runner 本身已经会把一次 LLM 轮次里的最多 4 个工具调用并行执行，所以两个旋钮是**相乘**的关系 —— 默认值下单个用户请求会有 `4 × 3 = 12` 个在途 completion，这还没算 LLM 客户端自己的 3 次重试预算。`maxAgentMapConcurrency` 把运维可配的上限钉在 5。

用**独立的环境变量**而不是复用 `WORKER_MAP_CONCURRENCY`：两条路径的扇出天花板不同，必须能独立调参。

## 刻意保留的四个性质

串行循环有四个性质是并发化时必须守住的：

- **顺序** —— 结果写进 `outcomes[i]`，绝不 append。所以拼接出的文档、以及索引冻结 manifest 的 `[n]` 引用标记，都不受完成顺序影响。
- **覆盖计数** —— `cov.ProcessedCount` / `OversizedMessageCount` 原本在循环体内自增；从 N 个 goroutine 里自增就是数据竞争，会**静默少计**覆盖率 —— 这正是 SS-01 存在要防的缺陷类型。现在改为 `Wait` 之后按索引顺序累加。
- **错误确定性** —— 串行循环是在**位置上第一个**失败的分片上返回错误。"最先到达的错误"每次运行都可能不同，所以这里等待所有已启动的 goroutine，返回**索引最小**的那个错误。
- **取消** —— 信号量 acquire 在 `ctx.Done()` 上 select，**并且在拿到 permit 之后再检查一次 `ctx.Err()`**：Go 的 select 在多个 case 同时就绪时是均匀随机挑选的，否则一个 goroutine 可能抢到某个刚中止的调用释放出的 permit，然后为一个**已取消的 run** 发出新请求。

## `AGENT_MAP_CONCURRENCY=1` 走的是专用串行路径

不是 1-permit 信号量。在信号量下，多个 goroutine 争抢那唯一一个 permit，**dispatch 顺序仍然是不确定的**，尽管同时只有一个调用在途。运维人员把它调成 1 来排除顺序影响时，实际上并没有跑回旧路径。这个短路让 **1 成为真正的回滚开关**。

## 测试

全部确定性（通过 `summarizeChunkFn` seam，不打真实 LLM）：

- 扇出上界
- 逆序完成时的顺序稳定性
- 精确的覆盖计数总量
- 最小索引错误
- 一个失败则整体失败
- 取消时释放排队中的分片
- 并发 1 的串行等价性
- 加上配置的 clamp / 永不为零 / 与 worker 配置相互独立

## 验证

```
CGO_ENABLED=0 go test ./internal/...              全绿
go test -race ./internal/agent/... ./internal/config/...   干净
go build ./... / go vet                            通过
```

## 注意

本改动**不受 `AGENT_SUMMARY_V2_MODE` 门控** —— 它修的是 `summarize_chunk` 内部的循环，属于线上已激活的 agent 路径。合入即生效。这是有意的：它解决的是线上真实存在的慢。

## 与 #205 / #206 的关系

基于已合入 #205、#206 的 `main`（`f1551ea`）重新 rebase，零冲突。特别核对过 #205 在同一文件引入的 `specGuidance`（SS-06）：它被完整透传进每一个并发分片，SS-06 行为未受影响。
