### PR TITLE
perf(agent): bound Map concurrency and hide summary bodies behind handles

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,6 +29,7 @@ All configuration is done via environment variables.
 | `WORKER_LISTEN_ADDR` | Listen address for worker server | No | `0.0.0.0` |
 | `WORKER_MAX_CONCURRENT_TASKS` | Max concurrent worker tasks | No | `20` |
 | `WORKER_MAP_CONCURRENCY` | Concurrency for map-phase LLM calls | No | `5` |
+| `AGENT_MAP_CONCURRENCY` | How many Map-phase chunk summaries ONE `summarize_chunk` tool call runs in parallel (agent path only). Clamped to `[1, 5]`; unset/0/negative resolve to the default. Deliberately separate from `WORKER_MAP_CONCURRENCY`: the agent runner already executes up to 4 tool calls from a single LLM turn concurrently (`agent.NewPool(4)`), so the two knobs MULTIPLY — at the default the ceiling of in-flight Map completions from one user request is 4×3=12, before the LLM client's own 3-attempt retry budget. Set to `1` to take a dedicated serial path identical to the pre-concurrency loop (rollback without redeploying). | No | `3` |
 | `WORKER_POLL_INTERVAL_SECONDS` | Task polling interval in seconds | No | `2` |
 | `WORKER_TASK_LEASE_MINUTES` | Task lease duration in minutes | No | `20` |
 | `WORKER_MAX_RETRY` | Maximum retry attempts for failed tasks | No | `3` |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,7 +29,7 @@ All configuration is done via environment variables.
 | `WORKER_LISTEN_ADDR` | Listen address for worker server | No | `0.0.0.0` |
 | `WORKER_MAX_CONCURRENT_TASKS` | Max concurrent worker tasks | No | `20` |
 | `WORKER_MAP_CONCURRENCY` | Concurrency for map-phase LLM calls | No | `5` |
-| `AGENT_MAP_CONCURRENCY` | How many Map-phase chunk summaries ONE `summarize_chunk` tool call runs in parallel (agent path only). Clamped to `[1, 5]`; unset/0/negative resolve to the default. Deliberately separate from `WORKER_MAP_CONCURRENCY`: the agent runner already executes up to 4 tool calls from a single LLM turn concurrently (`agent.NewPool(4)`), so the two knobs MULTIPLY — at the default the ceiling of in-flight Map completions from one user request is 4×3=12, before the LLM client's own 3-attempt retry budget. Set to `1` to take a dedicated serial path identical to the pre-concurrency loop (rollback without redeploying). | No | `3` |
+| `AGENT_MAP_CONCURRENCY` | How many Map-phase chunk summaries ONE `summarize_chunk` tool call runs in parallel (agent path only). Clamped to `[1, 5]`; unset/0/negative resolve to the default. Deliberately separate from `WORKER_MAP_CONCURRENCY`: the agent runner already executes up to 4 tool calls from a single LLM turn concurrently (`agent.NewPool(4)`), so the two knobs MULTIPLY — at the default the ceiling of in-flight Map completions from one user request is 4×3=12. Set to `1` to take a dedicated serial path identical to the pre-concurrency loop (rollback without redeploying). | No | `3` |
 | `WORKER_POLL_INTERVAL_SECONDS` | Task polling interval in seconds | No | `2` |
 | `WORKER_TASK_LEASE_MINUTES` | Task lease duration in minutes | No | `20` |
 | `WORKER_MAX_RETRY` | Maximum retry attempts for failed tasks | No | `3` |

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -49,10 +49,28 @@ func TruncateHistory(history []Message, n int) []Message {
 	return history[idx:]
 }
 
+// Compaction placeholders. They are SCHEMA-SHAPED on purpose: the planner is
+// few-shot conditioned by its own transcript, and a rewritten past call that
+// violates the live tool schema teaches it to emit the same malformed call
+// again. merge_summaries declares additionalProperties:false with
+// required:["summary_handles"], so a bare `{"history_compacted":true}` was a
+// worked example of an invalid call sitting in every compacted session — and
+// every merge_summaries failure latches the run fatal until a later merge
+// succeeds (tool_error.go). Same reasoning for the summarize_chunk result shape.
+//
+// The placeholder handle values are deliberately un-resolvable: they must not
+// look like a live handle the model could try to reuse. ResolveAllBefore
+// rejects them with "invalid or expired summary_handle", which is the accurate
+// thing for the model to learn about a previous turn's handles.
 const (
-	compactedMapHistoryResult    = `{"history_compacted":true,"note":"Map summary body omitted; historical handles are expired"}`
-	compactedReduceHistoryResult = `{"history_compacted":true,"note":"Reduce result omitted; use the final assistant message from that turn"}`
-	compactedReduceHistoryArgs   = `{"history_compacted":true}`
+	compactedMapHistoryResult    = `{"summary_handle":"__history__","chunk_count":0,"history_compacted":true,"note":"Map summary body omitted; historical handles are expired"}`
+	compactedReduceHistoryResult = `{"merged_summary":"","chunk_count":0,"history_compacted":true,"note":"Reduce result omitted; use the final assistant message from that turn"}`
+	compactedReduceHistoryArgs   = `{"summary_handles":["__compacted__"]}`
+
+	// Upper bound on merge_summaries arguments kept for a failed historical call.
+	// A handle-protocol call is at most ~128 short handles; anything larger is a
+	// legacy call carrying inlined summary bodies.
+	maxRetainedFailedReduceArgs = 8 << 10
 )
 
 // compactSummaryToolHistory removes duplicate/expired summary payloads from
@@ -63,22 +81,35 @@ const (
 // recreates the post-Map latency this handle protocol is meant to remove.
 //
 // Tool call IDs and result messages are preserved so the OpenAI tool protocol
-// remains paired. Structured/legacy error results stay intact for diagnostics.
+// remains paired. Structured/legacy error results stay intact for diagnostics,
+// and so do the arguments that produced them.
 func compactSummaryToolHistory(history []Message) []Message {
 	if len(history) == 0 {
 		return history
 	}
 	out := make([]Message, len(history))
+	// A tool_call_id whose RESULT was retained as a diagnostic error. Its
+	// arguments are retained too: an error result explains what the model did
+	// wrong, and the mistake IS the arguments, so pairing the complaint with
+	// invented placeholder arguments both destroys the diagnostic and leaves the
+	// preserved exchange internally inconsistent. Results are visited after their
+	// assistant turn in transcript order, so the rewrite is deferred to a second
+	// pass rather than done inline.
+	//
+	// Bounded by maxRetainedFailedReduceArgs: under the handle protocol these
+	// arguments are a short list of handles, but a LEGACY failed merge carried
+	// the full summary bodies, and retaining those would reintroduce exactly the
+	// transcript bloat this function exists to remove. Oversized arguments lose
+	// the diagnostic and take the placeholder — a bad diagnostic is cheaper than
+	// an unbounded prompt.
+	keepArgs := make(map[string]bool)
+	for _, message := range history {
+		if message.Role == "tool" && isHistoricalToolError(message.Content) && message.ToolCallID != "" {
+			keepArgs[message.ToolCallID] = true
+		}
+	}
 	for i, message := range history {
 		out[i] = message
-		if len(message.ToolCalls) > 0 {
-			out[i].ToolCalls = append([]ToolCall(nil), message.ToolCalls...)
-			for j := range out[i].ToolCalls {
-				if out[i].ToolCalls[j].Function.Name == "merge_summaries" {
-					out[i].ToolCalls[j].Function.Arguments = compactedReduceHistoryArgs
-				}
-			}
-		}
 		if message.Role != "tool" || isHistoricalToolError(message.Content) {
 			continue
 		}
@@ -87,6 +118,22 @@ func compactSummaryToolHistory(history []Message) []Message {
 			out[i].Content = compactedMapHistoryResult
 		case "merge_summaries":
 			out[i].Content = compactedReduceHistoryResult
+		}
+	}
+	for i := range out {
+		if len(out[i].ToolCalls) == 0 {
+			continue
+		}
+		out[i].ToolCalls = append([]ToolCall(nil), out[i].ToolCalls...)
+		for j := range out[i].ToolCalls {
+			call := &out[i].ToolCalls[j]
+			if call.Function.Name != "merge_summaries" {
+				continue
+			}
+			if keepArgs[call.ID] && len(call.Function.Arguments) <= maxRetainedFailedReduceArgs {
+				continue
+			}
+			call.Function.Arguments = compactedReduceHistoryArgs
 		}
 	}
 	return out

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"strconv"
 	"strings"
@@ -93,5 +94,11 @@ func compactSummaryToolHistory(history []Message) []Message {
 
 func isHistoricalToolError(content string) bool {
 	trimmed := strings.TrimSpace(content)
-	return strings.HasPrefix(trimmed, "错误:") || strings.Contains(trimmed, `"ok":false`)
+	if strings.HasPrefix(trimmed, "错误:") {
+		return true
+	}
+	var envelope struct {
+		OK *bool `json:"ok"`
+	}
+	return json.Unmarshal([]byte(trimmed), &envelope) == nil && envelope.OK != nil && !*envelope.OK
 }

--- a/internal/agent/history.go
+++ b/internal/agent/history.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 // DefaultHistoryWindow 是滑窗默认保留的"轮"数（env AGENT_HISTORY_WINDOW 覆盖）。
@@ -45,4 +46,52 @@ func TruncateHistory(history []Message, n int) []Message {
 		return history
 	}
 	return history[idx:]
+}
+
+const (
+	compactedMapHistoryResult    = `{"history_compacted":true,"note":"Map summary body omitted; historical handles are expired"}`
+	compactedReduceHistoryResult = `{"history_compacted":true,"note":"Reduce result omitted; use the final assistant message from that turn"}`
+	compactedReduceHistoryArgs   = `{"history_compacted":true}`
+)
+
+// compactSummaryToolHistory removes duplicate/expired summary payloads from
+// PREVIOUS turns before they are sent back to the planner. Legacy sessions may
+// contain tens of thousands of characters both in summarize_chunk tool results
+// and in merge_summaries arguments. The final assistant message already carries
+// the durable user-facing summary, so retaining those intermediate copies only
+// recreates the post-Map latency this handle protocol is meant to remove.
+//
+// Tool call IDs and result messages are preserved so the OpenAI tool protocol
+// remains paired. Structured/legacy error results stay intact for diagnostics.
+func compactSummaryToolHistory(history []Message) []Message {
+	if len(history) == 0 {
+		return history
+	}
+	out := make([]Message, len(history))
+	for i, message := range history {
+		out[i] = message
+		if len(message.ToolCalls) > 0 {
+			out[i].ToolCalls = append([]ToolCall(nil), message.ToolCalls...)
+			for j := range out[i].ToolCalls {
+				if out[i].ToolCalls[j].Function.Name == "merge_summaries" {
+					out[i].ToolCalls[j].Function.Arguments = compactedReduceHistoryArgs
+				}
+			}
+		}
+		if message.Role != "tool" || isHistoricalToolError(message.Content) {
+			continue
+		}
+		switch message.Name {
+		case "summarize_chunk":
+			out[i].Content = compactedMapHistoryResult
+		case "merge_summaries":
+			out[i].Content = compactedReduceHistoryResult
+		}
+	}
+	return out
+}
+
+func isHistoricalToolError(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	return strings.HasPrefix(trimmed, "错误:") || strings.Contains(trimmed, `"ok":false`)
 }

--- a/internal/agent/history_summary_compaction_test.go
+++ b/internal/agent/history_summary_compaction_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,110 @@ func TestCompactSummaryToolHistoryRemovesLegacyBodiesAndKeepsPairs(t *testing.T)
 	}
 	if got[7].Content != compactedMapHistoryResult {
 		t.Fatalf("summary body quoting an ok:false marker should still be compacted: %q", got[7].Content)
+	}
+}
+
+// PR #208 round-5 P2-3. Compaction rewrites past merge_summaries arguments, and
+// the model is few-shot conditioned by its own transcript: a placeholder that
+// violates the LIVE tool schema is a worked example of a malformed call. The
+// schema is additionalProperties:false with required:["summary_handles"], so
+// `{"history_compacted":true}` was exactly that — and every merge_summaries
+// failure latches the run fatal until a later merge succeeds.
+func TestCompactionPlaceholdersMatchTheLiveToolSchemas(t *testing.T) {
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(compactedReduceHistoryArgs), &args); err != nil {
+		t.Fatalf("compacted Reduce arguments are not valid JSON: %v", err)
+	}
+	schema, _ := MergeSummariesTool()
+	params, _ := schema.Function.Parameters.(map[string]interface{})
+	props, _ := params["properties"].(map[string]interface{})
+	if additional, ok := params["additionalProperties"].(bool); !ok || additional {
+		t.Fatal("test assumes merge_summaries forbids additional properties")
+	}
+	for key := range args {
+		if _, declared := props[key]; !declared {
+			t.Fatalf("compacted Reduce arguments carry %q, which additionalProperties:false forbids: %s",
+				key, compactedReduceHistoryArgs)
+		}
+	}
+	for _, required := range params["required"].([]string) {
+		if _, present := args[required]; !present {
+			t.Fatalf("compacted Reduce arguments omit required field %q: %s", required, compactedReduceHistoryArgs)
+		}
+	}
+	handles, ok := args["summary_handles"].([]interface{})
+	if !ok || len(handles) < 1 {
+		t.Fatalf("summary_handles must satisfy minItems:1: %s", compactedReduceHistoryArgs)
+	}
+	// The placeholder must not be mistaken for a live handle. Real handles are
+	// minted as map_<uuid>_<n>; this one resolves to nothing.
+	store := newSummaryHandleStore()
+	if _, err := store.ResolveAll([]string{handles[0].(string)}); err == nil {
+		t.Fatal("the placeholder handle must never resolve against a real store")
+	}
+
+	// The Map placeholder is a summarize_chunk RESULT, so it must parse as one:
+	// the planner reads summary_handle out of it to build the next Reduce call.
+	var mapResult summarizeChunkToolResult
+	if err := json.Unmarshal([]byte(compactedMapHistoryResult), &mapResult); err != nil {
+		t.Fatalf("compacted Map result does not parse as a summarize_chunk result: %v", err)
+	}
+	if mapResult.SummaryHandle == "" {
+		t.Fatalf("compacted Map result has no summary_handle field: %s", compactedMapHistoryResult)
+	}
+	if _, err := store.ResolveAll([]string{mapResult.SummaryHandle}); err == nil {
+		t.Fatal("the placeholder Map handle must never resolve against a real store")
+	}
+}
+
+// A RETAINED diagnostic error result must keep the arguments that caused it.
+// The rewrite used to run BEFORE the error check, so the model was shown a
+// complaint about a call it was simultaneously shown never making.
+func TestCompactionKeepsArgumentsThatProducedARetainedError(t *testing.T) {
+	badArgs := `{"summary_handles":["map_stale_7"]}`
+	history := []Message{
+		{Role: "user", Content: "old request"},
+		{Role: "assistant", ToolCalls: []ToolCall{mkToolCall("reduce-bad", "merge_summaries", badArgs)}},
+		{Role: "tool", ToolCallID: "reduce-bad", Name: "merge_summaries",
+			Content: `{"ok":false,"error_code":"INVALID_ARGUMENT","message":"invalid or expired summary_handle: map_stale_7"}`},
+		{Role: "assistant", ToolCalls: []ToolCall{mkToolCall("reduce-ok", "merge_summaries", `{"summary_handles":["map_live_1"]}`)}},
+		{Role: "tool", ToolCallID: "reduce-ok", Name: "merge_summaries", Content: `{"merged_summary":"body","chunk_count":1}`},
+	}
+
+	got := compactSummaryToolHistory(history)
+	if got[1].ToolCalls[0].Function.Arguments != badArgs {
+		t.Fatalf("arguments of a retained error were rewritten to %q; the preserved exchange no longer shows what failed",
+			got[1].ToolCalls[0].Function.Arguments)
+	}
+	if got[2].Content != history[2].Content {
+		t.Fatalf("diagnostic error result was compacted away: %q", got[2].Content)
+	}
+	// The SUCCESSFUL call still gets compacted — its arguments carry no
+	// diagnostic value and its result is reproduced by the final answer.
+	if got[3].ToolCalls[0].Function.Arguments != compactedReduceHistoryArgs {
+		t.Fatalf("successful Reduce arguments were not compacted: %q", got[3].ToolCalls[0].Function.Arguments)
+	}
+	if got[4].Content != compactedReduceHistoryResult {
+		t.Fatalf("successful Reduce result was not compacted: %q", got[4].Content)
+	}
+}
+
+// Retaining a failed call's arguments must not reintroduce transcript bloat: a
+// LEGACY failed merge carried the full summary bodies inline, which is exactly
+// what this function exists to strip.
+func TestCompactionDropsOversizedRetainedFailureArguments(t *testing.T) {
+	legacyBody := strings.Repeat("legacy-inline-body-", 5000)
+	history := []Message{
+		{Role: "user", Content: "old request"},
+		{Role: "assistant", ToolCalls: []ToolCall{mkToolCall("reduce-huge", "merge_summaries", `{"summaries":["`+legacyBody+`"]}`)}},
+		{Role: "tool", ToolCallID: "reduce-huge", Name: "merge_summaries", Content: `{"ok":false,"message":"boom"}`},
+	}
+	got := compactSummaryToolHistory(history)
+	if strings.Contains(got[1].ToolCalls[0].Function.Arguments, legacyBody[:100]) {
+		t.Fatal("an oversized failed-call argument blob was retained into the planner prompt")
+	}
+	if got[1].ToolCalls[0].Function.Arguments != compactedReduceHistoryArgs {
+		t.Fatalf("oversized arguments = %q, want the placeholder", got[1].ToolCalls[0].Function.Arguments)
 	}
 }
 

--- a/internal/agent/history_summary_compaction_test.go
+++ b/internal/agent/history_summary_compaction_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCompactSummaryToolHistoryRemovesLegacyBodiesAndKeepsPairs(t *testing.T) {
+	legacyBody := strings.Repeat("legacy-map-body-", 5000)
+	summarizeCall := mkToolCall("map-1", "summarize_chunk", `{"messages_handle":"old-messages"}`)
+	mergeCall := mkToolCall("reduce-1", "merge_summaries", `{"summaries":["`+legacyBody+`"]}`)
+	history := []Message{
+		{Role: "user", Content: "old request"},
+		{Role: "assistant", ToolCalls: []ToolCall{summarizeCall}},
+		{Role: "tool", ToolCallID: "map-1", Name: "summarize_chunk", Content: `{"summary":"` + legacyBody + `"}`},
+		{Role: "assistant", ToolCalls: []ToolCall{mergeCall}},
+		{Role: "tool", ToolCallID: "reduce-1", Name: "merge_summaries", Content: `{"merged_summary":"` + legacyBody + `"}`},
+		{Role: "assistant", Content: "durable final summary"},
+		{Role: "tool", ToolCallID: "error-1", Name: "merge_summaries", Content: `{"ok":false,"message":"keep this error"}`},
+	}
+
+	got := compactSummaryToolHistory(history)
+	if !strings.Contains(history[2].Content, legacyBody[:100]) || !strings.Contains(history[3].ToolCalls[0].Function.Arguments, legacyBody[:100]) {
+		t.Fatal("compaction mutated caller-owned history")
+	}
+	for _, msg := range got {
+		if strings.Contains(msg.Content, legacyBody[:100]) {
+			t.Fatalf("legacy body remained in message content: %+v", msg)
+		}
+		for _, call := range msg.ToolCalls {
+			if strings.Contains(call.Function.Arguments, legacyBody[:100]) {
+				t.Fatalf("legacy body remained in tool arguments: %+v", call)
+			}
+		}
+	}
+	if got[1].ToolCalls[0].ID != "map-1" || got[2].ToolCallID != "map-1" || got[3].ToolCalls[0].ID != "reduce-1" || got[4].ToolCallID != "reduce-1" {
+		t.Fatalf("tool call/result pairing changed: %+v", got)
+	}
+	if got[5].Content != "durable final summary" {
+		t.Fatalf("final assistant summary was changed: %+v", got[5])
+	}
+	if got[6].Content != history[6].Content {
+		t.Fatalf("historical tool error should be preserved: %q", got[6].Content)
+	}
+}
+
+func TestRunnerCompactsLegacySummaryHistoryBeforePlanner(t *testing.T) {
+	legacyBody := strings.Repeat("legacy-large-body-", 5000)
+	history := []Message{
+		{Role: "user", Content: "old request"},
+		{Role: "assistant", ToolCalls: []ToolCall{mkToolCall("map-1", "summarize_chunk", `{"messages_handle":"old"}`)}},
+		{Role: "tool", ToolCallID: "map-1", Name: "summarize_chunk", Content: `{"summary":"` + legacyBody + `"}`},
+		{Role: "assistant", ToolCalls: []ToolCall{mkToolCall("reduce-1", "merge_summaries", `{"summaries":["`+legacyBody+`"]}`)}},
+		{Role: "tool", ToolCallID: "reduce-1", Name: "merge_summaries", Content: `{"merged_summary":"` + legacyBody + `"}`},
+		{Role: "assistant", Content: "old final"},
+	}
+	client := &fakeClient{turns: []AssistantTurn{{Content: "new final"}}}
+	runner := NewRunner(client, NewRegistry(), NewPool(1), Policy{MaxSteps: 2, MaxTokens: 1000, StepTimeout: time.Second})
+	if _, _, err := runner.RunWithHistory(context.Background(), "system", history, "new request"); err != nil {
+		t.Fatalf("RunWithHistory: %v", err)
+	}
+	for _, msg := range client.lastMsgs {
+		if strings.Contains(msg.Content, legacyBody[:100]) {
+			t.Fatalf("legacy body reached planner content: %+v", msg)
+		}
+		for _, call := range msg.ToolCalls {
+			if strings.Contains(call.Function.Arguments, legacyBody[:100]) {
+				t.Fatalf("legacy body reached planner tool arguments: %+v", call)
+			}
+		}
+	}
+}

--- a/internal/agent/history_summary_compaction_test.go
+++ b/internal/agent/history_summary_compaction_test.go
@@ -18,7 +18,8 @@ func TestCompactSummaryToolHistoryRemovesLegacyBodiesAndKeepsPairs(t *testing.T)
 		{Role: "assistant", ToolCalls: []ToolCall{mergeCall}},
 		{Role: "tool", ToolCallID: "reduce-1", Name: "merge_summaries", Content: `{"merged_summary":"` + legacyBody + `"}`},
 		{Role: "assistant", Content: "durable final summary"},
-		{Role: "tool", ToolCallID: "error-1", Name: "merge_summaries", Content: `{"ok":false,"message":"keep this error"}`},
+		{Role: "tool", ToolCallID: "error-1", Name: "merge_summaries", Content: `{"ok": false, "message":"keep this error"}`},
+		{Role: "tool", ToolCallID: "quoted-1", Name: "summarize_chunk", Content: `{"summary":"quoted marker: \"ok\":false should not look like an envelope"}`},
 	}
 
 	got := compactSummaryToolHistory(history)
@@ -43,6 +44,9 @@ func TestCompactSummaryToolHistoryRemovesLegacyBodiesAndKeepsPairs(t *testing.T)
 	}
 	if got[6].Content != history[6].Content {
 		t.Fatalf("historical tool error should be preserved: %q", got[6].Content)
+	}
+	if got[7].Content != compactedMapHistoryResult {
+		t.Fatalf("summary body quoting an ok:false marker should still be compacted: %q", got[7].Content)
 	}
 }
 

--- a/internal/agent/llm.go
+++ b/internal/agent/llm.go
@@ -68,6 +68,7 @@ type chatResponse struct {
 			Content   string     `json:"content"`
 			ToolCalls []ToolCall `json:"tool_calls"`
 		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 	Usage struct {
 		TotalTokens int `json:"total_tokens"`
@@ -167,7 +168,13 @@ func (c *Client) attemptChat(ctx context.Context, model string, msgs []Message, 
 	if len(cr.Choices) == 0 {
 		return AssistantTurn{}, llmfallback.Terminal, fmt.Errorf("empty choices in response")
 	}
-	msg := cr.Choices[0].Message
+	choice := cr.Choices[0]
+	if choice.FinishReason == "length" {
+		// Tool-call arguments can be syntactically present but cut off mid-JSON.
+		// Never dispatch a truncated planner turn as if it were valid.
+		return AssistantTurn{}, false, fmt.Errorf("LLM response truncated: finish_reason=length")
+	}
+	msg := choice.Message
 	return AssistantTurn{
 		Content:   msg.Content,
 		ToolCalls: msg.ToolCalls,

--- a/internal/agent/llm.go
+++ b/internal/agent/llm.go
@@ -11,9 +11,8 @@ import (
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 )
-
-const truncatedAnswerNotice = "\n\n> 输出因长度限制被截断，请缩小范围或降低详细程度后重试。"
 
 // Client 是 agent 自带的 LLM 客户端，独立于 service/llm.go，只依赖标准库。
 type Client struct {
@@ -185,7 +184,7 @@ func (c *Client) attemptChat(ctx context.Context, model string, msgs []Message, 
 		// A content-only turn is the user-facing answer. It is degraded but still
 		// usable, so preserve it with an explicit disclosure instead of failing
 		// the whole request and discarding everything the model produced.
-		msg.Content += truncatedAnswerNotice
+		msg.Content += service.TruncationNotice
 	}
 	return AssistantTurn{
 		Content:   msg.Content,

--- a/internal/agent/llm.go
+++ b/internal/agent/llm.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
 )
+
+const truncatedAnswerNotice = "\n\n> 输出因长度限制被截断，请缩小范围或降低详细程度后重试。"
 
 // Client 是 agent 自带的 LLM 客户端，独立于 service/llm.go，只依赖标准库。
 type Client struct {
@@ -169,12 +172,21 @@ func (c *Client) attemptChat(ctx context.Context, model string, msgs []Message, 
 		return AssistantTurn{}, llmfallback.Terminal, fmt.Errorf("empty choices in response")
 	}
 	choice := cr.Choices[0]
-	if choice.FinishReason == "length" {
-		// Tool-call arguments can be syntactically present but cut off mid-JSON.
-		// Never dispatch a truncated planner turn as if it were valid.
-		return AssistantTurn{}, false, fmt.Errorf("LLM response truncated: finish_reason=length")
-	}
 	msg := choice.Message
+	if choice.FinishReason == "length" {
+		if len(msg.ToolCalls) > 0 {
+			// Tool-call arguments can be syntactically present but cut off mid-JSON.
+			// Never dispatch a truncated planner turn as if it were valid.
+			return AssistantTurn{}, llmfallback.Terminal, fmt.Errorf("LLM tool response truncated: finish_reason=length")
+		}
+		if strings.TrimSpace(msg.Content) == "" {
+			return AssistantTurn{}, llmfallback.RetrySameModel, fmt.Errorf("LLM response truncated before producing content: finish_reason=length")
+		}
+		// A content-only turn is the user-facing answer. It is degraded but still
+		// usable, so preserve it with an explicit disclosure instead of failing
+		// the whole request and discarding everything the model produced.
+		msg.Content += truncatedAnswerNotice
+	}
 	return AssistantTurn{
 		Content:   msg.Content,
 		ToolCalls: msg.ToolCalls,

--- a/internal/agent/llm_truncation_test.go
+++ b/internal/agent/llm_truncation_test.go
@@ -32,3 +32,26 @@ func TestAgentLLMRejectsLengthTruncatedToolCall(t *testing.T) {
 		t.Fatalf("error = %v, want explicit length-truncation failure", err)
 	}
 }
+
+func TestAgentLLMDisclosesLengthTruncatedContentAnswer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "choices":[{
+                "message":{"content":"partial final answer","tool_calls":null},
+                "finish_reason":"length"
+            }],
+            "usage":{"total_tokens":12000}
+        }`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "key", "test-model", 5, 12000, nil)
+	turn, err := client.Chat(context.Background(), []Message{{Role: "user", Content: "summarize"}}, nil)
+	if err != nil {
+		t.Fatalf("content-only truncation should remain usable: %v", err)
+	}
+	if !strings.Contains(turn.Content, "partial final answer") || !strings.Contains(turn.Content, "输出因长度限制被截断") {
+		t.Fatalf("truncated answer missing content or disclosure: %q", turn.Content)
+	}
+}

--- a/internal/agent/llm_truncation_test.go
+++ b/internal/agent/llm_truncation_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAgentLLMRejectsLengthTruncatedToolCall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "choices":[{
+                "message":{"content":"","tool_calls":[{
+                    "id":"call_1","type":"function",
+                    "function":{"name":"merge_summaries","arguments":"{\"summary_handles\":[\"map_1\""}
+                }]},
+                "finish_reason":"length"
+            }],
+            "usage":{"total_tokens":12000}
+        }`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "key", "test-model", 5, 12000, nil)
+	_, err := client.Chat(context.Background(), []Message{{Role: "user", Content: "summarize"}}, []Tool{{
+		Type: "function", Function: ToolFunction{Name: "merge_summaries"},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "finish_reason=length") {
+		t.Fatalf("error = %v, want explicit length-truncation failure", err)
+	}
+}

--- a/internal/agent/prompts/summary.md
+++ b/internal/agent/prompts/summary.md
@@ -7,8 +7,8 @@
 4. **深度抓取**：确认目标频道后，用 `fetch_channel` 抓取全量消息（结果存入缓存，只返回 handle）。
 5. **搜索定位**：如有特定关键词，用 `search_messages` 在缓存中快速定位相关内容。
 6. **过滤收敛**：用 `filter_relevant` 按主题或参与者进一步过滤消息。
-7. **分块总结**：用 `summarize_chunk` 对大量消息进行 Map 阶段局部总结。
-8. **合并输出**：用 `merge_summaries` 将多个局部总结合并为最终结构化摘要。
+7. **分块总结**：用 `summarize_chunk` 对大量消息进行 Map 阶段局部总结；工具只返回 `summary_handle`，正文由后端在本次请求内保存。
+8. **合并输出**：等所有 `summarize_chunk` 完成后，再用 `merge_summaries`，把本次请求产生的全部 `summary_handle` 原样放入 `summary_handles`。不要复制局部总结正文。
 
 ## 工具说明
 - `get_current_time` / `extract_time_range`：处理时间相关查询。
@@ -27,6 +27,8 @@
 - 每次 `fetch_channel` 或 `peek_channel` 都会返回 `messages_handle`，后续操作需用此 handle 从缓存读取。
 - `peek_channel.sample_truncated=true` 只表示预览做了采样；`fetch_channel.truncated=true` / `has_more=true` 表示抓取命中条数上限、仍可能有更多消息。不要混淆这两类覆盖信号。
 - 不要重复抓取同一频道的消息；如需多次分析，复用已有的 `messages_handle`。
+- `summary_handle` 仅在本次请求内有效；不得复用历史对话里的旧 handle，不得在同一批并发工具调用中同时执行 Map 和 Reduce。
+- 只要本次请求调用过 `summarize_chunk`，就必须成功调用一次覆盖全部 handle 的 `merge_summaries` 后才能输出最终答案。
 - 用中文输出。不编造无法从聊天记录中确认的信息。
 - 结论先行、分层清晰、控制篇幅。
 

--- a/internal/agent/prompts/summary_refine.md
+++ b/internal/agent/prompts/summary_refine.md
@@ -51,6 +51,12 @@
    - 但**永远不要**因为「看不到原始消息」就反问 —— 需要就自己调工具去拉
    - 也**永远不要**反问用户提供 JSON
 
+6. **Map/Reduce handle 规则**
+   - `summarize_chunk` 只返回本次请求有效的 `summary_handle`，局部总结正文由后端保存
+   - 等全部 Map 调用完成后，再调用 `merge_summaries`；在 `summary_handles` 中原样传入本次请求产生的全部 handle
+   - 不复制局部总结正文，不复用历史 handle，不在同一批并发工具调用中同时执行 Map 和 Reduce
+   - 调用过 `summarize_chunk` 时，必须成功 Reduce 后才能输出最终产物
+
 ---
 
 **产出结构**必须与首次生成一致:`{content, citations}`,citations 字段严格对齐 `model.Citation`。

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -46,8 +46,9 @@ type Runner struct {
 	// gate FAILED). The target is passed because fetch_channel / summarize_chunk
 	// run once per channel/chunk through the worker pool: keying the fatal set on
 	// the tool name alone let one chunk's success clear a different chunk's fatal
-	// marker (verdict-by-scheduling). Nil-safe; must be goroutine-safe (runTools
-	// calls it from the worker pool).
+	// marker (verdict-by-scheduling). Nil-safe. runTools reports one completed
+	// step as a batch: errors first, then successes, so a successful sibling call
+	// for the same target deterministically wins over a same-step failure.
 	OnToolError func(toolName, target string, env ToolErrorEnvelope)
 
 	// OnToolSuccess is the counterpart, called when a tool call SUCCEEDS. It
@@ -63,7 +64,7 @@ type Runner struct {
 	// fact ("that tool worked on a later call") instead of guessed from text.
 	// A retry of the same target is a new tool_call with a new id but the SAME
 	// target, so the target (not the call id) is what makes recovery observable.
-	// Nil-safe; must be goroutine-safe.
+	// Nil-safe; emitted after the step's error callbacks.
 	OnToolSuccess func(toolName, target string)
 }
 
@@ -277,6 +278,7 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 // 结果写入预分配 slice 的固定索引，天然无写冲突；WaitGroup 收齐。
 func (r *Runner) runTools(ctx context.Context, calls []ToolCall, step, ofSteps int) []string {
 	results := make([]string, len(calls))
+	hookOutcomes := make([]toolHookOutcome, len(calls))
 	var wg sync.WaitGroup
 	for i, tc := range calls {
 		wg.Add(1)
@@ -334,8 +336,10 @@ func (r *Runner) runTools(ctx context.Context, calls []ToolCall, step, ofSteps i
 				if SummaryV2Enabled() {
 					env := classifyToolError(tc.Function.Name, err)
 					results[i] = env.JSON()
-					if r.OnToolError != nil {
-						r.OnToolError(tc.Function.Name, toolCallTarget(tc.Function.Arguments), env)
+					hookOutcomes[i] = toolHookOutcome{
+						toolName: tc.Function.Name,
+						target:   toolCallTarget(tc.Function.Arguments),
+						err:      &env,
 					}
 				} else {
 					results[i] = "错误: " + err.Error()
@@ -347,13 +351,47 @@ func (r *Runner) runTools(ctx context.Context, calls []ToolCall, step, ofSteps i
 			// this tool+target was recoverable. Reported so the run's fatal marker can
 			// be cleared — see Runner.OnToolSuccess for why this is an observation
 			// rather than another error-string pattern.
-			if SummaryV2Enabled() && r.OnToolSuccess != nil {
-				r.OnToolSuccess(tc.Function.Name, toolCallTarget(tc.Function.Arguments))
+			if SummaryV2Enabled() {
+				hookOutcomes[i] = toolHookOutcome{
+					toolName: tc.Function.Name,
+					target:   toolCallTarget(tc.Function.Arguments),
+					success:  true,
+				}
 			}
 		})
 	}
 	wg.Wait()
+	r.reportToolHookOutcomes(hookOutcomes)
 	return results
+}
+
+type toolHookOutcome struct {
+	toolName string
+	target   string
+	err      *ToolErrorEnvelope
+	success  bool
+}
+
+// reportToolHookOutcomes makes the fatal-marker verdict independent of worker
+// completion order. All failures in one planner step are observed first, then
+// all successes. A same-step success for the same (tool, target) therefore
+// proves that the requested work completed despite a duplicate sibling call,
+// while failures for different targets remain latched.
+func (r *Runner) reportToolHookOutcomes(outcomes []toolHookOutcome) {
+	if r.OnToolError != nil {
+		for _, outcome := range outcomes {
+			if outcome.err != nil {
+				r.OnToolError(outcome.toolName, outcome.target, *outcome.err)
+			}
+		}
+	}
+	if r.OnToolSuccess != nil {
+		for _, outcome := range outcomes {
+			if outcome.success {
+				r.OnToolSuccess(outcome.toolName, outcome.target)
+			}
+		}
+	}
 }
 
 // extractToolCount extracts a cheap, safe integer count from a tool result.

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -93,11 +93,17 @@ func (r *Runner) Run(ctx context.Context, system, userInput string) (string, err
 // 返回最终回复 + 本回合新产生的消息（user + assistant(含 tool_calls) + tool），供上层落库；
 // 新消息不含 system，也不含传入的 history。
 func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Message, userInput string) (string, []Message, error) {
+	// Keep Map output out of the planner transcript. Every run gets an isolated,
+	// request-scoped store shared by summarize_chunk and merge_summaries through
+	// the tool context. It deliberately shadows any store on the parent context so
+	// a reused context cannot leak handles or pending state across runner calls.
+	ctx = withSummaryHandleStore(ctx)
+
 	userMsg := Message{Role: "user", Content: userInput}
 
 	msgs := make([]Message, 0, len(history)+2)
 	msgs = append(msgs, Message{Role: "system", Content: system})
-	msgs = append(msgs, history...)
+	msgs = append(msgs, compactSummaryToolHistory(history)...)
 	msgs = append(msgs, userMsg)
 
 	// newMsgs 只累积本回合新增（user + 各 assistant + 各 tool），供落库；不含 system/history。
@@ -137,6 +143,32 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 			return "", nil, err
 		}
 		totalTokens += turn.Tokens
+
+		// A final answer is not valid while this request still has Map outputs that
+		// have not passed through one successful Reduce covering every handle. The
+		// model can otherwise skip merge_summaries (or ignore its parse error) and
+		// confidently answer from partial Map text. Nudge it without persisting the
+		// rejected draft; at the final step fail closed.
+		if len(turn.ToolCalls) == 0 {
+			store, storeErr := summaryHandleStoreFromContext(ctx)
+			if storeErr == nil && (store.PendingMapFailures() > 0 || store.NeedsReduce()) {
+				pendingMaps := store.PendingMapFailures()
+				log.Printf("[agent] step %d/%d: final answer attempted with pending summary work (map_failures=%d reduce_needed=%t)",
+					step+1, r.policy.MaxSteps, pendingMaps, store.NeedsReduce())
+				if step >= r.policy.MaxSteps-1 {
+					return "", nil, errors.New("successful Map retries and Reduce required before final answer")
+				}
+				instruction := "本次请求仍有未合并的 Map 结果。请先调用 merge_summaries，并在 summary_handles 中原样传入本次请求产生的全部 summary_handle；不要复制摘要正文，也不要直接输出最终答案。"
+				if pendingMaps > 0 {
+					instruction = "本次请求仍有失败的 summarize_chunk。请先使用原 messages_handle 重试每个失败的 Map 调用。不同 handle 不能证明覆盖同一批消息；若原 handle 已失效，本轮必须失败并由用户重新发起请求。全部 Map 成功后，再调用 merge_summaries 合并全部 summary_handle；不要直接输出最终答案。"
+				}
+				msgs = append(msgs, Message{
+					Role:    "user",
+					Content: instruction,
+				})
+				continue
+			}
+		}
 
 		// SUM-158 blocker follow-up: 无工具调用 且 有 content = 模型给出最终答案，正常出口。
 		// 但如果 tool_calls 空 且 content 也空/空白，不能视为正常终止：
@@ -219,9 +251,18 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		// 预算触顶：注入收尾指令，逼模型下一轮直接给答案。
 		// 这条纯运行时提示，不并入 newMsgs（不落库，避免污染历史）。
 		if totalTokens >= r.policy.MaxTokens {
+			instruction := "已达token预算，请基于现有信息直接给出最终答案，不要再调用工具。"
+			if store, storeErr := summaryHandleStoreFromContext(ctx); storeErr == nil && store.PendingMapFailures() > 0 {
+				instruction = "已达token预算，但仍有失败的 summarize_chunk。下一步只重试失败的 Map；全部成功后调用 merge_summaries，Reduce 成功后再直接输出最终答案。"
+			} else if storeErr == nil && store.NeedsReduce() {
+				// Never contradict the Reduce gate. A direct-answer instruction here
+				// makes the next planner turn skip merge_summaries, wasting one full
+				// LLM call before the gate can nudge it back.
+				instruction = "已达token预算，但本次请求仍有未合并的 Map 结果。下一步只调用 merge_summaries，传入全部 summary_handle；Reduce 成功后再直接输出最终答案。"
+			}
 			msgs = append(msgs, Message{
 				Role:    "user",
-				Content: "已达token预算，请基于现有信息直接给出最终答案，不要再调用工具。",
+				Content: instruction,
 			})
 		}
 	}
@@ -249,7 +290,21 @@ func (r *Runner) runTools(ctx context.Context, calls []ToolCall, step, ofSteps i
 				})
 			}
 
-			out, err := r.reg.Dispatch(ctx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
+			toolCtx := withSummaryToolStep(ctx, step)
+			out, err := r.reg.Dispatch(toolCtx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
+			if tc.Function.Name == "summarize_chunk" {
+				if store, storeErr := summaryHandleStoreFromContext(ctx); storeErr == nil {
+					target := toolCallTarget(tc.Function.Arguments)
+					if target == "" {
+						target = "tool_call_id=" + tc.ID
+					}
+					if err != nil {
+						store.MarkMapFailed(target, step)
+					} else {
+						store.MarkMapSucceeded(target, step)
+					}
+				}
+			}
 
 			toolElapsed := time.Since(toolStart).Milliseconds()
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -124,8 +124,8 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 
 		// stepCtx bounds ONLY the planning LLM call (r.client.Chat below).
 		// Tool execution must NOT share this budget: LLM-backed tools such
-		// as summarize_chunk and merge_summaries run their own sequential
-		// per-chunk LLM calls, each with its own LLMTimeout (default 180s,
+		// as summarize_chunk and merge_summaries run their own LLM calls
+		// (Map calls use bounded concurrency), each with its own LLMTimeout (default 180s,
 		// see config.go). Wrapping runTools in stepCtx (default 60s) — as
 		// briefly attempted in commit 4f614cc — clamps every large map-reduce
 		// summary to 60s and breaks the feature's primary path (byte-verified
@@ -153,14 +153,18 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 			store, storeErr := summaryHandleStoreFromContext(ctx)
 			if storeErr == nil && (store.PendingMapFailures() > 0 || store.NeedsReduce()) {
 				pendingMaps := store.PendingMapFailures()
-				log.Printf("[agent] step %d/%d: final answer attempted with pending summary work (map_failures=%d reduce_needed=%t)",
-					step+1, r.policy.MaxSteps, pendingMaps, store.NeedsReduce())
+				anonymousMaps := store.PendingAnonymousMapFailures()
+				log.Printf("[agent] step %d/%d: final answer attempted with pending summary work (map_failures=%d anonymous_map_failures=%d reduce_needed=%t)",
+					step+1, r.policy.MaxSteps, pendingMaps, anonymousMaps, store.NeedsReduce())
 				if step >= r.policy.MaxSteps-1 {
 					return "", nil, errors.New("successful Map retries and Reduce required before final answer")
 				}
 				instruction := "本次请求仍有未合并的 Map 结果。请先调用 merge_summaries，并在 summary_handles 中原样传入本次请求产生的全部 summary_handle；不要复制摘要正文，也不要直接输出最终答案。"
 				if pendingMaps > 0 {
 					instruction = "本次请求仍有失败的 summarize_chunk。请先使用原 messages_handle 重试每个失败的 Map 调用。不同 handle 不能证明覆盖同一批消息；若原 handle 已失效，本轮必须失败并由用户重新发起请求。全部 Map 成功后，再调用 merge_summaries 合并全部 summary_handle；不要直接输出最终答案。"
+					if anonymousMaps > 0 {
+						instruction = "本次请求仍有 summarize_chunk 参数无效或缺少 messages_handle。请修正参数，使用本次请求中正确的 messages_handle 逐一重试失败的 Map 调用；每个失败调用都需要一次后续成功。全部 Map 成功后，再调用 merge_summaries 合并全部 summary_handle；不要直接输出最终答案。"
+					}
 				}
 				msgs = append(msgs, Message{
 					Role:    "user",
@@ -223,7 +227,7 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		// 单跳内多工具并发执行；结果按原索引回填以保证顺序稳定、无数据竞争。
 		// Use the outer request ctx (300s ChatStream backstop) — NOT stepCtx.
 		// See the stepCtx setup comment above for why: LLM-backed tools like
-		// summarize_chunk run their own sequential LLM calls that legitimately
+		// summarize_chunk run their own bounded-concurrent LLM calls that legitimately
 		// exceed the 60s per-step planning budget.
 		results := r.runTools(ctx, turn.ToolCalls, step+1, r.policy.MaxSteps)
 		for i, tc := range turn.ToolCalls {
@@ -296,7 +300,7 @@ func (r *Runner) runTools(ctx context.Context, calls []ToolCall, step, ofSteps i
 				if store, storeErr := summaryHandleStoreFromContext(ctx); storeErr == nil {
 					target := toolCallTarget(tc.Function.Arguments)
 					if target == "" {
-						target = "tool_call_id=" + tc.ID
+						target = anonymousMapFailurePrefix + tc.ID
 					}
 					if err != nil {
 						store.MarkMapFailed(target, step)

--- a/internal/agent/runner_summary_handle_test.go
+++ b/internal/agent/runner_summary_handle_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,54 @@ type reduceAwareClient struct {
 	bodyLeaked      bool
 	sawNudge        bool
 	sawBudgetReduce bool
+}
+
+type malformedMapRetryClient struct {
+	calls    int
+	sawNudge bool
+}
+
+func (c *malformedMapRetryClient) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
+	c.calls++
+	for _, msg := range msgs {
+		if strings.Contains(msg.Content, "参数无效或缺少 messages_handle") {
+			c.sawNudge = true
+		}
+	}
+	switch c.calls {
+	case 1:
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("bad-map-call", "summarize_chunk", `{"chunk_size":10}`),
+		}}, nil
+	case 2:
+		return AssistantTurn{Content: "premature final after malformed Map"}, nil
+	case 3:
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("good-map-call", "summarize_chunk", `{"messages_handle":"messages-1"}`),
+		}}, nil
+	case 4:
+		var handle string
+		for _, msg := range msgs {
+			if msg.Role != "tool" || msg.Name != "summarize_chunk" {
+				continue
+			}
+			var result struct {
+				SummaryHandle string `json:"summary_handle"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.SummaryHandle != "" {
+				handle = result.SummaryHandle
+			}
+		}
+		if handle == "" {
+			return AssistantTurn{}, fmt.Errorf("corrected Map did not return a summary_handle")
+		}
+		args, _ := json.Marshal(map[string]interface{}{"summary_handles": []string{handle}})
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("reduce-call", "merge_summaries", string(args)),
+		}}, nil
+	default:
+		return AssistantTurn{Content: "final after corrected retry"}, nil
+	}
 }
 
 func (c *reduceAwareClient) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
@@ -156,5 +205,56 @@ func TestRunnerShadowsSummaryStoreFromParentContext(t *testing.T) {
 	}
 	if !parentStore.NeedsReduce() {
 		t.Fatal("runner mutated the parent store instead of shadowing it")
+	}
+}
+
+func TestRunnerMalformedMapArgsCanRecoverWithCorrectedRetry(t *testing.T) {
+	client := &malformedMapRetryClient{}
+	reg := NewRegistry()
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "summarize_chunk"}},
+		func(ctx context.Context, args json.RawMessage) (string, error) {
+			var req struct {
+				MessagesHandle string `json:"messages_handle"`
+			}
+			if err := json.Unmarshal(args, &req); err != nil {
+				return "", fmt.Errorf("parse args: %w", err)
+			}
+			if req.MessagesHandle == "" {
+				return "", fmt.Errorf("messages_handle is required")
+			}
+			store, _ := summaryHandleStoreFromContext(ctx)
+			handle, err := store.PutAtStep("corrected Map body", 1, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			return `{"summary_handle":"` + handle + `","chunk_count":1}`, nil
+		})
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "merge_summaries"}},
+		func(ctx context.Context, args json.RawMessage) (string, error) {
+			var req struct {
+				Handles []string `json:"summary_handles"`
+			}
+			if err := json.Unmarshal(args, &req); err != nil {
+				return "", err
+			}
+			store, _ := summaryHandleStoreFromContext(ctx)
+			resolved, err := store.ResolveAllBefore(req.Handles, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			store.MarkReduced(resolved.Generation)
+			return `{"merged_summary":"merged","chunk_count":1}`, nil
+		})
+
+	runner := NewRunner(client, reg, NewPool(2), Policy{MaxSteps: 5, MaxTokens: 100000, StepTimeout: time.Second})
+	out, _, err := runner.RunWithHistory(context.Background(), "system", nil, "summarize")
+	if err != nil {
+		t.Fatalf("RunWithHistory: %v", err)
+	}
+	if out != "final after corrected retry" || client.calls != 5 {
+		t.Fatalf("out=%q calls=%d, want successful recovery in 5 turns", out, client.calls)
+	}
+	if !client.sawNudge {
+		t.Fatal("runner did not explain how to recover a handle-less Map failure")
 	}
 }

--- a/internal/agent/runner_summary_handle_test.go
+++ b/internal/agent/runner_summary_handle_test.go
@@ -1,0 +1,160 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+type reduceAwareClient struct {
+	calls           int
+	largeBody       string
+	bodyLeaked      bool
+	sawNudge        bool
+	sawBudgetReduce bool
+}
+
+func (c *reduceAwareClient) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
+	c.calls++
+	for _, msg := range msgs {
+		if strings.Contains(msg.Content, c.largeBody) {
+			c.bodyLeaked = true
+		}
+		if strings.Contains(msg.Content, "未合并的 Map 结果") {
+			c.sawNudge = true
+		}
+		if strings.Contains(msg.Content, "已达token预算") && strings.Contains(msg.Content, "merge_summaries") {
+			c.sawBudgetReduce = true
+		}
+	}
+
+	switch c.calls {
+	case 1:
+		return AssistantTurn{ToolCalls: []ToolCall{mkToolCall("map-call", "summarize_chunk", `{}`)}, Tokens: 10}, nil
+	case 2:
+		return AssistantTurn{Content: "premature final"}, nil
+	case 3:
+		var handles []string
+		for _, msg := range msgs {
+			if msg.Role != "tool" || msg.Name != "summarize_chunk" {
+				continue
+			}
+			var result struct {
+				SummaryHandle string `json:"summary_handle"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.SummaryHandle != "" {
+				handles = append(handles, result.SummaryHandle)
+			}
+		}
+		args, _ := json.Marshal(map[string]interface{}{"summary_handles": handles})
+		return AssistantTurn{ToolCalls: []ToolCall{mkToolCall("reduce-call", "merge_summaries", string(args))}}, nil
+	default:
+		return AssistantTurn{Content: "final after reduce"}, nil
+	}
+}
+
+func TestRunnerRequiresReduceAndKeepsMapBodyOutOfPlanner(t *testing.T) {
+	largeBody := strings.Repeat("large-map-body-", 10000)
+	client := &reduceAwareClient{largeBody: largeBody}
+	reg := NewRegistry()
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "summarize_chunk"}},
+		func(ctx context.Context, _ json.RawMessage) (string, error) {
+			store, _ := summaryHandleStoreFromContext(ctx)
+			handle, err := store.PutAtStep(largeBody, 4, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			data, _ := json.Marshal(map[string]interface{}{"summary_handle": handle, "chunk_count": 4})
+			return string(data), nil
+		})
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "merge_summaries"}},
+		func(ctx context.Context, args json.RawMessage) (string, error) {
+			var req struct {
+				Handles []string `json:"summary_handles"`
+			}
+			if err := json.Unmarshal(args, &req); err != nil {
+				return "", err
+			}
+			store, _ := summaryHandleStoreFromContext(ctx)
+			resolved, err := store.ResolveAllBefore(req.Handles, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			store.MarkReduced(resolved.Generation)
+			return `{"merged_summary":"merged","chunk_count":4}`, nil
+		})
+
+	runner := NewRunner(client, reg, NewPool(2), Policy{MaxSteps: 6, MaxTokens: 1, StepTimeout: time.Second})
+	out, newMsgs, err := runner.RunWithHistory(context.Background(), "system", nil, "summarize")
+	if err != nil {
+		t.Fatalf("RunWithHistory: %v", err)
+	}
+	if out != "final after reduce" || client.calls != 4 {
+		t.Fatalf("out=%q calls=%d, want reduced final after 4 planner turns", out, client.calls)
+	}
+	if !client.sawNudge {
+		t.Fatal("planner did not receive the Reduce-required nudge")
+	}
+	if !client.sawBudgetReduce {
+		t.Fatal("token-budget instruction contradicted the pending Reduce requirement")
+	}
+	if client.bodyLeaked {
+		t.Fatal("full Map body leaked back into planner messages")
+	}
+	for _, msg := range newMsgs {
+		if msg.Content == "premature final" || strings.Contains(msg.Content, "未合并的 Map 结果") {
+			t.Fatalf("rejected final/nudge must not be persisted: %+v", msg)
+		}
+	}
+}
+
+func TestRunnerFailsClosedWhenReduceStillPendingAtLastStep(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "summarize_chunk"}},
+		func(ctx context.Context, _ json.RawMessage) (string, error) {
+			store, _ := summaryHandleStoreFromContext(ctx)
+			handle, err := store.PutAtStep("map body", 1, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			return `{"summary_handle":"` + handle + `"}`, nil
+		})
+	client := &fakeClient{turns: []AssistantTurn{
+		{ToolCalls: []ToolCall{mkToolCall("map-call", "summarize_chunk", `{}`)}},
+		{Content: "final without reduce"},
+	}}
+	runner := NewRunner(client, reg, NewPool(1), Policy{MaxSteps: 2, MaxTokens: 100000, StepTimeout: time.Second})
+	if _, _, err := runner.RunWithHistory(context.Background(), "system", nil, "summarize"); err == nil || !strings.Contains(err.Error(), "Reduce required") {
+		t.Fatalf("error = %v, want Reduce-required failure", err)
+	}
+}
+
+func TestRunnerShadowsSummaryStoreFromParentContext(t *testing.T) {
+	parent := withSummaryHandleStore(context.Background())
+	parentStore, err := summaryHandleStoreFromContext(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parentStore.Put("stale Map result from an earlier run", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{turns: []AssistantTurn{{Content: "fresh final"}}}
+	runner := NewRunner(client, NewRegistry(), NewPool(1), Policy{
+		MaxSteps:    1,
+		MaxTokens:   100000,
+		StepTimeout: time.Second,
+	})
+	out, _, err := runner.RunWithHistory(parent, "system", nil, "new request")
+	if err != nil {
+		t.Fatalf("RunWithHistory reused stale parent store: %v", err)
+	}
+	if out != "fresh final" {
+		t.Fatalf("out = %q, want fresh final", out)
+	}
+	if !parentStore.NeedsReduce() {
+		t.Fatal("runner mutated the parent store instead of shadowing it")
+	}
+}

--- a/internal/agent/summary_handle_store.go
+++ b/internal/agent/summary_handle_store.go
@@ -2,12 +2,26 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/google/uuid"
 )
+
+// ErrSummaryHandleCapacity marks a request-scoped store cap that has been hit.
+// It is a typed sentinel rather than another error-string pattern on purpose:
+// these messages spell "summary handle" with a SPACE, while the tool-error
+// classifier matched "summary_handle" with an UNDERSCORE, so capacity failures
+// silently fell through to the critical-tool default (retryable=true) and the
+// nudged retry hit the identical cap every step until MaxSteps, ending the run
+// with zero output. Adding a second substring pattern would fix today's spelling
+// and leave the same trap armed for the next one; errors.Is cannot drift.
+//
+// Semantics: a deterministic dead end for THIS request. Retrying changes
+// nothing — the caps are per-request and the store only grows.
+var ErrSummaryHandleCapacity = errors.New("summary handle capacity exceeded")
 
 const (
 	maxSummaryHandles         = 128
@@ -90,10 +104,10 @@ func (s *summaryHandleStore) PutAtStep(text string, chunkCount, mapStep int) (st
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.items) >= maxSummaryHandles {
-		return "", fmt.Errorf("too many summary handles in one request (max %d)", maxSummaryHandles)
+		return "", fmt.Errorf("%w: too many summary handles in one request (max %d)", ErrSummaryHandleCapacity, maxSummaryHandles)
 	}
 	if s.totalTextBytes+len(text) > maxSummaryHandleText {
-		return "", fmt.Errorf("summary handle text exceeds per-request limit (%d bytes)", maxSummaryHandleText)
+		return "", fmt.Errorf("%w: summary handle text exceeds per-request limit (%d bytes)", ErrSummaryHandleCapacity, maxSummaryHandleText)
 	}
 
 	s.next++
@@ -122,6 +136,8 @@ func (s *summaryHandleStore) ResolveAllBefore(handles []string, reduceStep int) 
 		return summaryHandleResolution{}, fmt.Errorf("summary_handles must contain at least one handle")
 	}
 	if len(handles) > maxSummaryHandles {
+		// NOT ErrSummaryHandleCapacity: this is the model handing over more
+		// handles than can exist, which it CAN fix by passing the real set.
 		return summaryHandleResolution{}, fmt.Errorf("too many summary_handles (max %d)", maxSummaryHandles)
 	}
 

--- a/internal/agent/summary_handle_store.go
+++ b/internal/agent/summary_handle_store.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxSummaryHandles    = 128
+	maxSummaryHandleText = 8 << 20 // 8 MiB per request
+)
+
+// summaryHandleEntry is one Map result kept out of the planner transcript.
+// It lives only for one RunWithHistory call; the opaque handle is the only part
+// returned to the model.
+type summaryHandleEntry struct {
+	Handle     string
+	Text       string
+	ChunkCount int
+	MapStep    int
+}
+
+type summaryHandleResolution struct {
+	Entries    []summaryHandleEntry
+	Generation uint64
+}
+
+type summaryMapFailure struct {
+	Step int
+}
+
+// summaryHandleStore is request-scoped. It deliberately is not a Runner field
+// or global cache: either would let handles leak across concurrent requests and
+// would require owner binding, expiry and cleanup. RunWithHistory installs one
+// store in its derived context and all tool calls share that context.
+type summaryHandleStore struct {
+	mu                sync.RWMutex
+	prefix            string
+	next              uint64
+	generation        uint64
+	reducedGeneration uint64
+	totalTextBytes    int
+	items             map[string]summaryHandleEntry
+	mapFailures       map[string]summaryMapFailure
+}
+
+type summaryHandleStoreContextKey struct{}
+type summaryToolStepContextKey struct{}
+
+func newSummaryHandleStore() *summaryHandleStore {
+	return &summaryHandleStore{
+		prefix:      strings.ReplaceAll(uuid.NewString(), "-", ""),
+		items:       make(map[string]summaryHandleEntry),
+		mapFailures: make(map[string]summaryMapFailure),
+	}
+}
+
+func withSummaryHandleStore(ctx context.Context) context.Context {
+	// A context can outlive one Runner invocation (tests, jobs, or callers that
+	// reuse a request-derived context). Always shadow any parent store so handles,
+	// pending failures, and Reduce state cannot bleed into the next run.
+	return context.WithValue(ctx, summaryHandleStoreContextKey{}, newSummaryHandleStore())
+}
+
+func summaryHandleStoreFromContext(ctx context.Context) (*summaryHandleStore, error) {
+	store, ok := ctx.Value(summaryHandleStoreContextKey{}).(*summaryHandleStore)
+	if !ok || store == nil {
+		return nil, fmt.Errorf("missing request-scoped summary handle store")
+	}
+	return store, nil
+}
+
+func (s *summaryHandleStore) Put(text string, chunkCount int) (string, error) {
+	return s.PutAtStep(text, chunkCount, 0)
+}
+
+func (s *summaryHandleStore) PutAtStep(text string, chunkCount, mapStep int) (string, error) {
+	if strings.TrimSpace(text) == "" {
+		return "", fmt.Errorf("summary text is empty")
+	}
+	if chunkCount < 0 {
+		return "", fmt.Errorf("chunk_count must be non-negative")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.items) >= maxSummaryHandles {
+		return "", fmt.Errorf("too many summary handles in one request (max %d)", maxSummaryHandles)
+	}
+	if s.totalTextBytes+len(text) > maxSummaryHandleText {
+		return "", fmt.Errorf("summary handle text exceeds per-request limit (%d bytes)", maxSummaryHandleText)
+	}
+
+	s.next++
+	handle := fmt.Sprintf("map_%s_%d", s.prefix, s.next)
+	s.generation++
+	s.totalTextBytes += len(text)
+	s.items[handle] = summaryHandleEntry{
+		Handle:     handle,
+		Text:       text,
+		ChunkCount: chunkCount,
+		MapStep:    mapStep,
+	}
+	return handle, nil
+}
+
+// ResolveAll resolves handles in the caller-provided order and rejects partial,
+// duplicate or cross-request sets. Reduce must consume every Map result from the
+// current request; silently omitting one would recreate the completeness bug in
+// a smaller prompt.
+func (s *summaryHandleStore) ResolveAll(handles []string) (summaryHandleResolution, error) {
+	return s.ResolveAllBefore(handles, 0)
+}
+
+func (s *summaryHandleStore) ResolveAllBefore(handles []string, reduceStep int) (summaryHandleResolution, error) {
+	if len(handles) == 0 {
+		return summaryHandleResolution{}, fmt.Errorf("summary_handles must contain at least one handle")
+	}
+	if len(handles) > maxSummaryHandles {
+		return summaryHandleResolution{}, fmt.Errorf("too many summary_handles (max %d)", maxSummaryHandles)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.mapFailures) > 0 {
+		return summaryHandleResolution{}, fmt.Errorf("cannot Reduce while %d summarize_chunk call(s) still need a successful retry", len(s.mapFailures))
+	}
+	seen := make(map[string]bool, len(handles))
+	entries := make([]summaryHandleEntry, 0, len(handles))
+	for _, handle := range handles {
+		if handle == "" {
+			return summaryHandleResolution{}, fmt.Errorf("summary_handle must not be empty")
+		}
+		if seen[handle] {
+			return summaryHandleResolution{}, fmt.Errorf("duplicate summary_handle: %s", handle)
+		}
+		seen[handle] = true
+		entry, ok := s.items[handle]
+		if !ok {
+			return summaryHandleResolution{}, fmt.Errorf("invalid or expired summary_handle: %s", handle)
+		}
+		if reduceStep > 0 && entry.MapStep >= reduceStep {
+			return summaryHandleResolution{}, fmt.Errorf("summary_handle %s was produced in the same or a later tool step; run Reduce after all Map calls finish", handle)
+		}
+		entries = append(entries, entry)
+	}
+	if len(handles) != len(s.items) {
+		return summaryHandleResolution{}, fmt.Errorf(
+			"summary_handles must include all Map results from this request: got %d of %d",
+			len(handles), len(s.items),
+		)
+	}
+	return summaryHandleResolution{Entries: entries, Generation: s.generation}, nil
+}
+
+func withSummaryToolStep(ctx context.Context, step int) context.Context {
+	return context.WithValue(ctx, summaryToolStepContextKey{}, step)
+}
+
+func summaryToolStepFromContext(ctx context.Context) int {
+	step, _ := ctx.Value(summaryToolStepContextKey{}).(int)
+	return step
+}
+
+// MarkMapFailed records a summarize_chunk failure that did not produce a
+// summary handle. Recovery must use the same messages_handle in a later step;
+// without durable lineage, a different handle cannot prove it covers the same
+// message set.
+func (s *summaryHandleStore) MarkMapFailed(target string, step int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mapFailures[target] = summaryMapFailure{Step: step}
+}
+
+// MarkMapSucceeded clears only a failure recovered in a LATER tool step. This
+// prevents a parallel success in the same fan-out from masking another Map
+// call's failure. A success on a different handle never clears it: the two
+// handles may represent unrelated channels.
+func (s *summaryHandleStore) MarkMapSucceeded(target string, step int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if failure, ok := s.mapFailures[target]; ok && failure.Step < step {
+		delete(s.mapFailures, target)
+	}
+}
+
+func (s *summaryHandleStore) PendingMapFailures() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.mapFailures)
+}
+
+// MarkReduced records a successful Reduce only if no new Map result appeared
+// while the Reduce LLM was running. A concurrent/new Map increments generation,
+// so the Runner will require another merge before accepting a final answer.
+func (s *summaryHandleStore) MarkReduced(generation uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if generation == s.generation {
+		s.reducedGeneration = generation
+	}
+}
+
+func (s *summaryHandleStore) NeedsReduce() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.generation > s.reducedGeneration
+}

--- a/internal/agent/summary_handle_store.go
+++ b/internal/agent/summary_handle_store.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	maxSummaryHandles    = 128
-	maxSummaryHandleText = 8 << 20 // 8 MiB per request
+	maxSummaryHandles         = 128
+	maxSummaryHandleText      = 8 << 20 // 8 MiB per request
+	anonymousMapFailurePrefix = "tool_call_id="
 )
 
 // summaryHandleEntry is one Map result kept out of the planner transcript.
@@ -167,9 +168,9 @@ func summaryToolStepFromContext(ctx context.Context) int {
 }
 
 // MarkMapFailed records a summarize_chunk failure that did not produce a
-// summary handle. Recovery must use the same messages_handle in a later step;
-// without durable lineage, a different handle cannot prove it covers the same
-// message set.
+// summary handle. A valid messages_handle gives the failure durable lineage;
+// malformed/handle-less calls use an anonymous tool_call_id key because there
+// is no message set to bind yet.
 func (s *summaryHandleStore) MarkMapFailed(target string, step int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -178,13 +179,23 @@ func (s *summaryHandleStore) MarkMapFailed(target string, step int) {
 
 // MarkMapSucceeded clears only a failure recovered in a LATER tool step. This
 // prevents a parallel success in the same fan-out from masking another Map
-// call's failure. A success on a different handle never clears it: the two
-// handles may represent unrelated channels.
+// call's failure. A known messages_handle clears only its exact failure because
+// different handles may represent unrelated channels. If there is no exact
+// match, one older anonymous argument failure may be cleared: a malformed call
+// has no lineage to match, and without this bounded fallback a corrected retry
+// with a new tool-call ID could never recover the request.
 func (s *summaryHandleStore) MarkMapSucceeded(target string, step int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if failure, ok := s.mapFailures[target]; ok && failure.Step < step {
 		delete(s.mapFailures, target)
+		return
+	}
+	for failedTarget, failure := range s.mapFailures {
+		if strings.HasPrefix(failedTarget, anonymousMapFailurePrefix) && failure.Step < step {
+			delete(s.mapFailures, failedTarget)
+			return
+		}
 	}
 }
 
@@ -192,6 +203,18 @@ func (s *summaryHandleStore) PendingMapFailures() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.mapFailures)
+}
+
+func (s *summaryHandleStore) PendingAnonymousMapFailures() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for target := range s.mapFailures {
+		if strings.HasPrefix(target, anonymousMapFailurePrefix) {
+			count++
+		}
+	}
+	return count
 }
 
 // MarkReduced records a successful Reduce only if no new Map result appeared

--- a/internal/agent/summary_handle_store_test.go
+++ b/internal/agent/summary_handle_store_test.go
@@ -2,10 +2,54 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
 )
+
+// PR #208 round-5 P2-4. The capacity messages spell "summary handle" with a
+// SPACE, so classifyToolError's "summary_handle" substring branch never matched
+// them and they fell through to the retryable critical-tool default. A typed
+// sentinel is what makes the classification immune to that class of drift, so
+// pin that these errors actually carry it — and that the store's OTHER errors
+// deliberately do not.
+func TestSummaryHandleStoreCapacityErrorsAreTyped(t *testing.T) {
+	store := newSummaryHandleStore()
+	for i := 0; i < maxSummaryHandles; i++ {
+		if _, err := store.Put("x", 0); err != nil {
+			t.Fatalf("Put %d: %v", i, err)
+		}
+	}
+	_, err := store.Put("one too many", 0)
+	if !errors.Is(err, ErrSummaryHandleCapacity) {
+		t.Fatalf("handle-count cap err = %v, want ErrSummaryHandleCapacity", err)
+	}
+	if !strings.Contains(err.Error(), "too many summary handles in one request") {
+		t.Fatalf("err = %q, want the operator-readable wording preserved", err)
+	}
+
+	big := newSummaryHandleStore()
+	if _, err := big.Put(strings.Repeat("x", maxSummaryHandleText), 0); err != nil {
+		t.Fatalf("Put at the byte limit: %v", err)
+	}
+	_, err = big.Put("x", 0)
+	if !errors.Is(err, ErrSummaryHandleCapacity) {
+		t.Fatalf("text-size cap err = %v, want ErrSummaryHandleCapacity", err)
+	}
+
+	// An empty body is the model's mistake, fixable by retrying — it must NOT be
+	// classified as a request-scoped dead end.
+	if _, err := newSummaryHandleStore().Put("   ", 0); err == nil || errors.Is(err, ErrSummaryHandleCapacity) {
+		t.Fatalf("empty-text err = %v, want a plain non-capacity error", err)
+	}
+	// Same for the model passing an impossible handle COUNT: it can pass fewer.
+	small := newSummaryHandleStore()
+	handles := make([]string, maxSummaryHandles+1)
+	if _, err := small.ResolveAll(handles); err == nil || errors.Is(err, ErrSummaryHandleCapacity) {
+		t.Fatalf("oversized argument list err = %v, want a plain non-capacity error", err)
+	}
+}
 
 func TestSummaryHandleStoreResolveAll(t *testing.T) {
 	store := newSummaryHandleStore()

--- a/internal/agent/summary_handle_store_test.go
+++ b/internal/agent/summary_handle_store_test.go
@@ -135,6 +135,31 @@ func TestSummaryHandleStoreUnrelatedSuccessCannotClearFailure(t *testing.T) {
 	}
 }
 
+func TestSummaryHandleStoreLaterSuccessClearsOneAnonymousArgumentFailure(t *testing.T) {
+	store := newSummaryHandleStore()
+	store.MarkMapFailed(anonymousMapFailurePrefix+"bad-1", 1)
+	store.MarkMapFailed(anonymousMapFailurePrefix+"bad-2", 1)
+	if store.PendingAnonymousMapFailures() != 2 {
+		t.Fatalf("anonymous failures = %d, want 2", store.PendingAnonymousMapFailures())
+	}
+
+	store.MarkMapSucceeded("messages_handle=corrected", 1)
+	if store.PendingMapFailures() != 2 {
+		t.Fatal("same-step success must not clear an anonymous argument failure")
+	}
+	store.MarkMapSucceeded("messages_handle=corrected", 2)
+	if store.PendingMapFailures() != 1 {
+		t.Fatalf("first corrected retry should clear one anonymous failure, pending=%d", store.PendingMapFailures())
+	}
+	store.MarkMapSucceeded("messages_handle=corrected-again", 2)
+	if store.PendingMapFailures() != 0 {
+		t.Fatalf("second corrected retry should clear the remaining anonymous failure, pending=%d", store.PendingMapFailures())
+	}
+	if store.PendingAnonymousMapFailures() != 0 {
+		t.Fatalf("anonymous failures remained after recovery: %d", store.PendingAnonymousMapFailures())
+	}
+}
+
 func TestSummaryHandleStoreConcurrentPut(t *testing.T) {
 	const n = 64
 	store := newSummaryHandleStore()

--- a/internal/agent/summary_handle_store_test.go
+++ b/internal/agent/summary_handle_store_test.go
@@ -1,0 +1,172 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestSummaryHandleStoreResolveAll(t *testing.T) {
+	store := newSummaryHandleStore()
+	h1, err := store.Put("first summary", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := store.Put("second summary", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := store.ResolveAll([]string{h2, h1})
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+	if len(resolved.Entries) != 2 || resolved.Entries[0].Text != "second summary" || resolved.Entries[1].Text != "first summary" {
+		t.Fatalf("resolution did not preserve requested order: %+v", resolved.Entries)
+	}
+	if !store.NeedsReduce() {
+		t.Fatal("new Map results must require Reduce")
+	}
+	store.MarkReduced(resolved.Generation)
+	if store.NeedsReduce() {
+		t.Fatal("successful full Reduce should satisfy the current generation")
+	}
+	if _, err := store.Put("late summary", 1); err != nil {
+		t.Fatal(err)
+	}
+	if !store.NeedsReduce() {
+		t.Fatal("a Map result added after Reduce must require another Reduce")
+	}
+}
+
+func TestSummaryHandleStoreRejectsIncompleteOrInvalidSets(t *testing.T) {
+	store := newSummaryHandleStore()
+	h1, _ := store.Put("one", 1)
+	h2, _ := store.Put("two", 1)
+
+	for _, tc := range []struct {
+		name    string
+		handles []string
+		want    string
+	}{
+		{name: "empty", handles: nil, want: "at least one"},
+		{name: "partial", handles: []string{h1}, want: "all Map results"},
+		{name: "duplicate", handles: []string{h1, h1}, want: "duplicate"},
+		{name: "unknown", handles: []string{h1, "map_unknown_9"}, want: "invalid or expired"},
+		{name: "empty handle", handles: []string{h1, ""}, want: "must not be empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := store.ResolveAll(tc.handles); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ResolveAll(%v) error = %v, want substring %q", tc.handles, err, tc.want)
+			}
+		})
+	}
+	_ = h2
+}
+
+func TestSummaryHandleStoreIsRequestScoped(t *testing.T) {
+	ctxA := withSummaryHandleStore(context.Background())
+	ctxB := withSummaryHandleStore(context.Background())
+	storeA, _ := summaryHandleStoreFromContext(ctxA)
+	storeB, _ := summaryHandleStoreFromContext(ctxB)
+
+	hA, _ := storeA.Put("request A", 1)
+	hB, _ := storeB.Put("request B", 1)
+	if hA == hB {
+		t.Fatalf("request handles must carry distinct namespaces: %q", hA)
+	}
+	if _, err := storeB.ResolveAll([]string{hA}); err == nil || !strings.Contains(err.Error(), "invalid or expired") {
+		t.Fatalf("request B resolved request A handle: %v", err)
+	}
+	if _, err := storeA.ResolveAll([]string{hB}); err == nil || !strings.Contains(err.Error(), "invalid or expired") {
+		t.Fatalf("request A resolved request B handle: %v", err)
+	}
+}
+
+func TestSummaryHandleStoreRejectsSameStepReduce(t *testing.T) {
+	store := newSummaryHandleStore()
+	handle, err := store.PutAtStep("map body", 1, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ResolveAllBefore([]string{handle}, 3); err == nil || !strings.Contains(err.Error(), "same or a later tool step") {
+		t.Fatalf("same-step Reduce error = %v", err)
+	}
+	if _, err := store.ResolveAllBefore([]string{handle}, 4); err != nil {
+		t.Fatalf("next-step Reduce should resolve: %v", err)
+	}
+}
+
+func TestSummaryHandleStoreMapFailureNeedsLaterSuccessfulRetry(t *testing.T) {
+	store := newSummaryHandleStore()
+	handle, _ := store.PutAtStep("successful map", 1, 1)
+	store.MarkMapFailed("messages_handle=failed", 1)
+	store.MarkMapSucceeded("messages_handle=other", 1)
+	if store.PendingMapFailures() != 1 {
+		t.Fatal("same-step success on another target masked a failed Map")
+	}
+	if _, err := store.ResolveAllBefore([]string{handle}, 2); err == nil || !strings.Contains(err.Error(), "successful retry") {
+		t.Fatalf("Reduce should be blocked by failed Map, got %v", err)
+	}
+	store.MarkMapSucceeded("messages_handle=failed", 1)
+	if store.PendingMapFailures() != 1 {
+		t.Fatal("same-step success must not clear a failure")
+	}
+	store.MarkMapSucceeded("messages_handle=failed", 2)
+	if store.PendingMapFailures() != 0 {
+		t.Fatal("later successful retry did not clear the failed target")
+	}
+	if _, err := store.ResolveAllBefore([]string{handle}, 2); err != nil {
+		t.Fatalf("Reduce should proceed after recovery: %v", err)
+	}
+}
+
+func TestSummaryHandleStoreUnrelatedSuccessCannotClearFailure(t *testing.T) {
+	store := newSummaryHandleStore()
+	store.MarkMapFailed("messages_handle=expired", 1)
+	store.MarkMapSucceeded("messages_handle=fresh", 1)
+	if store.PendingMapFailures() != 1 {
+		t.Fatal("same-step fresh handle must not mask an expired-handle failure")
+	}
+	store.MarkMapSucceeded("messages_handle=fresh", 2)
+	if store.PendingMapFailures() != 1 {
+		t.Fatal("an unrelated later handle must not clear a failed Map target")
+	}
+}
+
+func TestSummaryHandleStoreConcurrentPut(t *testing.T) {
+	const n = 64
+	store := newSummaryHandleStore()
+	handles := make(chan string, n)
+	errCh := make(chan error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handle, err := store.Put("summary", 1)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			handles <- handle
+		}()
+	}
+	wg.Wait()
+	close(handles)
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("Put: %v", err)
+	}
+	seen := map[string]bool{}
+	for handle := range handles {
+		if seen[handle] {
+			t.Fatalf("duplicate handle %q", handle)
+		}
+		seen[handle] = true
+	}
+	if len(seen) != n {
+		t.Fatalf("unique handles = %d, want %d", len(seen), n)
+	}
+}

--- a/internal/agent/tool_error.go
+++ b/internal/agent/tool_error.go
@@ -38,6 +38,8 @@ var criticalTools = map[string]bool{
 //   - context deadline / canceled            → retryable, not fatal
 //   - 429 / 5xx / network / DB connection    → retryable, not fatal
 //   - stale/expired messages_handle           → retryable, not fatal (cache miss)
+//   - request-scoped store capacity (typed)    → never retryable; fatal on a
+//     critical tool (the cap is per-request, so no retry can clear it)
 //   - permission / access / identity / auth  → never retryable; fatal only on a
 //     critical tool (elsewhere it is a per-channel gap, not a failed run)
 //   - explicit invalid args / parse           → retryable, not fatal
@@ -96,6 +98,19 @@ func classifyToolError(toolName string, err error) ToolErrorEnvelope {
 		// `permission denied; please try again later` carries both, and a stale
 		// permission is fatal — retrying "try again" text can never clear it.
 		env.ErrorCode, env.Retryable, env.Fatal = "TRANSIENT_TOOL_ERROR", true, false
+	case errors.Is(err, ErrSummaryHandleCapacity):
+		// A per-request store cap (handle count / total text bytes). Unlike every
+		// other branch here this is matched by identity, not by substring, because
+		// substring matching is what broke it: the store spells "summary handle"
+		// with a space, the branch below matches "summary_handle" with an
+		// underscore, so capacity errors fell through to the critical-tool default
+		// and came back retryable=true. The nudged retry re-ran the same Map into
+		// the same full store, every step, until MaxSteps ended the run with zero
+		// output. NON-retryable because the caps are per-request and the store only
+		// grows: no retry within this request can succeed. Fatal on a critical tool
+		// because the chunk it could not store is coverage that is genuinely lost —
+		// the run should end reporting that, not spin.
+		env.ErrorCode, env.Retryable, env.Fatal = "RESOURCE_EXHAUSTED", false, criticalTools[toolName]
 	case strings.Contains(low, "messages_handle") || strings.Contains(low, "summary_handle"):
 		// A dropped/expired message-cache handle (`messages_handle`) or a bad
 		// request-scoped Map result handle (`summary_handle`).

--- a/internal/agent/tool_error.go
+++ b/internal/agent/tool_error.go
@@ -96,10 +96,9 @@ func classifyToolError(toolName string, err error) ToolErrorEnvelope {
 		// `permission denied; please try again later` carries both, and a stale
 		// permission is fatal — retrying "try again" text can never clear it.
 		env.ErrorCode, env.Retryable, env.Fatal = "TRANSIENT_TOOL_ERROR", true, false
-	case strings.Contains(low, "messages_handle"):
-		// A dropped/expired message-cache handle (`invalid or expired
-		// messages_handle: h-123`, emitted on a plain cache miss by
-		// tool_search_messages / tool_filter_relevant / tool_summarize_chunk).
+	case strings.Contains(low, "messages_handle") || strings.Contains(low, "summary_handle"):
+		// A dropped/expired message-cache handle (`messages_handle`) or a bad
+		// request-scoped Map result handle (`summary_handle`).
 		// It is NOT a permission failure — the handle simply aged out of the
 		// cache — so it must be caught before the permission branch below.
 		// Retryable + non-fatal: re-minting the handle (list/fetch again) and
@@ -160,6 +159,13 @@ func classifyToolError(toolName string, err error) ToolErrorEnvelope {
 		} else {
 			env.ErrorCode, env.Retryable, env.Fatal = "TOOL_ERROR", true, false
 		}
+	}
+	// Reduce is the completeness boundary. Any merge_summaries failure leaves
+	// successful Map output without a validated final synthesis, so it must latch
+	// the run as failed until a later merge succeeds. Retryability still follows
+	// the classification above; OnToolSuccess clears the fatal marker.
+	if toolName == "merge_summaries" {
+		env.Fatal = true
 	}
 	return env
 }

--- a/internal/agent/tool_error_test.go
+++ b/internal/agent/tool_error_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -41,6 +42,39 @@ func TestClassifyToolError(t *testing.T) {
 		{"bare required does not classify as argument", "fetch_channel", errors.New("required backend unavailable"), "CRITICAL_TOOL_ERROR", true, true},
 		{"evidence", "fetch_channel", errors.New("persist evidence: db down"), "EVIDENCE_WRITE_FAILED", false, true},
 		{"critical default", "summarize_chunk", errors.New("something odd"), "CRITICAL_TOOL_ERROR", true, true},
+		// PR #208 round-5 P2-4. These are per-request store caps: the store only
+		// grows within a request, so a retry hits the identical cap. Classified
+		// retryable (via the critical-tool default, because the message spells
+		// "summary handle" with a space and missed the "summary_handle" branch),
+		// they made the runner nudge an identical retry every step until MaxSteps
+		// and end the request with ZERO output.
+		{
+			"store handle-count cap is a deterministic dead end",
+			"summarize_chunk",
+			fmt.Errorf("store summary result: %w", fmt.Errorf("%w: too many summary handles in one request (max 128)", ErrSummaryHandleCapacity)),
+			"RESOURCE_EXHAUSTED", false, true,
+		},
+		{
+			"store text-size cap is a deterministic dead end",
+			"summarize_chunk",
+			fmt.Errorf("store summary result: %w", fmt.Errorf("%w: summary handle text exceeds per-request limit (8388608 bytes)", ErrSummaryHandleCapacity)),
+			"RESOURCE_EXHAUSTED", false, true,
+		},
+		{
+			"store cap on a non-critical tool is not fatal",
+			"peek_channel",
+			fmt.Errorf("%w: too many summary handles in one request (max 128)", ErrSummaryHandleCapacity),
+			"RESOURCE_EXHAUSTED", false, false,
+		},
+		// The model passing more handles than can exist is NOT a capacity dead
+		// end: it can fix its own arguments, so it keeps the retryable handle
+		// classification.
+		{
+			"too many handles in the ARGUMENTS stays retryable",
+			"merge_summaries",
+			errors.New("too many summary_handles (max 128)"),
+			"INVALID_ARGUMENT", true, true,
+		},
 		{"noncritical default", "get_current_time", errors.New("something odd"), "TOOL_ERROR", true, false},
 		// A permission denial is fatal only where it costs the deliverable something.
 		{"permission on a non-critical tool is not fatal", "peek_channel", errors.New("channel 12345 not accessible by user u-88"), "PERMISSION_DENIED", false, false},

--- a/internal/agent/tool_error_test.go
+++ b/internal/agent/tool_error_test.go
@@ -26,6 +26,8 @@ func TestClassifyToolError(t *testing.T) {
 		{"channel-scoped permission", "fetch_channel", errors.New("channel not accessible by user"), "PERMISSION_DENIED", false, false},
 		{"identity", "summarize_chunk", errors.New("missing user identity in context"), "PERMISSION_DENIED", false, true},
 		{"invalid args", "fetch_channel", errors.New("parse args: bad json"), "INVALID_ARGUMENT", true, false},
+		{"merge invalid args is completeness-fatal", "merge_summaries", errors.New("parse args: unexpected end of JSON input"), "INVALID_ARGUMENT", true, true},
+		{"merge timeout is completeness-fatal", "merge_summaries", context.DeadlineExceeded, "TIMEOUT", true, true},
 		{"empty time_start (issue C)", "fetch_channel", errors.New("parse time_start: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\""), "INVALID_ARGUMENT", true, false},
 		{"specific required arg", "fetch_channel", errors.New("channel_type is required (1=DM, 2=Group, 5=Thread)"), "INVALID_ARGUMENT", true, false},
 		// The critical-tool default is fatal AND retryable. The two fields answer
@@ -153,9 +155,23 @@ func TestClassifyToolErrorAnchorsHTTPStatuses(t *testing.T) {
 
 	// Real statuses must still classify.
 	for _, msg := range []string{"LLM API error: status=503 body=upstream busy", "http 429 too many"} {
-		env = classifyToolError("merge_summaries", errors.New(msg))
+		env = classifyToolError("fetch_channel", errors.New(msg))
 		if env.Fatal || !env.Retryable {
 			t.Errorf("classifyToolError(%q) = %s fatal=%t, want retryable", msg, env.ErrorCode, env.Fatal)
+		}
+	}
+}
+
+func TestMergeSummariesErrorsAreAlwaysFatalUntilRecovered(t *testing.T) {
+	for _, err := range []error{
+		errors.New("parse args: unexpected end of JSON input"),
+		context.DeadlineExceeded,
+		errors.New("LLM API error: status=503 body=busy"),
+		errors.New("invalid or expired summary_handle: map_old_1"),
+	} {
+		env := classifyToolError("merge_summaries", err)
+		if !env.Fatal {
+			t.Errorf("merge_summaries error %q must be fatal until a successful retry: %+v", err, env)
 		}
 	}
 }

--- a/internal/agent/tool_error_test.go
+++ b/internal/agent/tool_error_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestClassifyToolError(t *testing.T) {
@@ -291,6 +293,103 @@ func TestRunnerReportsToolSuccess(t *testing.T) {
 
 	if len(succeeded) != 1 || succeeded[0] != "fetch_channel" {
 		t.Fatalf("OnToolSuccess not fired for a successful call, got %v", succeeded)
+	}
+}
+
+// TestRunnerSameStepSuccessWinsRegardlessCompletionOrder pins PR #208 round-3
+// B1. Duplicate merge_summaries calls share one (tool, target) fatal-marker key.
+// A successful full Reduce in the same planner step must win over a failed
+// sibling regardless of which worker returns last; otherwise callback scheduling
+// can turn a saved deliverable into a false FAILED verdict.
+func TestRunnerSameStepSuccessWinsRegardlessCompletionOrder(t *testing.T) {
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+
+	for _, first := range []string{"success", "failure"} {
+		t.Run(first+" completes first", func(t *testing.T) {
+			started := make(chan string, 2)
+			finished := make(chan string, 2)
+			release := map[string]chan struct{}{
+				"success": make(chan struct{}),
+				"failure": make(chan struct{}),
+			}
+
+			reg := NewRegistry()
+			reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "merge_summaries"}},
+				func(_ context.Context, args json.RawMessage) (string, error) {
+					var req struct {
+						Outcome string `json:"outcome"`
+					}
+					if err := json.Unmarshal(args, &req); err != nil {
+						return "", err
+					}
+					started <- req.Outcome
+					<-release[req.Outcome]
+					finished <- req.Outcome
+					if req.Outcome == "failure" {
+						return "", errors.New("reduce failed")
+					}
+					return `{"merged_summary":"complete"}`, nil
+				})
+
+			r := NewRunner(nil, reg, NewPool(2), Policy{})
+			var mu sync.Mutex
+			failed := false
+			errorsSeen := 0
+			successesSeen := 0
+			r.OnToolError = func(_, _ string, env ToolErrorEnvelope) {
+				mu.Lock()
+				defer mu.Unlock()
+				errorsSeen++
+				if env.Fatal {
+					failed = true
+				}
+			}
+			r.OnToolSuccess = func(_, _ string) {
+				mu.Lock()
+				defer mu.Unlock()
+				successesSeen++
+				failed = false
+			}
+
+			calls := []ToolCall{
+				mkToolCall("reduce-success", "merge_summaries", `{"outcome":"success"}`),
+				mkToolCall("reduce-failure", "merge_summaries", `{"outcome":"failure"}`),
+			}
+			done := make(chan struct{})
+			go func() {
+				r.runTools(context.Background(), calls, 1, 1)
+				close(done)
+			}()
+
+			<-started
+			<-started
+			close(release[first])
+			if got := <-finished; got != first {
+				t.Fatalf("first completed worker = %q, want %q", got, first)
+			}
+			// Give the first Dispatch return and its callback time to complete before
+			// releasing the sibling. This makes both historical callback orders
+			// deterministic while the production fix itself does not rely on timing.
+			time.Sleep(20 * time.Millisecond)
+			second := "success"
+			if first == "success" {
+				second = "failure"
+			}
+			close(release[second])
+			if got := <-finished; got != second {
+				t.Fatalf("second completed worker = %q, want %q", got, second)
+			}
+			<-done
+
+			mu.Lock()
+			defer mu.Unlock()
+			if errorsSeen != 1 || successesSeen != 1 {
+				t.Fatalf("callbacks = errors:%d successes:%d, want 1 each", errorsSeen, successesSeen)
+			}
+			if failed {
+				t.Fatal("same-step successful Reduce must clear its duplicate sibling failure")
+			}
+		})
 	}
 }
 

--- a/internal/agent/tool_merge_summaries.go
+++ b/internal/agent/tool_merge_summaries.go
@@ -66,7 +66,7 @@ func MergeSummariesTool() (Tool, Handler) {
 		specGuidance := loadRunSpecGuidance(ctx)
 
 		// Use LLM to merge and structure
-		merged, err := mergeSummariesLLM(ctx, combined, specGuidance)
+		merged, truncated, err := mergeSummariesLLM(ctx, combined, specGuidance)
 		if err != nil {
 			return "", fmt.Errorf("merge summaries: %w", err)
 		}
@@ -78,10 +78,23 @@ func MergeSummariesTool() (Tool, Handler) {
 			"merged_summary": merged,
 			"chunk_count":    chunkCount,
 		}
+		// A length-truncated Reduce is degraded, not failed. The planner must be
+		// able to see the degradation structurally (not only as prose buried in
+		// merged_summary) so it repeats the disclosure in the final answer rather
+		// than presenting a partial merge as a complete one.
+		if truncated {
+			result["truncated"] = true
+			result["truncation_notice"] = strings.TrimSpace(service.TruncationNotice)
+		}
 		data, err := json.Marshal(result)
 		if err != nil {
 			return "", fmt.Errorf("marshal result: %w", err)
 		}
+		// Reached on the truncated-but-usable path too. Skipping it would leave
+		// NeedsReduce() true forever: the runner gate would reject every final
+		// answer and nudge an IDENTICAL merge_summaries retry (same handles, same
+		// combined text, no shrinking parameter), which truncates again until
+		// MaxSteps and ends the request with zero output.
 		store.MarkReduced(resolved.Generation)
 		return string(data), nil
 	}
@@ -97,7 +110,14 @@ var mergeSummariesLLM = mergeSummariesWithLLM
 // user's language / detail level / required sections / exclusions; the priority
 // note inside the guidance lets detail_level=detailed override the default
 // "每条不超过 50 字" compression. Empty (V2 off) → the exact legacy prompt.
-func mergeSummariesWithLLM(ctx context.Context, combined string, specGuidance string) (string, error) {
+//
+// Truncation policy: this is the TERMINAL deliverable of the agent Map/Reduce
+// pipeline, so it DISCLOSES rather than rejects (CallDisclosingTruncation).
+// Map (summarize_chunk) keeps CallStrict: a truncated chunk drops messages that
+// no later stage can recover, which is the SS-01 no-silent-loss invariant. Here
+// the input is already-summarized text and the output goes straight to the
+// user, so a hard failure trades a degraded answer for no answer at all.
+func mergeSummariesWithLLM(ctx context.Context, combined string, specGuidance string) (string, bool, error) {
 	_, _, _, cfg := GetSummaryDeps()
 	client := service.NewLLMClient(cfg.LLMApiURL, cfg.LLMApiKey, cfg.LLMModel, cfg.LLMTimeout, cfg.LLMMaxToken, cfg.LLMEnableThinking, 30, cfg.LLMFallbackModels)
 
@@ -124,6 +144,6 @@ func mergeSummariesWithLLM(ctx context.Context, combined string, specGuidance st
 		{Role: "user", Content: combined},
 	}
 
-	content, _, err := client.CallStrict(ctx, msgs, 0.1)
-	return content, err
+	content, truncated, _, err := client.CallDisclosingTruncation(ctx, msgs, 0.1)
+	return content, truncated, err
 }

--- a/internal/agent/tool_merge_summaries.go
+++ b/internal/agent/tool_merge_summaries.go
@@ -124,6 +124,6 @@ func mergeSummariesWithLLM(ctx context.Context, combined string, specGuidance st
 		{Role: "user", Content: combined},
 	}
 
-	content, _, err := client.Call(ctx, msgs, 0.1)
+	content, _, err := client.CallStrict(ctx, msgs, 0.1)
 	return content, err
 }

--- a/internal/agent/tool_merge_summaries.go
+++ b/internal/agent/tool_merge_summaries.go
@@ -15,35 +15,50 @@ func MergeSummariesTool() (Tool, Handler) {
 		Type: "function",
 		Function: ToolFunction{
 			Name:        "merge_summaries",
-			Description: "将多个局部总结合并为最终的结构化摘要（Reduce 阶段）。提取关键点、决策、待办事项。",
+			Description: "将本次请求中 summarize_chunk 返回的全部 summary_handle 合并为最终结构化摘要（Reduce 阶段）。只传 handle，不要复制摘要正文。",
 			Parameters: map[string]interface{}{
-				"type": "object",
+				"type":                 "object",
+				"additionalProperties": false,
 				"properties": map[string]interface{}{
-					"summaries": map[string]interface{}{
+					"summary_handles": map[string]interface{}{
 						"type":        "array",
 						"items":       map[string]interface{}{"type": "string"},
-						"description": "局部总结文本列表，由 summarize_chunk 返回",
+						"minItems":    1,
+						"uniqueItems": true,
+						"description": "本次请求内 summarize_chunk 返回的全部 summary_handle，按工具结果顺序传入",
 					},
 				},
-				"required": []string{"summaries"},
+				"required": []string{"summary_handles"},
 			},
 		},
 	}
 
 	handler := func(ctx context.Context, args json.RawMessage) (string, error) {
 		var req struct {
-			Summaries []string `json:"summaries"`
+			SummaryHandles []string `json:"summary_handles"`
 		}
 		if err := json.Unmarshal(args, &req); err != nil {
 			return "", fmt.Errorf("parse args: %w", err)
 		}
 
-		if len(req.Summaries) == 0 {
-			return "{\"highlights\":[\"无内容可合并\"]}", nil
+		store, err := summaryHandleStoreFromContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		resolved, err := store.ResolveAllBefore(req.SummaryHandles, summaryToolStepFromContext(ctx))
+		if err != nil {
+			return "", err
 		}
 
-		// Combine all summaries
-		combined := strings.Join(req.Summaries, "\n\n--- Chunk Boundary ---\n\n")
+		// The planner only sees short handles. The full Map text is joined here,
+		// inside the backend, and sent directly to the Reduce LLM.
+		summaries := make([]string, 0, len(resolved.Entries))
+		chunkCount := 0
+		for _, entry := range resolved.Entries {
+			summaries = append(summaries, entry.Text)
+			chunkCount += entry.ChunkCount
+		}
+		combined := strings.Join(summaries, "\n\n--- Chunk Boundary ---\n\n")
 
 		// SS-06: load the run's SummarySpec-derived guidance so the Reduce
 		// respects the user's language / detail level / sections / exclusions
@@ -51,24 +66,30 @@ func MergeSummariesTool() (Tool, Handler) {
 		specGuidance := loadRunSpecGuidance(ctx)
 
 		// Use LLM to merge and structure
-		merged, err := mergeSummariesWithLLM(ctx, combined, specGuidance)
+		merged, err := mergeSummariesLLM(ctx, combined, specGuidance)
 		if err != nil {
 			return "", fmt.Errorf("merge summaries: %w", err)
+		}
+		if strings.TrimSpace(merged) == "" {
+			return "", fmt.Errorf("merge summaries: empty Reduce result")
 		}
 
 		result := map[string]interface{}{
 			"merged_summary": merged,
-			"chunk_count":    len(req.Summaries),
+			"chunk_count":    chunkCount,
 		}
 		data, err := json.Marshal(result)
 		if err != nil {
 			return "", fmt.Errorf("marshal result: %w", err)
 		}
+		store.MarkReduced(resolved.Generation)
 		return string(data), nil
 	}
 
 	return schema, handler
 }
+
+var mergeSummariesLLM = mergeSummariesWithLLM
 
 // mergeSummariesWithLLM uses LLM to merge and structure multiple summaries.
 //

--- a/internal/agent/tool_merge_summaries.go
+++ b/internal/agent/tool_merge_summaries.go
@@ -70,19 +70,30 @@ func MergeSummariesTool() (Tool, Handler) {
 		if err != nil {
 			return "", fmt.Errorf("merge summaries: %w", err)
 		}
+		// This check is load-bearing precisely BECAUSE the client no longer
+		// appends the disclosure: `merged` here is the raw model body. When the
+		// client concatenated TruncationNotice before returning, a whitespace-only
+		// truncated completion arrived as " \n\t" + notice, this guard could never
+		// fire, MarkReduced below cleared the completeness gate, and the user got
+		// a deliverable whose entire body was the notice.
 		if strings.TrimSpace(merged) == "" {
 			return "", fmt.Errorf("merge summaries: empty Reduce result")
 		}
 
+		// A length-truncated Reduce is degraded, not failed. The planner must be
+		// able to see the degradation structurally (not only as prose buried in
+		// merged_summary) so it repeats the disclosure in the final answer rather
+		// than presenting a partial merge as a complete one. The notice is
+		// appended here, after the emptiness check above has passed on the raw
+		// body, and only in merged_summary: `truncation_notice` stays the
+		// structural signal so a planner concatenating both fields does not emit
+		// the same sentence twice.
 		result := map[string]interface{}{
 			"merged_summary": merged,
 			"chunk_count":    chunkCount,
 		}
-		// A length-truncated Reduce is degraded, not failed. The planner must be
-		// able to see the degradation structurally (not only as prose buried in
-		// merged_summary) so it repeats the disclosure in the final answer rather
-		// than presenting a partial merge as a complete one.
 		if truncated {
+			result["merged_summary"] = merged + service.TruncationNotice
 			result["truncated"] = true
 			result["truncation_notice"] = strings.TrimSpace(service.TruncationNotice)
 		}
@@ -117,6 +128,10 @@ var mergeSummariesLLM = mergeSummariesWithLLM
 // no later stage can recover, which is the SS-01 no-silent-loss invariant. Here
 // the input is already-summarized text and the output goes straight to the
 // user, so a hard failure trades a degraded answer for no answer at all.
+//
+// The returned content is the RAW model body: CallDisclosingTruncation does not
+// append TruncationNotice, so the handler can still tell an empty truncated
+// Reduce from a usable one before it decides to disclose.
 func mergeSummariesWithLLM(ctx context.Context, combined string, specGuidance string) (string, bool, error) {
 	_, _, _, cfg := GetSummaryDeps()
 	client := service.NewLLMClient(cfg.LLMApiURL, cfg.LLMApiKey, cfg.LLMModel, cfg.LLMTimeout, cfg.LLMMaxToken, cfg.LLMEnableThinking, 30, cfg.LLMFallbackModels)

--- a/internal/agent/tool_merge_summaries_truncation_test.go
+++ b/internal/agent/tool_merge_summaries_truncation_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 )
 
 // PR #208 round-4 B2/P1. A length-truncated agent Reduce used to hard-fail the
@@ -200,8 +202,52 @@ func TestRunnerDeliversTruncatedReduceWithDisclosure(t *testing.T) {
 // An EMPTY truncated Reduce has nothing to deliver and nothing to disclose
 // against, so it must still be an error rather than a bare notice presented as
 // a summary.
+//
+// The whitespace cases are PR #208 round-5 P1-1. " \n\t" is not "", so the
+// service client's `content == ""` guard let it take the disclose branch; the
+// client then appended TruncationNotice itself, which pre-satisfied this
+// handler's own `strings.TrimSpace(merged) == ""` check. The result was a
+// deliverable whose entire body was the truncation notice, with MarkReduced
+// called and NeedsReduce() false — the completeness gate cleared by a Reduce
+// that produced nothing.
 func TestMergeSummariesRejectsEmptyTruncatedReduce(t *testing.T) {
-	srv, _ := truncatedReduceServer(t, "")
+	for _, body := range []string{"", " \n\t", "   ", "\n"} {
+		t.Run(strconv.Quote(body), func(t *testing.T) {
+			srv, _ := truncatedReduceServer(t, body)
+			withReduceLLM(t, srv.URL)
+
+			ctx := withSummaryHandleStore(context.Background())
+			store, err := summaryHandleStoreFromContext(ctx)
+			if err != nil {
+				t.Fatalf("store: %v", err)
+			}
+			handle, err := store.Put("局部总结正文", 2)
+			if err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+
+			_, handler := MergeSummariesTool()
+			args, _ := json.Marshal(map[string]interface{}{"summary_handles": []string{handle}})
+			out, err := handler(ctx, args)
+			if err == nil || !strings.Contains(err.Error(), "truncated") {
+				t.Fatalf("out=%q err=%v, want empty truncation to fail loudly", out, err)
+			}
+			if strings.Contains(out, "输出因长度限制被截断") {
+				t.Fatalf("out=%q, want no bare disclosure returned as a deliverable", out)
+			}
+			if !store.NeedsReduce() {
+				t.Fatal("a failed Reduce must leave the completeness gate armed")
+			}
+		})
+	}
+}
+
+// The notice must appear exactly ONCE inside merged_summary. A planner that
+// concatenates merged_summary and truncation_notice would otherwise repeat the
+// same sentence, and if BOTH the client and the handler appended it the body
+// itself would already carry it twice.
+func TestMergeSummariesAppendsDisclosureExactlyOnce(t *testing.T) {
+	srv, _ := truncatedReduceServer(t, "合并结果：项目进展（正文在此被截断")
 	withReduceLLM(t, srv.URL)
 
 	ctx := withSummaryHandleStore(context.Background())
@@ -217,11 +263,25 @@ func TestMergeSummariesRejectsEmptyTruncatedReduce(t *testing.T) {
 	_, handler := MergeSummariesTool()
 	args, _ := json.Marshal(map[string]interface{}{"summary_handles": []string{handle}})
 	out, err := handler(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "truncated") {
-		t.Fatalf("out=%q err=%v, want empty truncation to fail loudly", out, err)
+	if err != nil {
+		t.Fatalf("a non-empty truncated Reduce must remain usable: %v", err)
 	}
-	if !store.NeedsReduce() {
-		t.Fatal("a failed Reduce must leave the completeness gate armed")
+	var result struct {
+		MergedSummary string `json:"merged_summary"`
+		Truncated     bool   `json:"truncated"`
+		Notice        string `json:"truncation_notice"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal merge result: %v", err)
+	}
+	if !result.Truncated || result.Notice == "" {
+		t.Fatalf("merge result did not flag truncation structurally: %s", out)
+	}
+	if n := strings.Count(result.MergedSummary, "输出因长度限制被截断"); n != 1 {
+		t.Fatalf("disclosure appears %d times in merged_summary, want exactly 1: %q", n, result.MergedSummary)
+	}
+	if !strings.HasSuffix(result.MergedSummary, service.TruncationNotice) {
+		t.Fatalf("merged_summary = %q, want the shared notice appended verbatim at the end", result.MergedSummary)
 	}
 }
 

--- a/internal/agent/tool_merge_summaries_truncation_test.go
+++ b/internal/agent/tool_merge_summaries_truncation_test.go
@@ -1,0 +1,240 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+)
+
+// PR #208 round-4 B2/P1. A length-truncated agent Reduce used to hard-fail the
+// whole request with ZERO output and no way to recover:
+//
+//	merge_summaries -> CallStrict -> any finish_reason=length is an error, the
+//	non-empty partial merge is DISCARDED -> the handler returns before
+//	store.MarkReduced -> NeedsReduce() stays true -> tool_error marks every
+//	merge_summaries failure fatal -> the runner gate rejects every final answer
+//	and nudges a retry -> the retry is byte-identical (same handles, same
+//	combined text, same temperature; the tool exposes no parameter that could
+//	shrink the output) -> it truncates again every step until MaxSteps.
+//
+// These tests pin the disclosure contract that replaced it, and the one case
+// that must still fail.
+
+// withReduceLLM points the summary deps at a stub LLM endpoint and restores
+// whatever deps the package had before (they are process-global).
+func withReduceLLM(t *testing.T, url string) {
+	t.Helper()
+	prev := func() (cfg config.Config) {
+		defer func() { _ = recover() }() // deps may be unset in a fresh package run
+		_, _, _, cfg = GetSummaryDeps()
+		return cfg
+	}()
+
+	cfg := prev
+	cfg.LLMApiURL = url
+	cfg.LLMApiKey = "test-key"
+	cfg.LLMModel = "test-model"
+	cfg.LLMTimeout = 5
+	cfg.LLMMaxToken = 4096
+	cfg.LLMEnableThinking = false
+	SetSummaryDeps(nil, nil, nil, cfg)
+	t.Cleanup(func() { SetSummaryDeps(nil, nil, nil, prev) })
+}
+
+// truncatedReduceServer always answers with finish_reason=length and the given
+// content, and counts how many Reduce round-trips the run actually spent.
+func truncatedReduceServer(t *testing.T, content string) (*httptest.Server, *int64) {
+	t.Helper()
+	var hits int64
+	body, err := json.Marshal(map[string]interface{}{
+		"choices": []map[string]interface{}{{
+			"message":       map[string]interface{}{"content": content},
+			"finish_reason": "length",
+		}},
+		"usage": map[string]interface{}{"total_tokens": 4096, "completion_tokens": 4096},
+	})
+	if err != nil {
+		t.Fatalf("marshal stub response: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// truncationPlannerClient is a minimal planner: Map, then Reduce over every
+// returned handle, then answer with whatever the Reduce produced. If Reduce
+// errors it keeps retrying, which is exactly the pre-fix behavior that burned
+// MaxSteps.
+type truncationPlannerClient struct {
+	calls           int
+	mergeAttempts   int
+	sawNudge        bool
+	lastMergeResult string
+}
+
+func (c *truncationPlannerClient) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
+	c.calls++
+	var handles []string
+	mergeResult := ""
+	for _, msg := range msgs {
+		if strings.HasPrefix(msg.Content, "本次请求仍有未合并的 Map 结果") {
+			c.sawNudge = true
+		}
+		if msg.Role != "tool" {
+			continue
+		}
+		switch msg.Name {
+		case "summarize_chunk":
+			var result struct {
+				SummaryHandle string `json:"summary_handle"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.SummaryHandle != "" {
+				handles = append(handles, result.SummaryHandle)
+			}
+		case "merge_summaries":
+			var result struct {
+				MergedSummary string `json:"merged_summary"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.MergedSummary != "" {
+				mergeResult = msg.Content
+			}
+		}
+	}
+
+	if mergeResult != "" {
+		c.lastMergeResult = mergeResult
+		var result struct {
+			MergedSummary string `json:"merged_summary"`
+		}
+		_ = json.Unmarshal([]byte(mergeResult), &result)
+		// The planner's final answer is the Reduce deliverable verbatim, so the
+		// disclosure it carries reaches the user.
+		return AssistantTurn{Content: result.MergedSummary}, nil
+	}
+
+	if len(handles) > 0 {
+		c.mergeAttempts++
+		args, _ := json.Marshal(map[string]interface{}{"summary_handles": handles})
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("reduce-call", "merge_summaries", string(args)),
+		}}, nil
+	}
+	return AssistantTurn{ToolCalls: []ToolCall{
+		mkToolCall("map-call", "summarize_chunk", `{}`),
+	}}, nil
+}
+
+// A non-empty truncated Reduce must still produce output, disclose the
+// truncation, clear the Reduce gate, and cost exactly ONE Reduce round-trip.
+func TestRunnerDeliversTruncatedReduceWithDisclosure(t *testing.T) {
+	srv, hits := truncatedReduceServer(t, "合并结果：项目进展、风险与待办（正文在此被截断")
+	withReduceLLM(t, srv.URL)
+
+	reg := NewRegistry()
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "summarize_chunk"}},
+		func(ctx context.Context, _ json.RawMessage) (string, error) {
+			store, err := summaryHandleStoreFromContext(ctx)
+			if err != nil {
+				return "", err
+			}
+			handle, err := store.PutAtStep("局部总结正文", 3, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			data, _ := json.Marshal(map[string]interface{}{"summary_handle": handle, "chunk_count": 3})
+			return string(data), nil
+		})
+	reg.Register(MergeSummariesTool())
+
+	client := &truncationPlannerClient{}
+	// MaxTokens is set high on purpose: a zero budget makes the runner inject its
+	// budget instruction every step, which is unrelated noise for this test.
+	runner := NewRunner(client, reg, NewPool(2), Policy{MaxSteps: 8, MaxTokens: 1 << 20, StepTimeout: 5 * time.Second})
+	out, _, err := runner.RunWithHistory(context.Background(), "system", nil, "summarize")
+	if err != nil {
+		t.Fatalf("a non-empty truncated Reduce must not fail the request: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("request produced ZERO output for a usable truncated Reduce")
+	}
+	if !strings.Contains(out, "合并结果：项目进展") {
+		t.Fatalf("final answer lost the partial merge: %q", out)
+	}
+	if !strings.Contains(out, "输出因长度限制被截断") {
+		t.Fatalf("truncation was not disclosed to the user: %q", out)
+	}
+	if got := atomic.LoadInt64(hits); got != 1 {
+		t.Fatalf("Reduce LLM round-trips = %d, want exactly 1 (identical retries are pure waste)", got)
+	}
+	if client.mergeAttempts != 1 {
+		t.Fatalf("merge_summaries attempts = %d, want 1", client.mergeAttempts)
+	}
+	if client.sawNudge {
+		t.Fatal("runner still nudged for a Reduce after a usable merge; NeedsReduce() was never cleared")
+	}
+	// The planner must be able to see the degradation structurally, not only as
+	// prose inside merged_summary.
+	var result struct {
+		Truncated bool   `json:"truncated"`
+		Notice    string `json:"truncation_notice"`
+	}
+	if err := json.Unmarshal([]byte(client.lastMergeResult), &result); err != nil {
+		t.Fatalf("unmarshal merge result: %v", err)
+	}
+	if !result.Truncated || result.Notice == "" {
+		t.Fatalf("merge result did not flag truncation: %s", client.lastMergeResult)
+	}
+}
+
+// An EMPTY truncated Reduce has nothing to deliver and nothing to disclose
+// against, so it must still be an error rather than a bare notice presented as
+// a summary.
+func TestMergeSummariesRejectsEmptyTruncatedReduce(t *testing.T) {
+	srv, _ := truncatedReduceServer(t, "")
+	withReduceLLM(t, srv.URL)
+
+	ctx := withSummaryHandleStore(context.Background())
+	store, err := summaryHandleStoreFromContext(ctx)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	handle, err := store.Put("局部总结正文", 2)
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, handler := MergeSummariesTool()
+	args, _ := json.Marshal(map[string]interface{}{"summary_handles": []string{handle}})
+	out, err := handler(ctx, args)
+	if err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("out=%q err=%v, want empty truncation to fail loudly", out, err)
+	}
+	if !store.NeedsReduce() {
+		t.Fatal("a failed Reduce must leave the completeness gate armed")
+	}
+}
+
+// The Map phase must NOT inherit the disclosure: a truncated chunk summary
+// silently drops messages that no later stage can recover (SS-01).
+func TestSummarizeChunkStillRejectsTruncatedMap(t *testing.T) {
+	srv, _ := truncatedReduceServer(t, "局部总结被截断")
+	withReduceLLM(t, srv.URL)
+
+	_, _, _, err := summarizeMessagesChunk(context.Background(), []map[string]interface{}{
+		{"content": "hello", "sender_name": "a"},
+	}, "")
+	if err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("error = %v, want a truncated Map chunk to keep failing loudly", err)
+	}
+}

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -228,7 +228,7 @@ func SummarizeChunkTool() (Tool, Handler) {
 		Type: "function",
 		Function: ToolFunction{
 			Name:        "summarize_chunk",
-			Description: "对缓存中的一批消息进行局部总结（Map 阶段）。返回结构化摘要文本。",
+			Description: "对缓存中的一批消息进行局部总结（Map 阶段）。正文保存在本次请求内，返回 summary_handle 和覆盖统计；后续 merge_summaries 必须传 handle，不要复制正文。",
 			Parameters: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -278,7 +278,7 @@ func SummarizeChunkTool() (Tool, Handler) {
 			// Same result shape as the normal path (PR #196 review P2-5,
 			// closed in round-3): the planner must see one stable contract on
 			// both branches, so the empty branch carries chunk_size too.
-			return `{"summary":"无可总结内容","chunk_count":0,"input_count":0,"processed_count":0,"dropped_count":0,"oversized_message_count":0,"truncated":false,"chunk_size":0}`, nil
+			return marshalSummarizeChunkResult(ctx, "无可总结内容", 0, chunkCoverage{})
 		}
 
 		// Get the global message pool for the session and pre-assign CitationIndex.
@@ -320,23 +320,14 @@ func SummarizeChunkTool() (Tool, Handler) {
 		if len(messages) == 0 {
 			if manifestMisses > 0 {
 				recordDroppedMessages(ctx, uid, runID, manifestMisses)
-				result := map[string]interface{}{
-					"summary":                 "无可总结内容",
-					"chunk_count":             0,
-					"input_count":             inputCount,
-					"processed_count":         0,
-					"dropped_count":           manifestMisses,
-					"oversized_message_count": 0,
-					"truncated":               true,
-					"chunk_size":              clampChunkSize(req.ChunkSize),
-				}
-				resultJSON, err := json.Marshal(result)
-				if err != nil {
-					return "", fmt.Errorf("marshal result: %w", err)
-				}
-				return string(resultJSON), nil
+				return marshalSummarizeChunkResult(ctx, "无可总结内容", 0, chunkCoverage{
+					InputCount:   inputCount,
+					DroppedCount: manifestMisses,
+					Truncated:    true,
+					ChunkSize:    clampChunkSize(req.ChunkSize),
+				})
 			}
-			return "{\"summary\":\"无可总结内容\",\"chunk_count\":0}", nil
+			return marshalSummarizeChunkResult(ctx, "无可总结内容", 0, chunkCoverage{})
 		}
 
 		// Convert to map format for the token-budget splitter.
@@ -380,28 +371,46 @@ func SummarizeChunkTool() (Tool, Handler) {
 		recordDroppedMessages(ctx, uid, runID, cov.DroppedCount)
 
 		combinedSummary := strings.Join(summaries, "\n\n---\n\n")
-		result := map[string]interface{}{
-			"summary":                 combinedSummary,
-			"chunk_count":             len(chunks),
-			"input_count":             cov.InputCount,
-			"processed_count":         cov.ProcessedCount,
-			"dropped_count":           cov.DroppedCount,
-			"oversized_message_count": cov.OversizedMessageCount,
-			"truncated":               cov.Truncated,
-			// chunk_size is now emitted (PR #196 review P2-5): it is the
-			// clamped value actually applied, not the raw model request.
-			"chunk_size": cov.ChunkSize,
-		}
-
-		// Marshal result
-		resultJSON, err := json.Marshal(result)
-		if err != nil {
-			return "", fmt.Errorf("marshal result: %w", err)
-		}
-		return string(resultJSON), nil
+		return marshalSummarizeChunkResult(ctx, combinedSummary, len(chunks), cov)
 	}
 
 	return schema, handler
+}
+
+type summarizeChunkToolResult struct {
+	SummaryHandle         string `json:"summary_handle"`
+	ChunkCount            int    `json:"chunk_count"`
+	InputCount            int    `json:"input_count"`
+	ProcessedCount        int    `json:"processed_count"`
+	DroppedCount          int    `json:"dropped_count"`
+	OversizedMessageCount int    `json:"oversized_message_count"`
+	Truncated             bool   `json:"truncated"`
+	ChunkSize             int    `json:"chunk_size"`
+}
+
+func marshalSummarizeChunkResult(ctx context.Context, summary string, chunkCount int, cov chunkCoverage) (string, error) {
+	store, err := summaryHandleStoreFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	handle, err := store.PutAtStep(summary, chunkCount, summaryToolStepFromContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("store summary result: %w", err)
+	}
+	data, err := json.Marshal(summarizeChunkToolResult{
+		SummaryHandle:         handle,
+		ChunkCount:            chunkCount,
+		InputCount:            cov.InputCount,
+		ProcessedCount:        cov.ProcessedCount,
+		DroppedCount:          cov.DroppedCount,
+		OversizedMessageCount: cov.OversizedMessageCount,
+		Truncated:             cov.Truncated,
+		ChunkSize:             cov.ChunkSize,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal result: %w", err)
+	}
+	return string(data), nil
 }
 
 func recordDroppedMessages(ctx context.Context, uid, runID string, count int) {

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -566,12 +566,17 @@ type chunkMapOutcome struct {
 //   - Cancellation. Acquiring the semaphore selects on ctx.Done(): when the
 //     request deadline fires, queued chunks abort immediately instead of
 //     waiting for an in-flight LLM call to release a slot.
+//   - Panic containment. Registry.Dispatch deliberately converts handler
+//     panics into tool errors. Map workers run below that recovery boundary, so
+//     each worker must recover locally to preserve the same process-safety
+//     contract as the old serial loop.
 //
 // Concurrency 1 takes a dedicated serial path (see below) rather than a
 // one-permit semaphore, so it is a true rollback switch.
 func summarizeChunksConcurrently(ctx context.Context, chunks [][]map[string]interface{}, specGuidance string, cov *chunkCoverage) ([]string, error) {
 	_, _, _, cfg := GetSummaryDeps()
 	concurrency := cfg.ResolveAgentMapConcurrency()
+	start := time.Now()
 
 	// Concurrency 1 is the documented rollback setting, so it must reproduce the
 	// pre-change loop EXACTLY — including dispatch order. A 1-permit semaphore
@@ -591,6 +596,8 @@ func summarizeChunksConcurrently(ctx context.Context, chunks [][]map[string]inte
 			cov.ProcessedCount += processed
 			cov.OversizedMessageCount += oversized
 		}
+		log.Printf("[summarize_chunk] map phase: chunks=%d concurrency=1 elapsed=%dms",
+			len(chunks), time.Since(start).Milliseconds())
 		return summaries, nil
 	}
 
@@ -598,11 +605,15 @@ func summarizeChunksConcurrently(ctx context.Context, chunks [][]map[string]inte
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 
-	start := time.Now()
 	for i, chunk := range chunks {
 		wg.Add(1)
 		go func(idx int, c []map[string]interface{}) {
 			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					outcomes[idx] = chunkMapOutcome{err: fmt.Errorf("map chunk %d panicked: %v", idx, p)}
+				}
+			}()
 			select {
 			case sem <- struct{}{}:
 			case <-ctx.Done():

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -484,7 +484,7 @@ func summarizeMessagesChunk(ctx context.Context, chunk []map[string]interface{},
 		{Role: "user", Content: formatted},
 	}
 
-	content, _, err := client.Call(ctx, msgs, 0.3)
+	content, _, err := client.CallStrict(ctx, msgs, 0.3)
 	if err != nil {
 		return "", processed, oversized, fmt.Errorf("call LLM: %w", err)
 	}

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
@@ -369,15 +371,9 @@ func SummarizeChunkTool() (Tool, Handler) {
 		// call summarizes toward the user's actual requirements. Empty when V2 is
 		// off / no run / no spec → legacy generic prompt.
 		specGuidance := loadRunSpecGuidance(ctx)
-		var summaries []string
-		for _, chunk := range chunks {
-			summary, processed, oversized, err := summarizeMessagesChunk(ctx, chunk, specGuidance)
-			if err != nil {
-				return "", fmt.Errorf("summarize chunk: %w", err)
-			}
-			summaries = append(summaries, summary)
-			cov.ProcessedCount += processed
-			cov.OversizedMessageCount += oversized
+		summaries, err := summarizeChunksConcurrently(ctx, chunks, specGuidance, &cov)
+		if err != nil {
+			return "", err
 		}
 		cov.DroppedCount = cov.InputCount - cov.ProcessedCount
 		cov.Truncated = cov.DroppedCount > 0
@@ -520,4 +516,120 @@ func assignCitationIndexes(messages []pipeline.Message, citationMap map[string]i
 		kept = append(kept, messages[i])
 	}
 	return kept, manifestMisses
+}
+
+// summarizeChunkFn is the Map call seam. Production always uses
+// summarizeMessagesChunk; tests swap it to drive concurrency/order/error
+// behaviour deterministically without a live LLM. It is only reassigned from
+// tests, before any goroutine starts, so it needs no synchronisation.
+var summarizeChunkFn = summarizeMessagesChunk
+
+// chunkMapOutcome is one Map call's result, held in a slot indexed by chunk
+// position. Every field is written by exactly one goroutine and read only after
+// wg.Wait(), so no field needs synchronisation of its own.
+type chunkMapOutcome struct {
+	summary   string
+	processed int
+	oversized int
+	err       error
+}
+
+// summarizeChunksConcurrently runs the Map phase over chunks with bounded
+// concurrency and returns the summaries in ORIGINAL chunk order, aggregating
+// coverage counters into cov.
+//
+// Why this is not a plain `go` over the old loop body:
+//
+//   - Order. Callers join the summaries into one document and the [n] citation
+//     markers inside them index a frozen manifest, so a completion-ordered
+//     append would reorder the deliverable. Results land in outcomes[i], never
+//     appended, so output order is independent of completion order.
+//   - Coverage counters. The serial loop incremented cov.ProcessedCount /
+//     cov.OversizedMessageCount inside the loop body. Those are plain ints on a
+//     shared struct; incrementing them from N goroutines is a data race and
+//     would silently under-count coverage — the exact class of defect SS-01
+//     exists to prevent. They are accumulated here, after Wait, in index order.
+//   - Error determinism. The serial loop failed on the first chunk by position.
+//     With concurrency, "first error to arrive" varies run to run, so the same
+//     input could surface different errors. This waits for every started
+//     goroutine and reports the LOWEST-INDEX error, preserving the old
+//     behaviour exactly.
+//   - Cancellation. Acquiring the semaphore selects on ctx.Done(): when the
+//     request deadline fires, queued chunks abort immediately instead of
+//     waiting for an in-flight LLM call to release a slot.
+//
+// Concurrency 1 takes a dedicated serial path (see below) rather than a
+// one-permit semaphore, so it is a true rollback switch.
+func summarizeChunksConcurrently(ctx context.Context, chunks [][]map[string]interface{}, specGuidance string, cov *chunkCoverage) ([]string, error) {
+	_, _, _, cfg := GetSummaryDeps()
+	concurrency := cfg.ResolveAgentMapConcurrency()
+
+	// Concurrency 1 is the documented rollback setting, so it must reproduce the
+	// pre-change loop EXACTLY — including dispatch order. A 1-permit semaphore
+	// would still only run one call at a time, but the goroutines race for that
+	// permit, so chunk 3 could be sent to the model before chunk 0. Output order
+	// would survive (indexed slots), but "identical to before" would not: an
+	// operator flipping this to 1 to debug a model-side ordering effect would
+	// still not be running the old code path. Short-circuit instead.
+	if concurrency <= 1 {
+		summaries := make([]string, 0, len(chunks))
+		for i, chunk := range chunks {
+			summary, processed, oversized, err := summarizeChunkFn(ctx, chunk, specGuidance)
+			if err != nil {
+				return nil, fmt.Errorf("summarize chunk %d: %w", i, err)
+			}
+			summaries = append(summaries, summary)
+			cov.ProcessedCount += processed
+			cov.OversizedMessageCount += oversized
+		}
+		return summaries, nil
+	}
+
+	outcomes := make([]chunkMapOutcome, len(chunks))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	start := time.Now()
+	for i, chunk := range chunks {
+		wg.Add(1)
+		go func(idx int, c []map[string]interface{}) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				outcomes[idx] = chunkMapOutcome{err: ctx.Err()}
+				return
+			}
+			defer func() { <-sem }()
+
+			// Re-check after acquiring. select picks uniformly among READY cases,
+			// so a goroutine can win the permit released by a call that just
+			// aborted on cancellation — dispatching a fresh LLM request for a
+			// request the client already gave up on. Without this guard a
+			// cancelled run still burns up to `concurrency` extra completions.
+			if err := ctx.Err(); err != nil {
+				outcomes[idx] = chunkMapOutcome{err: err}
+				return
+			}
+
+			summary, processed, oversized, err := summarizeChunkFn(ctx, c, specGuidance)
+			outcomes[idx] = chunkMapOutcome{summary: summary, processed: processed, oversized: oversized, err: err}
+		}(i, chunk)
+	}
+	wg.Wait()
+
+	log.Printf("[summarize_chunk] map phase: chunks=%d concurrency=%d elapsed=%dms",
+		len(chunks), concurrency, time.Since(start).Milliseconds())
+
+	summaries := make([]string, 0, len(chunks))
+	for i, o := range outcomes {
+		if o.err != nil {
+			// Lowest-index error wins (see doc comment): deterministic across runs.
+			return nil, fmt.Errorf("summarize chunk %d: %w", i, o.err)
+		}
+		summaries = append(summaries, o.summary)
+		cov.ProcessedCount += o.processed
+		cov.OversizedMessageCount += o.oversized
+	}
+	return summaries, nil
 }

--- a/internal/agent/tool_summarize_chunk_concurrency_test.go
+++ b/internal/agent/tool_summarize_chunk_concurrency_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,14 +23,11 @@ import (
 // test and restores whatever deps were set before.
 func withMapConcurrency(t *testing.T, n int) {
 	t.Helper()
-	summaryDB, imDB, octoClient, prev := func() (a, b interface{}, c interface{}, cfg config.Config) {
+	prev := func() (cfg config.Config) {
 		defer func() { _ = recover() }() // deps may be unset in a fresh package run
-		db, im, oc, cf := GetSummaryDeps()
-		return db, im, oc, cf
+		_, _, _, cfg = GetSummaryDeps()
+		return cfg
 	}()
-	_ = summaryDB
-	_ = imDB
-	_ = octoClient
 
 	cfg := prev
 	cfg.AgentMapConcurrency = n
@@ -191,7 +189,8 @@ func TestSummarizeChunksConcurrently_OneFailureFailsAll(t *testing.T) {
 // Queued chunks must abort on cancellation instead of waiting for an in-flight
 // LLM call to release a semaphore slot.
 func TestSummarizeChunksConcurrently_CancelReleasesQueuedChunks(t *testing.T) {
-	withMapConcurrency(t, 1) // everything after the first chunk queues on the semaphore
+	const concurrency = 3
+	withMapConcurrency(t, concurrency)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var started sync.WaitGroup
@@ -225,8 +224,29 @@ func TestSummarizeChunksConcurrently_CancelReleasesQueuedChunks(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected a cancellation error, got nil")
 	}
-	if n := atomic.LoadInt64(&calls); n > 1 {
-		t.Fatalf("%d Map calls started after cancellation, want 1 — queued chunks should abort at the semaphore", n)
+	if n := atomic.LoadInt64(&calls); n > concurrency {
+		t.Fatalf("%d Map calls started after cancellation, want <=%d — queued chunks should abort at the semaphore", n, concurrency)
+	}
+}
+
+// A panic below Registry.Dispatch's recovery boundary must become a normal Map
+// error rather than terminating the process.
+func TestSummarizeChunksConcurrently_PanicBecomesError(t *testing.T) {
+	withMapConcurrency(t, 2)
+	withStubMapCall(t, func(_ context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		if chunk[0]["content"].(string) == "chunk-1" {
+			panic("boom")
+		}
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(3), "", &cov)
+	if err == nil || !strings.Contains(err.Error(), "map chunk 1 panicked: boom") {
+		t.Fatalf("error = %v, want contained worker panic", err)
+	}
+	if got != nil {
+		t.Fatalf("panic must fail the whole Map phase, got %d summaries", len(got))
 	}
 }
 

--- a/internal/agent/tool_summarize_chunk_concurrency_test.go
+++ b/internal/agent/tool_summarize_chunk_concurrency_test.go
@@ -1,0 +1,268 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+)
+
+// Map-phase concurrency tests. All of them swap summarizeChunkFn, so none of
+// them touches a real LLM; they assert the four properties the concurrent Map
+// path must preserve relative to the previous serial loop: bounded fan-out,
+// original output order, deterministic (lowest-index) error, and prompt
+// cancellation.
+
+// withMapConcurrency installs cfg.AgentMapConcurrency for the duration of a
+// test and restores whatever deps were set before.
+func withMapConcurrency(t *testing.T, n int) {
+	t.Helper()
+	summaryDB, imDB, octoClient, prev := func() (a, b interface{}, c interface{}, cfg config.Config) {
+		defer func() { _ = recover() }() // deps may be unset in a fresh package run
+		db, im, oc, cf := GetSummaryDeps()
+		return db, im, oc, cf
+	}()
+	_ = summaryDB
+	_ = imDB
+	_ = octoClient
+
+	cfg := prev
+	cfg.AgentMapConcurrency = n
+	SetSummaryDeps(nil, nil, nil, cfg)
+	t.Cleanup(func() { SetSummaryDeps(nil, nil, nil, prev) })
+}
+
+// withStubMapCall swaps the Map seam and restores it afterwards.
+func withStubMapCall(t *testing.T, fn func(ctx context.Context, chunk []map[string]interface{}, specGuidance string) (string, int, int, error)) {
+	t.Helper()
+	prev := summarizeChunkFn
+	summarizeChunkFn = fn
+	t.Cleanup(func() { summarizeChunkFn = prev })
+}
+
+func makeChunks(n int) [][]map[string]interface{} {
+	chunks := make([][]map[string]interface{}, n)
+	for i := range chunks {
+		chunks[i] = []map[string]interface{}{{"content": fmt.Sprintf("chunk-%d", i)}}
+	}
+	return chunks
+}
+
+// The semaphore must cap in-flight Map calls at the configured concurrency.
+func TestSummarizeChunksConcurrently_RespectsConcurrencyLimit(t *testing.T) {
+	const concurrency = 3
+	withMapConcurrency(t, concurrency)
+
+	var inFlight, maxInFlight int64
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		cur := atomic.AddInt64(&inFlight, 1)
+		for {
+			old := atomic.LoadInt64(&maxInFlight)
+			if cur <= old || atomic.CompareAndSwapInt64(&maxInFlight, old, cur) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt64(&inFlight, -1)
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(6), "", &cov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 6 {
+		t.Fatalf("got %d summaries, want 6", len(got))
+	}
+	if maxInFlight > concurrency {
+		t.Fatalf("max in-flight Map calls = %d, want <= %d", maxInFlight, concurrency)
+	}
+	if maxInFlight < 2 {
+		t.Fatalf("max in-flight Map calls = %d — calls never overlapped, concurrency is not in effect", maxInFlight)
+	}
+}
+
+// Completion order must not affect output order: the joined document and its
+// [n] citation markers depend on chunk position.
+func TestSummarizeChunksConcurrently_PreservesChunkOrder(t *testing.T) {
+	withMapConcurrency(t, 5)
+
+	// Finish in reverse: the last chunk returns first.
+	const n = 5
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		id := chunk[0]["content"].(string)
+		var idx int
+		if _, err := fmt.Sscanf(id, "chunk-%d", &idx); err != nil {
+			t.Errorf("unexpected chunk payload %q", id)
+		}
+		time.Sleep(time.Duration(n-idx) * 15 * time.Millisecond)
+		return id, 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(n), "", &cov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, s := range got {
+		if want := fmt.Sprintf("chunk-%d", i); s != want {
+			t.Fatalf("summaries[%d] = %q, want %q — completion order leaked into output order", i, s, want)
+		}
+	}
+}
+
+// Coverage counters were incremented inside the old serial loop. Aggregating
+// them concurrently would be a data race and would under-count; assert the
+// totals are exact. Run this one under -race for full value.
+func TestSummarizeChunksConcurrently_AggregatesCoverageExactly(t *testing.T) {
+	withMapConcurrency(t, 4)
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		return "s", 7, 2, nil
+	})
+
+	cov := chunkCoverage{InputCount: 70}
+	if _, err := summarizeChunksConcurrently(context.Background(), makeChunks(10), "", &cov); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cov.ProcessedCount != 70 {
+		t.Fatalf("ProcessedCount = %d, want 70", cov.ProcessedCount)
+	}
+	if cov.OversizedMessageCount != 20 {
+		t.Fatalf("OversizedMessageCount = %d, want 20", cov.OversizedMessageCount)
+	}
+}
+
+// The serial loop failed on the first chunk BY POSITION. With concurrency,
+// "first error to arrive" is nondeterministic, so the lowest index must win.
+func TestSummarizeChunksConcurrently_ReturnsLowestIndexError(t *testing.T) {
+	withMapConcurrency(t, 5)
+
+	errEarly := errors.New("chunk 1 failed")
+	errLate := errors.New("chunk 4 failed")
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		id := chunk[0]["content"].(string)
+		switch id {
+		case "chunk-4":
+			return "", 0, 0, errLate // fails immediately
+		case "chunk-1":
+			time.Sleep(40 * time.Millisecond) // fails last
+			return "", 0, 0, errEarly
+		}
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	_, err := summarizeChunksConcurrently(context.Background(), makeChunks(5), "", &cov)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(err, errEarly) {
+		t.Fatalf("got %v, want the lowest-index error %v — error selection is not deterministic", err, errEarly)
+	}
+}
+
+// A single chunk failure must fail the whole tool: no partial deliverable.
+func TestSummarizeChunksConcurrently_OneFailureFailsAll(t *testing.T) {
+	withMapConcurrency(t, 3)
+	boom := errors.New("boom")
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		if chunk[0]["content"].(string) == "chunk-2" {
+			return "", 0, 0, boom
+		}
+		return "s", 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(4), "", &cov)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if got != nil {
+		t.Fatalf("expected no summaries on failure, got %d — partial output must not escape", len(got))
+	}
+}
+
+// Queued chunks must abort on cancellation instead of waiting for an in-flight
+// LLM call to release a semaphore slot.
+func TestSummarizeChunksConcurrently_CancelReleasesQueuedChunks(t *testing.T) {
+	withMapConcurrency(t, 1) // everything after the first chunk queues on the semaphore
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var started sync.WaitGroup
+	started.Add(1)
+	var once sync.Once
+	var calls int64
+
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		atomic.AddInt64(&calls, 1)
+		once.Do(started.Done)
+		<-ctx.Done() // first call blocks until cancellation
+		return "", 0, 0, ctx.Err()
+	})
+
+	done := make(chan struct{})
+	var cov chunkCoverage
+	var err error
+	go func() {
+		_, err = summarizeChunksConcurrently(ctx, makeChunks(8), "", &cov)
+		close(done)
+	}()
+
+	started.Wait()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("summarizeChunksConcurrently did not return after cancellation — queued chunks are not selecting on ctx.Done()")
+	}
+	if err == nil {
+		t.Fatal("expected a cancellation error, got nil")
+	}
+	if n := atomic.LoadInt64(&calls); n > 1 {
+		t.Fatalf("%d Map calls started after cancellation, want 1 — queued chunks should abort at the semaphore", n)
+	}
+}
+
+// Concurrency 1 must behave exactly like the previous serial loop: one call at
+// a time, in order. This is the documented rollback path.
+func TestSummarizeChunksConcurrently_ConcurrencyOneIsSerial(t *testing.T) {
+	withMapConcurrency(t, 1)
+
+	var mu sync.Mutex
+	var order []string
+	var inFlight, maxInFlight int64
+	withStubMapCall(t, func(ctx context.Context, chunk []map[string]interface{}, _ string) (string, int, int, error) {
+		cur := atomic.AddInt64(&inFlight, 1)
+		if cur > atomic.LoadInt64(&maxInFlight) {
+			atomic.StoreInt64(&maxInFlight, cur)
+		}
+		id := chunk[0]["content"].(string)
+		mu.Lock()
+		order = append(order, id)
+		mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+		atomic.AddInt64(&inFlight, -1)
+		return id, 1, 0, nil
+	})
+
+	var cov chunkCoverage
+	got, err := summarizeChunksConcurrently(context.Background(), makeChunks(4), "", &cov)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if maxInFlight != 1 {
+		t.Fatalf("max in-flight = %d with concurrency 1, want 1", maxInFlight)
+	}
+	for i := range got {
+		if want := fmt.Sprintf("chunk-%d", i); got[i] != want || order[i] != want {
+			t.Fatalf("serial path diverged at %d: got %q order %q, want %q", i, got[i], order[i], want)
+		}
+	}
+}

--- a/internal/agent/tool_summarize_chunk_first_turn_cgo_test.go
+++ b/internal/agent/tool_summarize_chunk_first_turn_cgo_test.go
@@ -259,7 +259,7 @@ func TestSummarizeChunkManifestMissesRecordedAsDropped(t *testing.T) {
 	t.Cleanup(func() { SetSummaryDeps(nil, nil, nil, config.Config{}) })
 
 	_, h := SummarizeChunkTool()
-	toolCtx := context.WithValue(ctx, ContextKeyUID, uid)
+	toolCtx := withSummaryHandleStore(context.WithValue(ctx, ContextKeyUID, uid))
 	toolCtx = context.WithValue(toolCtx, ContextKeySessionID, sessionID)
 	toolCtx = context.WithValue(toolCtx, ContextKeyRunID, run.RunID)
 	args, _ := json.Marshal(map[string]string{"messages_handle": handle})

--- a/internal/agent/tool_summary_handles_test.go
+++ b/internal/agent/tool_summary_handles_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMarshalSummarizeChunkResultReturnsOnlyHandleAndCoverage(t *testing.T) {
+	ctx := withSummaryHandleStore(context.Background())
+	largeSummary := strings.Repeat("局部总结正文", 6000)
+	out, err := marshalSummarizeChunkResult(ctx, largeSummary, 7, chunkCoverage{
+		InputCount:            1200,
+		ProcessedCount:        1200,
+		OversizedMessageCount: 2,
+		ChunkSize:             200,
+	})
+	if err != nil {
+		t.Fatalf("marshalSummarizeChunkResult: %v", err)
+	}
+	if len(out) >= 1024 {
+		t.Fatalf("planner-visible Map result is %d bytes, want < 1024", len(out))
+	}
+	if strings.Contains(out, largeSummary[:100]) || strings.Contains(out, `"summary":`) {
+		t.Fatal("planner-visible Map result leaked the summary body")
+	}
+
+	var result summarizeChunkToolResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.SummaryHandle == "" || result.ChunkCount != 7 || result.ProcessedCount != 1200 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	store, _ := summaryHandleStoreFromContext(ctx)
+	resolved, err := store.ResolveAll([]string{result.SummaryHandle})
+	if err != nil {
+		t.Fatalf("ResolveAll: %v", err)
+	}
+	if resolved.Entries[0].Text != largeSummary {
+		t.Fatal("stored Map text did not round-trip")
+	}
+}
+
+func TestMergeSummariesToolResolvesHandlesInsideBackend(t *testing.T) {
+	ctx := withSummaryHandleStore(context.Background())
+	store, _ := summaryHandleStoreFromContext(ctx)
+	h1, _ := store.Put("first body", 2)
+	h2, _ := store.Put("second body", 5)
+
+	original := mergeSummariesLLM
+	defer func() { mergeSummariesLLM = original }()
+	var gotCombined string
+	mergeSummariesLLM = func(_ context.Context, combined, _ string) (string, error) {
+		gotCombined = combined
+		return "# merged", nil
+	}
+
+	_, handler := MergeSummariesTool()
+	args, _ := json.Marshal(map[string]interface{}{"summary_handles": []string{h2, h1}})
+	out, err := handler(ctx, args)
+	if err != nil {
+		t.Fatalf("merge_summaries: %v", err)
+	}
+	if !strings.HasPrefix(gotCombined, "second body") || !strings.Contains(gotCombined, "first body") {
+		t.Fatalf("resolved bodies in wrong order: %q", gotCombined)
+	}
+	var result struct {
+		MergedSummary string `json:"merged_summary"`
+		ChunkCount    int    `json:"chunk_count"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.MergedSummary != "# merged" || result.ChunkCount != 7 {
+		t.Fatalf("unexpected merge result: %+v", result)
+	}
+	if store.NeedsReduce() {
+		t.Fatal("successful Reduce over all handles should satisfy the runner gate")
+	}
+}
+
+func TestMergeSummariesToolRejectsBodyOrPartialHandleArguments(t *testing.T) {
+	ctx := withSummaryHandleStore(context.Background())
+	store, _ := summaryHandleStoreFromContext(ctx)
+	h1, _ := store.Put("one", 1)
+	_, _ = store.Put("two", 1)
+	_, handler := MergeSummariesTool()
+
+	for _, tc := range []struct {
+		name string
+		args string
+		want string
+	}{
+		{name: "legacy body argument", args: `{"summaries":["one","two"]}`, want: "at least one"},
+		{name: "partial handles", args: `{"summary_handles":["` + h1 + `"]}`, want: "all Map results"},
+		{name: "malformed JSON", args: `{"summary_handles":["` + h1 + `"`, want: "parse args"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := handler(ctx, json.RawMessage(tc.args)); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agent/tool_summary_handles_test.go
+++ b/internal/agent/tool_summary_handles_test.go
@@ -52,9 +52,9 @@ func TestMergeSummariesToolResolvesHandlesInsideBackend(t *testing.T) {
 	original := mergeSummariesLLM
 	defer func() { mergeSummariesLLM = original }()
 	var gotCombined string
-	mergeSummariesLLM = func(_ context.Context, combined, _ string) (string, error) {
+	mergeSummariesLLM = func(_ context.Context, combined, _ string) (string, bool, error) {
 		gotCombined = combined
-		return "# merged", nil
+		return "# merged", false, nil
 	}
 
 	_, handler := MergeSummariesTool()

--- a/internal/agent/tools_summary_test.go
+++ b/internal/agent/tools_summary_test.go
@@ -184,7 +184,7 @@ func TestMergeSummariesToolSchema(t *testing.T) {
 		t.Fatal("parameters should be map[string]interface{}")
 	}
 
-	checkRequiredFields(t, params, "summaries")
+	checkRequiredFields(t, params, "summary_handles")
 }
 
 func TestTruncateStr(t *testing.T) {

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -1124,6 +1124,14 @@ func safeErrorDetail(err error) string {
 	case strings.Contains(err.Error(), "LLM returned empty response with no tool_calls"):
 		// runner.go final-step empty content guard (SUM-158 blocker follow-up).
 		return "LLM returned empty response with no tool_calls at final step"
+	case strings.Contains(err.Error(), "successful Map retries and Reduce required before final answer"):
+		// runner.go final-step completeness gate: the model never landed a
+		// successful merge_summaries over every Map handle (or left a Map retry
+		// outstanding). Generic "internal error" is actively misleading here —
+		// nothing broke server-side, the run failed to converge on a complete
+		// summary — and the wording is a constant errors.New with no interpolated
+		// data, so it is safe to pass through.
+		return "successful Map retries and Reduce required before final answer"
 	case strings.Contains(err.Error(), "unknown agent profile"):
 		// profile.go GetProfile lookup miss.
 		return "unknown agent profile"

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -372,9 +372,11 @@ func truncateRunes(s string, max int) string {
 // second fetch_channel, the model re-calls it and it works, the summary is
 // complete — and the user was shown finish_status=FAILED on a good deliverable.
 //
-// The hooks run concurrently from the tool worker pool, so state is mutex-guarded
-// and DB writes use a fresh context (the request context may already be canceled
-// by the very error being reported); SetStatus is a plain idempotent UPDATE.
+// The runner settles each tool step as a batch (errors before successes), so a
+// same-step success deterministically clears a duplicate sibling failure for the
+// same key. State remains mutex-guarded for direct/test callers, and DB writes use
+// a fresh context (the request context may already be canceled by the very error
+// being reported); SetStatus is a plain idempotent UPDATE.
 func (h *AgentChatHandler) attachToolErrorHook(runner *agent.Runner, userID, runID string) {
 	if runner == nil || userID == "" || runID == "" || h.runStore == nil {
 		return

--- a/internal/api/handler/agent_chat_detail_test.go
+++ b/internal/api/handler/agent_chat_detail_test.go
@@ -43,6 +43,20 @@ func TestSafeErrorDetail(t *testing.T) {
 			"LLM returned empty response with no tool_calls at final step",
 		},
 		{
+			// PR #208 round-5 P2-10. The Reduce completeness gate is a run
+			// outcome the user can act on ("the model never merged its Map
+			// results"), not a server fault. Collapsing it to "internal error"
+			// told them nothing.
+			"reduce completeness gate is whitelisted",
+			errors.New("successful Map retries and Reduce required before final answer"),
+			"successful Map retries and Reduce required before final answer",
+		},
+		{
+			"wrapped reduce completeness gate is whitelisted",
+			fmt.Errorf("agent run: %w", errors.New("successful Map retries and Reduce required before final answer")),
+			"successful Map retries and Reduce required before final answer",
+		},
+		{
 			"unknown profile is whitelisted",
 			errors.New(`unknown agent profile "summary_x"`),
 			"unknown agent profile",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,13 @@ type Config struct {
 	WorkerInternalPort        string
 	WorkerListenAllInterfaces string
 
+	// AgentMapConcurrency bounds how many Map-phase chunk summaries a single
+	// summarize_chunk tool call runs in parallel (agent path). Deliberately
+	// SEPARATE from WorkerMapConcurrency: the agent path already runs up to 4
+	// tool calls concurrently (agent.NewPool(4) in agent_chat.go), so the two
+	// knobs multiply and must be tuned independently.
+	AgentMapConcurrency int
+
 	// Worker
 	WorkerMaxConcurrent  int
 	WorkerMapConcurrency int
@@ -202,6 +209,8 @@ func Load() *Config {
 
 		WorkerInternalPort:        envStr("WORKER_INTERNAL_PORT", "8082"),
 		WorkerListenAllInterfaces: envStr("WORKER_LISTEN_ADDR", "0.0.0.0"),
+
+		AgentMapConcurrency: envInt("AGENT_MAP_CONCURRENCY", defaultAgentMapConcurrency),
 
 		WorkerMaxConcurrent:        envInt("WORKER_MAX_CONCURRENT_TASKS", 20),
 		WorkerMapConcurrency:       envInt("WORKER_MAP_CONCURRENCY", 5),
@@ -353,6 +362,40 @@ var modelMapThresholds = []modelThreshold{
 }
 
 const defaultMapMaxTokens = 100000
+
+const (
+	// defaultAgentMapConcurrency is the agent Map-phase fan-out default.
+	//
+	// 3, not the worker path's 5: the agent runner executes up to 4 tool calls
+	// from one LLM turn concurrently (agent.NewPool(4)), and each of those can
+	// be a summarize_chunk. The knobs multiply, so the real ceiling of in-flight
+	// Map calls is poolSize * AgentMapConcurrency = 12 at this default — before
+	// the LLM client's own 3-attempt retry budget. The worker path has no such
+	// outer fan-out, which is why its default can be higher.
+	defaultAgentMapConcurrency = 3
+	// maxAgentMapConcurrency caps operator input. Above this the gateway sees
+	// 4*N concurrent completions from a single user request.
+	maxAgentMapConcurrency = 5
+)
+
+// ResolveAgentMapConcurrency returns the effective agent Map fan-out, clamped
+// to [1, maxAgentMapConcurrency].
+//
+// 1 is the serial fallback: it makes the concurrent path byte-equivalent to the
+// pre-change loop (one worker, one in-flight call, same order, same error), so
+// an operator can revert the behaviour with an env var instead of a rollback.
+// Values <= 0 (unset / malformed / explicitly disabled) resolve to the default
+// rather than to 0, which would deadlock a zero-capacity semaphore.
+func (c *Config) ResolveAgentMapConcurrency() int {
+	n := c.AgentMapConcurrency
+	if n <= 0 {
+		n = defaultAgentMapConcurrency
+	}
+	if n > maxAgentMapConcurrency {
+		n = maxAgentMapConcurrency
+	}
+	return n
+}
 
 // ResolveCharsPerTokenCJK returns the CJK chars-per-token ratio.
 // For qwen/deepseek/kimi models, defaults to 2 if not explicitly configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -369,9 +369,9 @@ const (
 	// 3, not the worker path's 5: the agent runner executes up to 4 tool calls
 	// from one LLM turn concurrently (agent.NewPool(4)), and each of those can
 	// be a summarize_chunk. The knobs multiply, so the real ceiling of in-flight
-	// Map calls is poolSize * AgentMapConcurrency = 12 at this default — before
-	// the LLM client's own 3-attempt retry budget. The worker path has no such
-	// outer fan-out, which is why its default can be higher.
+	// Map calls is poolSize * AgentMapConcurrency = 12 at this default. The
+	// worker path has no such outer fan-out, which is why its default can be
+	// higher.
 	defaultAgentMapConcurrency = 3
 	// maxAgentMapConcurrency caps operator input. Above this the gateway sees
 	// 4*N concurrent completions from a single user request.

--- a/internal/config/config_agent_map_test.go
+++ b/internal/config/config_agent_map_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+// ResolveAgentMapConcurrency guards operator input: the value multiplies with
+// the agent runner's outer tool pool (agent.NewPool(4)), so an unbounded or
+// zero value is not merely odd — 0 would deadlock a zero-capacity semaphore and
+// a large value fans out 4*N concurrent completions from one user request.
+func TestResolveAgentMapConcurrency(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"unset -> default", 0, defaultAgentMapConcurrency},
+		{"negative -> default", -3, defaultAgentMapConcurrency},
+		{"one -> serial rollback path", 1, 1},
+		{"in range -> kept", 4, 4},
+		{"at cap -> kept", maxAgentMapConcurrency, maxAgentMapConcurrency},
+		{"over cap -> clamped", maxAgentMapConcurrency + 10, maxAgentMapConcurrency},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := Config{AgentMapConcurrency: c.in}
+			if got := cfg.ResolveAgentMapConcurrency(); got != c.want {
+				t.Fatalf("ResolveAgentMapConcurrency(%d) = %d, want %d", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// The resolved value must never be 0: summarizeChunksConcurrently sizes a
+// buffered channel with it, and make(chan struct{}, 0) blocks forever.
+func TestResolveAgentMapConcurrency_NeverZero(t *testing.T) {
+	for _, in := range []int{-100, -1, 0} {
+		cfg := Config{AgentMapConcurrency: in}
+		if got := cfg.ResolveAgentMapConcurrency(); got < 1 {
+			t.Fatalf("ResolveAgentMapConcurrency(%d) = %d — a zero-capacity semaphore deadlocks the Map phase", in, got)
+		}
+	}
+}
+
+// The agent knob must stay independent of the worker knob: they apply to
+// different code paths and only the agent one multiplies with a tool pool.
+func TestAgentAndWorkerMapConcurrencyAreIndependent(t *testing.T) {
+	cfg := Config{AgentMapConcurrency: 2, WorkerMapConcurrency: 5}
+	if got := cfg.ResolveAgentMapConcurrency(); got != 2 {
+		t.Fatalf("agent resolve = %d, want 2 (worker value must not leak in)", got)
+	}
+	if cfg.WorkerMapConcurrency != 5 {
+		t.Fatalf("worker value = %d, want 5 (agent resolve must not mutate it)", cfg.WorkerMapConcurrency)
+	}
+}

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -143,6 +143,7 @@ type chatResponseWithTools struct {
 			ReasoningContent string `json:"reasoning_content"`
 			Reasoning        string `json:"reasoning"`
 		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 	Usage struct {
 		TotalTokens int `json:"total_tokens"`
@@ -279,8 +280,8 @@ func (c *LLMClient) CallWithModel(ctx context.Context, messages []ChatMessage, t
 				reasoningLen, chatResp.Choices[0].FinishReason, chatResp.Usage.CompletionTokens)
 			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrReasoningBudgetExhausted
 		}
-		if content == "" && chatResp.Choices[0].FinishReason == "length" {
-			log.Printf("[llm] WARNING: content is empty and finish_reason=length, completion_tokens=%d", chatResp.Usage.CompletionTokens)
+		if chatResp.Choices[0].FinishReason == "length" {
+			log.Printf("[llm] WARNING: response truncated with finish_reason=length, completion_tokens=%d", chatResp.Usage.CompletionTokens)
 			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
 		}
 		return result{content: content, tokens: chatResp.Usage.TotalTokens}, llmfallback.Success, nil
@@ -435,7 +436,7 @@ func (c *LLMClient) CallStreamWithModel(ctx context.Context, messages []ChatMess
 		if content == "" && reasoningLen > 0 {
 			return result{tokens: totalTokens}, llmfallback.Terminal, ErrReasoningBudgetExhausted
 		}
-		if content == "" && finishReason == "length" {
+		if finishReason == "length" {
 			return result{tokens: totalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
 		}
 		if content == "" {
@@ -538,6 +539,10 @@ func (c *LLMClient) CallWithTools(ctx context.Context, messages []ChatMessage, t
 		}
 		if len(chatResp.Choices) == 0 {
 			return result{}, llmfallback.RetrySameModel, fmt.Errorf("LLM returned no choices")
+		}
+		if chatResp.Choices[0].FinishReason == "length" {
+			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal,
+				fmt.Errorf("LLM tool response truncated due to token limit")
 		}
 		if len(chatResp.Choices[0].Message.ToolCalls) == 0 {
 			reasoningPresent := chatResp.Choices[0].Message.ReasoningContent != "" || chatResp.Choices[0].Message.Reasoning != ""
@@ -692,7 +697,10 @@ func (c *LLMClient) CallMapWithModel(ctx context.Context, formattedMessages stri
 		return content, tokens, usedModel, nil
 	}
 	log.Printf("[llm] Map chunk %d failed: %s", chunkIndex, llmfallback.SafeErrorForLog(err, 200))
-	if errors.Is(err, ErrReasoningBudgetExhausted) || errors.Is(err, ErrTokenLimitExhausted) {
+	if errors.Is(err, ErrTokenLimitExhausted) {
+		return "", tokens, usedModel, fmt.Errorf("output truncated on chunk %d: %w", chunkIndex, err)
+	}
+	if errors.Is(err, ErrReasoningBudgetExhausted) {
 		return "", tokens, usedModel, fmt.Errorf("reasoning budget exhausted on chunk %d: %w", chunkIndex, err)
 	}
 	return fmt.Sprintf("(分片 %d %s)", chunkIndex, MapFailedMarker), 0, c.model, nil
@@ -761,7 +769,10 @@ func (c *LLMClient) CallMapStreamWithModel(ctx context.Context, formattedMessage
 	if emitted {
 		return content, tokens, usedModel, err
 	}
-	if errors.Is(err, ErrReasoningBudgetExhausted) || errors.Is(err, ErrTokenLimitExhausted) {
+	if errors.Is(err, ErrTokenLimitExhausted) {
+		return "", tokens, usedModel, fmt.Errorf("output truncated on chunk %d: %w", chunkIndex, err)
+	}
+	if errors.Is(err, ErrReasoningBudgetExhausted) {
 		return "", tokens, usedModel, fmt.Errorf("reasoning budget exhausted on chunk %d: %w", chunkIndex, err)
 	}
 	return fmt.Sprintf("(分片 %d %s)", chunkIndex, MapFailedMarker), 0, c.model, nil

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -200,34 +200,54 @@ func readErrorBody(body io.Reader) string {
 	return llmfallback.SafeTextForLog(string(b), 200)
 }
 
-const streamedTruncationNotice = "\n\n> 输出因长度限制被截断，请缩小范围或降低详细程度后重试。"
+// TruncationNotice is the single disclosure wording used whenever a degraded but
+// usable length-truncated result is handed to the user instead of being
+// discarded. Streaming and non-streaming paths share one convention.
+const TruncationNotice = "\n\n> 输出因长度限制被截断，请缩小范围或降低详细程度后重试。"
+
+type truncationPolicy int
+
+const (
+	truncateAllow truncationPolicy = iota
+	truncateReject
+	truncateDisclose
+)
 
 // Call makes a general chat completion request. A non-empty content response
 // remains usable when the provider reports finish_reason=length, preserving the
 // pre-existing behavior for refine and topic-narrowing callers.
 func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, error) {
-	content, tokens, _, err := c.callWithModel(ctx, messages, temperature, false)
+	content, _, tokens, _, err := c.callWithPolicyAndModel(ctx, messages, temperature, truncateAllow)
 	return content, tokens, err
 }
 
 // CallStrict rejects any length-truncated response. Map/Reduce callers use this
 // path because a partial intermediate result can silently drop coverage.
 func (c *LLMClient) CallStrict(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, error) {
-	content, tokens, _, err := c.callWithModel(ctx, messages, temperature, true)
+	content, _, tokens, _, err := c.callWithPolicyAndModel(ctx, messages, temperature, truncateReject)
 	return content, tokens, err
+}
+
+// CallDisclosingTruncation keeps a usable terminal result and marks it as
+// degraded; empty truncation still fails because there is nothing to deliver.
+func (c *LLMClient) CallDisclosingTruncation(ctx context.Context, messages []ChatMessage, temperature float64) (content string, truncated bool, tokens int, err error) {
+	content, truncated, tokens, _, err = c.callWithPolicyAndModel(ctx, messages, temperature, truncateDisclose)
+	return content, truncated, tokens, err
 }
 
 // CallWithModel makes a chat completion request and also returns the model
 // that produced the response. Callers that persist model attribution should
 // use this method instead of ModelVersion.
 func (c *LLMClient) CallWithModel(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, string, error) {
-	return c.callWithModel(ctx, messages, temperature, false)
+	content, _, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, messages, temperature, truncateAllow)
+	return content, tokens, usedModel, err
 }
 
-func (c *LLMClient) callWithModel(ctx context.Context, messages []ChatMessage, temperature float64, rejectTruncation bool) (string, int, string, error) {
+func (c *LLMClient) callWithPolicyAndModel(ctx context.Context, messages []ChatMessage, temperature float64, policy truncationPolicy) (string, bool, int, string, error) {
 	type result struct {
-		content string
-		tokens  int
+		content   string
+		truncated bool
+		tokens    int
 	}
 	// Keep retry ownership in the shared runner: exhaust transient failures on
 	// one model before switching to the next model.
@@ -295,13 +315,19 @@ func (c *LLMClient) callWithModel(ctx context.Context, messages []ChatMessage, t
 				reasoningLen, chatResp.Choices[0].FinishReason, chatResp.Usage.CompletionTokens)
 			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrReasoningBudgetExhausted
 		}
-		if chatResp.Choices[0].FinishReason == "length" && (rejectTruncation || content == "") {
+		if chatResp.Choices[0].FinishReason == "length" {
 			log.Printf("[llm] WARNING: response truncated with finish_reason=length, completion_tokens=%d", chatResp.Usage.CompletionTokens)
-			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
+			if content == "" || policy == truncateReject {
+				return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
+			}
+			if policy == truncateDisclose {
+				content += TruncationNotice
+			}
+			return result{content: content, truncated: true, tokens: chatResp.Usage.TotalTokens}, llmfallback.Success, nil
 		}
 		return result{content: content, tokens: chatResp.Usage.TotalTokens}, llmfallback.Success, nil
 	})
-	return res.content, res.tokens, usedModel, err
+	return res.content, res.truncated, res.tokens, usedModel, err
 }
 
 type chatStreamResponse struct {
@@ -472,11 +498,11 @@ func (c *LLMClient) callStreamWithModel(ctx context.Context, messages []ChatMess
 		}
 		if finishReason == "length" && discloseTruncation {
 			if onDelta != nil {
-				if err := onDelta(streamedTruncationNotice); err != nil {
+				if err := onDelta(TruncationNotice); err != nil {
 					return result{content: content, tokens: totalTokens}, llmfallback.Terminal, err
 				}
 			}
-			content += streamedTruncationNotice
+			content += TruncationNotice
 		}
 		return result{content: content, tokens: totalTokens}, llmfallback.Success, nil
 	})
@@ -725,10 +751,10 @@ func (c *LLMClient) CallMapWithModel(ctx context.Context, formattedMessages stri
 	userPrompt := fmt.Sprintf("来源：%s\n时间范围：%s ~ %s\n消息数：%d 条\n\n聊天记录：\n%s",
 		sourceName, timeStart, timeEnd, msgCount, formattedMessages)
 
-	content, tokens, usedModel, err := c.callWithModel(ctx, []ChatMessage{
+	content, _, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, []ChatMessage{
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userPrompt},
-	}, 0.1, true)
+	}, 0.1, truncateReject)
 	if err == nil {
 		return content, tokens, usedModel, nil
 	}
@@ -764,10 +790,11 @@ func (c *LLMClient) CallReduceWithModel(ctx context.Context, chunkSummaries []st
 	userPrompt := fmt.Sprintf("信息来源：%s\n时间范围：%s ~ %s\n消息总量：%d 条\n\n以下是各分片的总结，请合并：\n\n%s",
 		sourceNames, startTime, endTime, totalMsgCount, summariesText)
 
-	return c.callWithModel(ctx, []ChatMessage{
+	content, _, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, []ChatMessage{
 		{Role: "system", Content: system},
 		{Role: "user", Content: userPrompt},
-	}, 0.1, true)
+	}, 0.1, truncateReject)
+	return content, tokens, usedModel, err
 }
 
 // CallMapStream runs the Map phase for a user-visible single chunk and streams
@@ -877,7 +904,8 @@ func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries
 
 // CallReduceByPersonWithModel is CallReduceByPerson with the actual producing model included.
 func (c *LLMClient) CallReduceByPersonWithModel(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, string, error) {
-	return c.callWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, true)
+	content, _, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, truncateReject)
+	return content, tokens, usedModel, err
 }
 
 // CallReduceByPersonStream merges participant-level summaries and streams the

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -200,9 +200,20 @@ func readErrorBody(body io.Reader) string {
 	return llmfallback.SafeTextForLog(string(b), 200)
 }
 
-// Call makes a chat completion request. Returns (content, tokenUsed, error).
+const streamedTruncationNotice = "\n\n> 输出因长度限制被截断，请缩小范围或降低详细程度后重试。"
+
+// Call makes a general chat completion request. A non-empty content response
+// remains usable when the provider reports finish_reason=length, preserving the
+// pre-existing behavior for refine and topic-narrowing callers.
 func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, error) {
-	content, tokens, _, err := c.CallWithModel(ctx, messages, temperature)
+	content, tokens, _, err := c.callWithModel(ctx, messages, temperature, false)
+	return content, tokens, err
+}
+
+// CallStrict rejects any length-truncated response. Map/Reduce callers use this
+// path because a partial intermediate result can silently drop coverage.
+func (c *LLMClient) CallStrict(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, error) {
+	content, tokens, _, err := c.callWithModel(ctx, messages, temperature, true)
 	return content, tokens, err
 }
 
@@ -210,6 +221,10 @@ func (c *LLMClient) Call(ctx context.Context, messages []ChatMessage, temperatur
 // that produced the response. Callers that persist model attribution should
 // use this method instead of ModelVersion.
 func (c *LLMClient) CallWithModel(ctx context.Context, messages []ChatMessage, temperature float64) (string, int, string, error) {
+	return c.callWithModel(ctx, messages, temperature, false)
+}
+
+func (c *LLMClient) callWithModel(ctx context.Context, messages []ChatMessage, temperature float64, rejectTruncation bool) (string, int, string, error) {
 	type result struct {
 		content string
 		tokens  int
@@ -280,7 +295,7 @@ func (c *LLMClient) CallWithModel(ctx context.Context, messages []ChatMessage, t
 				reasoningLen, chatResp.Choices[0].FinishReason, chatResp.Usage.CompletionTokens)
 			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrReasoningBudgetExhausted
 		}
-		if chatResp.Choices[0].FinishReason == "length" {
+		if chatResp.Choices[0].FinishReason == "length" && (rejectTruncation || content == "") {
 			log.Printf("[llm] WARNING: response truncated with finish_reason=length, completion_tokens=%d", chatResp.Usage.CompletionTokens)
 			return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
 		}
@@ -304,17 +319,30 @@ type chatStreamResponse struct {
 	} `json:"usage"`
 }
 
-// CallStream makes a chat completion streaming request. onDelta is called for
-// each user-visible content delta. It returns the accumulated full content so
-// downstream citation building and DB persistence remain source-of-truth.
+// CallStream makes a general streaming request and preserves the historical
+// behavior for non-empty length-truncated content: what was already delivered
+// remains the returned/persisted source of truth.
 func (c *LLMClient) CallStream(ctx context.Context, messages []ChatMessage, temperature float64, onDelta func(string) error) (string, int, error) {
-	content, tokens, _, err := c.CallStreamWithModel(ctx, messages, temperature, onDelta)
+	content, tokens, _, err := c.callStreamWithModel(ctx, messages, temperature, onDelta, false)
+	return content, tokens, err
+}
+
+// callStreamWithTruncationNotice is used by user-visible Map/Reduce streams.
+// Once deltas have been emitted they cannot be retracted, so a usable partial
+// result is completed with an explicit notice instead of returning an error
+// after the client has already rendered content.
+func (c *LLMClient) callStreamWithTruncationNotice(ctx context.Context, messages []ChatMessage, temperature float64, onDelta func(string) error) (string, int, error) {
+	content, tokens, _, err := c.callStreamWithModel(ctx, messages, temperature, onDelta, true)
 	return content, tokens, err
 }
 
 // CallStreamWithModel is CallStream with the actual producing model included
 // for persistence and audit attribution.
 func (c *LLMClient) CallStreamWithModel(ctx context.Context, messages []ChatMessage, temperature float64, onDelta func(string) error) (string, int, string, error) {
+	return c.callStreamWithModel(ctx, messages, temperature, onDelta, false)
+}
+
+func (c *LLMClient) callStreamWithModel(ctx context.Context, messages []ChatMessage, temperature float64, onDelta func(string) error, discloseTruncation bool) (string, int, string, error) {
 	type result struct {
 		content string
 		tokens  int
@@ -436,11 +464,19 @@ func (c *LLMClient) CallStreamWithModel(ctx context.Context, messages []ChatMess
 		if content == "" && reasoningLen > 0 {
 			return result{tokens: totalTokens}, llmfallback.Terminal, ErrReasoningBudgetExhausted
 		}
-		if finishReason == "length" {
-			return result{tokens: totalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
-		}
 		if content == "" {
+			if finishReason == "length" {
+				return result{tokens: totalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
+			}
 			return streamFailure(fmt.Errorf("LLM returned empty streamed content"))
+		}
+		if finishReason == "length" && discloseTruncation {
+			if onDelta != nil {
+				if err := onDelta(streamedTruncationNotice); err != nil {
+					return result{content: content, tokens: totalTokens}, llmfallback.Terminal, err
+				}
+			}
+			content += streamedTruncationNotice
 		}
 		return result{content: content, tokens: totalTokens}, llmfallback.Success, nil
 	})
@@ -689,10 +725,10 @@ func (c *LLMClient) CallMapWithModel(ctx context.Context, formattedMessages stri
 	userPrompt := fmt.Sprintf("来源：%s\n时间范围：%s ~ %s\n消息数：%d 条\n\n聊天记录：\n%s",
 		sourceName, timeStart, timeEnd, msgCount, formattedMessages)
 
-	content, tokens, usedModel, err := c.CallWithModel(ctx, []ChatMessage{
+	content, tokens, usedModel, err := c.callWithModel(ctx, []ChatMessage{
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userPrompt},
-	}, 0.1)
+	}, 0.1, true)
 	if err == nil {
 		return content, tokens, usedModel, nil
 	}
@@ -728,10 +764,10 @@ func (c *LLMClient) CallReduceWithModel(ctx context.Context, chunkSummaries []st
 	userPrompt := fmt.Sprintf("信息来源：%s\n时间范围：%s ~ %s\n消息总量：%d 条\n\n以下是各分片的总结，请合并：\n\n%s",
 		sourceNames, startTime, endTime, totalMsgCount, summariesText)
 
-	return c.CallWithModel(ctx, []ChatMessage{
+	return c.callWithModel(ctx, []ChatMessage{
 		{Role: "system", Content: system},
 		{Role: "user", Content: userPrompt},
-	}, 0.1)
+	}, 0.1, true)
 }
 
 // CallMapStream runs the Map phase for a user-visible single chunk and streams
@@ -758,10 +794,10 @@ func (c *LLMClient) CallMapStreamWithModel(ctx context.Context, formattedMessage
 		}
 		return onDelta(delta)
 	}
-	content, tokens, usedModel, err := c.CallStreamWithModel(ctx, []ChatMessage{
+	content, tokens, usedModel, err := c.callStreamWithModel(ctx, []ChatMessage{
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userPrompt},
-	}, 0.1, wrappedDelta)
+	}, 0.1, wrappedDelta, true)
 	if err == nil {
 		return content, tokens, usedModel, nil
 	}
@@ -803,10 +839,10 @@ func (c *LLMClient) CallReduceStreamWithModel(ctx context.Context, chunkSummarie
 	userPrompt := fmt.Sprintf("信息来源：%s\n时间范围：%s ~ %s\n消息总量：%d 条\n\n以下是各分片的总结，请合并：\n\n%s",
 		sourceNames, startTime, endTime, totalMsgCount, summariesText)
 
-	return c.CallStreamWithModel(ctx, []ChatMessage{
+	return c.callStreamWithModel(ctx, []ChatMessage{
 		{Role: "system", Content: system},
 		{Role: "user", Content: userPrompt},
-	}, 0.1, onDelta)
+	}, 0.1, onDelta, true)
 }
 
 func buildReduceByPersonMessages(participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) []ChatMessage {
@@ -836,22 +872,22 @@ func buildReduceByPersonMessages(participantSummaries []struct{ Name, Summary st
 // CallReduceByPerson merges participant-level summaries.
 // Each participant is assigned a [Pn] tag that the LLM should reference in the output.
 func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
-	return c.Call(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1)
+	return c.CallStrict(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1)
 }
 
 // CallReduceByPersonWithModel is CallReduceByPerson with the actual producing model included.
 func (c *LLMClient) CallReduceByPersonWithModel(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, string, error) {
-	return c.CallWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1)
+	return c.callWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, true)
 }
 
 // CallReduceByPersonStream merges participant-level summaries and streams the
 // final team summary. Each participant is assigned a [Pn] tag that the LLM should
 // reference in the output.
 func (c *LLMClient) CallReduceByPersonStream(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string, onDelta func(string) error) (string, int, error) {
-	return c.CallStream(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta)
+	return c.callStreamWithTruncationNotice(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta)
 }
 
 // CallReduceByPersonStreamWithModel is CallReduceByPersonStream with the actual producing model included.
 func (c *LLMClient) CallReduceByPersonStreamWithModel(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string, onDelta func(string) error) (string, int, string, error) {
-	return c.CallStreamWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta)
+	return c.callStreamWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta, true)
 }

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -31,6 +31,11 @@ var ErrReasoningBudgetExhausted = errors.New("LLM returned empty content: reason
 // ErrTokenLimitExhausted marks an empty response terminated by the token cap.
 var ErrTokenLimitExhausted = errors.New("LLM returned empty content due to token limit")
 
+var (
+	ErrOutputTruncated       = errors.New("LLM response truncated due to token limit")
+	ErrStreamOutputTruncated = errors.New("LLM streamed response truncated due to token limit")
+)
+
 // LLMClient handles calls to a chat-completions-compatible LLM API.
 type LLMClient struct {
 	apiURL          string
@@ -309,7 +314,7 @@ func (c *LLMClient) callWithPolicyAndModel(ctx context.Context, messages []ChatM
 		}
 		content := chatResp.Choices[0].Message.Content
 		reasoningPresent := chatResp.Choices[0].Message.ReasoningContent != "" || chatResp.Choices[0].Message.Reasoning != ""
-		if content == "" && reasoningPresent {
+		if strings.TrimSpace(content) == "" && reasoningPresent {
 			reasoningLen := len(chatResp.Choices[0].Message.ReasoningContent) + len(chatResp.Choices[0].Message.Reasoning)
 			log.Printf("[llm] WARNING: content is empty but reasoning present (%d chars), finish_reason=%s, completion_tokens=%d. Reasoning consumed entire budget.",
 				reasoningLen, chatResp.Choices[0].FinishReason, chatResp.Usage.CompletionTokens)
@@ -317,11 +322,8 @@ func (c *LLMClient) callWithPolicyAndModel(ctx context.Context, messages []ChatM
 		}
 		if chatResp.Choices[0].FinishReason == "length" {
 			log.Printf("[llm] WARNING: response truncated with finish_reason=length, completion_tokens=%d", chatResp.Usage.CompletionTokens)
-			if content == "" || policy == truncateReject {
-				return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
-			}
-			if policy == truncateDisclose {
-				content += TruncationNotice
+			if strings.TrimSpace(content) == "" || policy == truncateReject {
+				return result{tokens: chatResp.Usage.TotalTokens}, llmfallback.Terminal, ErrOutputTruncated
 			}
 			return result{content: content, truncated: true, tokens: chatResp.Usage.TotalTokens}, llmfallback.Success, nil
 		}
@@ -487,12 +489,12 @@ func (c *LLMClient) callStreamWithModel(ctx context.Context, messages []ChatMess
 			return streamFailure(fmt.Errorf("LLM stream ended without terminal marker"))
 		}
 		content := sb.String()
-		if content == "" && reasoningLen > 0 {
+		if strings.TrimSpace(content) == "" && reasoningLen > 0 {
 			return result{tokens: totalTokens}, llmfallback.Terminal, ErrReasoningBudgetExhausted
 		}
-		if content == "" {
+		if strings.TrimSpace(content) == "" {
 			if finishReason == "length" {
-				return result{tokens: totalTokens}, llmfallback.Terminal, ErrTokenLimitExhausted
+				return result{tokens: totalTokens}, llmfallback.Terminal, ErrStreamOutputTruncated
 			}
 			return streamFailure(fmt.Errorf("LLM returned empty streamed content"))
 		}
@@ -759,7 +761,7 @@ func (c *LLMClient) CallMapWithModel(ctx context.Context, formattedMessages stri
 		return content, tokens, usedModel, nil
 	}
 	log.Printf("[llm] Map chunk %d failed: %s", chunkIndex, llmfallback.SafeErrorForLog(err, 200))
-	if errors.Is(err, ErrTokenLimitExhausted) {
+	if errors.Is(err, ErrOutputTruncated) {
 		return "", tokens, usedModel, fmt.Errorf("output truncated on chunk %d: %w", chunkIndex, err)
 	}
 	if errors.Is(err, ErrReasoningBudgetExhausted) {
@@ -790,11 +792,21 @@ func (c *LLMClient) CallReduceWithModel(ctx context.Context, chunkSummaries []st
 	userPrompt := fmt.Sprintf("信息来源：%s\n时间范围：%s ~ %s\n消息总量：%d 条\n\n以下是各分片的总结，请合并：\n\n%s",
 		sourceNames, startTime, endTime, totalMsgCount, summariesText)
 
-	content, _, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, []ChatMessage{
+	return c.callDisclosingTerminalReduceWithModel(ctx, []ChatMessage{
 		{Role: "system", Content: system},
 		{Role: "user", Content: userPrompt},
-	}, 0.1, truncateReject)
-	return content, tokens, usedModel, err
+	})
+}
+
+func (c *LLMClient) callDisclosingTerminalReduceWithModel(ctx context.Context, msgs []ChatMessage) (string, int, string, error) {
+	content, truncated, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, msgs, 0.1, truncateDisclose)
+	if err != nil {
+		return "", tokens, usedModel, err
+	}
+	if truncated {
+		content += TruncationNotice
+	}
+	return content, tokens, usedModel, nil
 }
 
 // CallMapStream runs the Map phase for a user-visible single chunk and streams
@@ -832,7 +844,7 @@ func (c *LLMClient) CallMapStreamWithModel(ctx context.Context, formattedMessage
 	if emitted {
 		return content, tokens, usedModel, err
 	}
-	if errors.Is(err, ErrTokenLimitExhausted) {
+	if errors.Is(err, ErrStreamOutputTruncated) {
 		return "", tokens, usedModel, fmt.Errorf("output truncated on chunk %d: %w", chunkIndex, err)
 	}
 	if errors.Is(err, ErrReasoningBudgetExhausted) {
@@ -899,13 +911,13 @@ func buildReduceByPersonMessages(participantSummaries []struct{ Name, Summary st
 // CallReduceByPerson merges participant-level summaries.
 // Each participant is assigned a [Pn] tag that the LLM should reference in the output.
 func (c *LLMClient) CallReduceByPerson(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, error) {
-	return c.CallStrict(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1)
+	content, tokens, _, err := c.callDisclosingTerminalReduceWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic))
+	return content, tokens, err
 }
 
 // CallReduceByPersonWithModel is CallReduceByPerson with the actual producing model included.
 func (c *LLMClient) CallReduceByPersonWithModel(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string) (string, int, string, error) {
-	content, _, tokens, usedModel, err := c.callWithPolicyAndModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, truncateReject)
-	return content, tokens, usedModel, err
+	return c.callDisclosingTerminalReduceWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic))
 }
 
 // CallReduceByPersonStream merges participant-level summaries and streams the

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -31,9 +31,19 @@ var ErrReasoningBudgetExhausted = errors.New("LLM returned empty content: reason
 // ErrTokenLimitExhausted marks an empty response terminated by the token cap.
 var ErrTokenLimitExhausted = errors.New("LLM returned empty content due to token limit")
 
+type tokenLimitError struct {
+	message string
+}
+
+func (e *tokenLimitError) Error() string { return e.message }
+
+// Is preserves the token-limit identity introduced on main while allowing
+// callers to distinguish streaming from non-streaming truncation.
+func (e *tokenLimitError) Is(target error) bool { return target == ErrTokenLimitExhausted }
+
 var (
-	ErrOutputTruncated       = errors.New("LLM response truncated due to token limit")
-	ErrStreamOutputTruncated = errors.New("LLM streamed response truncated due to token limit")
+	ErrOutputTruncated       = &tokenLimitError{message: "LLM response truncated due to token limit"}
+	ErrStreamOutputTruncated = &tokenLimitError{message: "LLM streamed response truncated due to token limit"}
 )
 
 // LLMClient handles calls to a chat-completions-compatible LLM API.

--- a/internal/service/llm_kimi_test.go
+++ b/internal/service/llm_kimi_test.go
@@ -420,8 +420,8 @@ func TestCallMap_PropagatesTokenLimitError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error to propagate for token limit exhaustion")
 	}
-	if !strings.Contains(err.Error(), "reasoning budget exhausted") {
-		t.Errorf("expected reasoning budget exhausted error, got: %v", err)
+	if !strings.Contains(err.Error(), "output truncated") {
+		t.Errorf("expected output truncated error, got: %v", err)
 	}
 }
 

--- a/internal/service/llm_truncation_test.go
+++ b/internal/service/llm_truncation_test.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -41,11 +44,126 @@ func TestCallDisclosingTruncationKeepsNonEmptyPartialAndFlagsIt(t *testing.T) {
 	if !truncated {
 		t.Fatal("truncated flag = false, want the degradation reported to the caller")
 	}
-	if !strings.Contains(content, "partial merged summary") || !strings.Contains(content, "输出因长度限制被截断") {
-		t.Fatalf("content = %q, want partial content plus the shared disclosure notice", content)
+	// The RAW body, with no notice concatenated. The disclosure belongs to the
+	// caller: while this client appended it, the caller's own emptiness check ran
+	// against text the client had already added to, so it could never fire.
+	if content != "partial merged summary" {
+		t.Fatalf("content = %q, want the raw model body with no client-appended notice", content)
 	}
-	if content != "partial merged summary"+TruncationNotice {
-		t.Fatalf("content = %q, want the streaming path's notice wording appended verbatim", content)
+}
+
+// P1-1. A whitespace-only truncated completion is not "" but is not a
+// deliverable either. Letting it take the disclose branch hands the caller a
+// body that is pure whitespace; once the caller appends TruncationNotice the
+// user's entire summary IS the notice, and on the agent path the completeness
+// gate is cleared by a Reduce that produced nothing.
+func TestCallDisclosingTruncationRejectsWhitespaceOnlyTruncation(t *testing.T) {
+	for _, body := range []string{" \n\t", "   ", "\n\n"} {
+		t.Run(strconv.Quote(body), func(t *testing.T) {
+			payload, err := json.Marshal(map[string]interface{}{
+				"choices": []map[string]interface{}{{
+					"message":       map[string]interface{}{"content": body},
+					"finish_reason": "length",
+				}},
+				"usage": map[string]interface{}{"total_tokens": 100, "completion_tokens": 4096},
+			})
+			if err != nil {
+				t.Fatalf("marshal stub: %v", err)
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(payload)
+			}))
+			defer srv.Close()
+
+			client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+			content, truncated, _, err := client.CallDisclosingTruncation(
+				context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1)
+			if err == nil || !errors.Is(err, ErrOutputTruncated) {
+				t.Fatalf("err = %v, want whitespace-only truncation to fail like empty truncation", err)
+			}
+			if content != "" || truncated {
+				t.Fatalf("content=%q truncated=%v, want nothing delivered", content, truncated)
+			}
+		})
+	}
+}
+
+// The streaming counterpart. This path feeds live worker code, so a
+// whitespace-only truncated stream would be PERSISTED as a summary whose entire
+// body is the disclosure notice.
+func TestCallStreamWithTruncationNoticeRejectsWhitespaceOnlyTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\" \\n\\t\"},\"finish_reason\":\"length\"}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+	var delivered strings.Builder
+	content, _, err := client.callStreamWithTruncationNotice(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "go"}},
+		0.1,
+		func(delta string) error {
+			delivered.WriteString(delta)
+			return nil
+		},
+	)
+	if err == nil || !errors.Is(err, ErrStreamOutputTruncated) {
+		t.Fatalf("err = %v, want whitespace-only streamed truncation to fail", err)
+	}
+	if content != "" {
+		t.Fatalf("content = %q, want nothing returned for a whitespace-only stream", content)
+	}
+	if strings.Contains(delivered.String(), "输出因长度限制被截断") {
+		t.Fatalf("delivered = %q, want no bare disclosure streamed as if it were a summary", delivered.String())
+	}
+}
+
+// The terminal non-streaming Reduce entry points are user-facing deliverables.
+// They used to reject any truncation via CallStrict, which reproduces the
+// zero-output failure this PR fixed on the agent Reduce the moment either is
+// wired up.
+func TestNonStreamingReduceDisclosesTruncationInsteadOfFailing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"合并结果（正文在此被截断"},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+
+	content, _, err := client.CallReduce(context.Background(),
+		[]string{"分片一", "分片二"}, "群聊", "2026-08-01", "2026-08-02", 10, "")
+	if err != nil {
+		t.Fatalf("CallReduce must deliver a truncated terminal summary, not fail: %v", err)
+	}
+	if content != "合并结果（正文在此被截断"+TruncationNotice {
+		t.Fatalf("CallReduce content = %q, want the partial merge plus the disclosure", content)
+	}
+
+	content, _, err = client.CallReduceByPerson(context.Background(),
+		[]struct{ Name, Summary string }{{Name: "A", Summary: "a"}, {Name: "B", Summary: "b"}},
+		"2026-08-01", "2026-08-02", "")
+	if err != nil {
+		t.Fatalf("CallReduceByPerson must deliver a truncated terminal summary, not fail: %v", err)
+	}
+	if content != "合并结果（正文在此被截断"+TruncationNotice {
+		t.Fatalf("CallReduceByPerson content = %q, want the partial merge plus the disclosure", content)
+	}
+}
+
+// An EMPTY truncated terminal Reduce still has nothing to deliver, so the
+// disclosing switch above must not turn it into a bare notice.
+func TestNonStreamingReduceStillRejectsEmptyTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":" \n\t"},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+
+	content, _, err := client.CallReduce(context.Background(),
+		[]string{"分片一", "分片二"}, "群聊", "2026-08-01", "2026-08-02", 10, "")
+	if err == nil || !errors.Is(err, ErrOutputTruncated) {
+		t.Fatalf("err = %v content = %q, want an empty truncated Reduce to still fail", err, content)
 	}
 }
 

--- a/internal/service/llm_truncation_test.go
+++ b/internal/service/llm_truncation_test.go
@@ -8,28 +8,50 @@ import (
 	"testing"
 )
 
-func TestCallRejectsNonEmptyLengthTruncation(t *testing.T) {
+func TestCallUsesCallerSpecificLengthTruncationPolicy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"partial summary"},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":50}}`))
 	}))
 	defer srv.Close()
 
-	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5)
-	if _, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1); err == nil || !strings.Contains(err.Error(), "truncated") {
-		t.Fatalf("error = %v, want non-empty length truncation to fail", err)
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+	content, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1)
+	if err != nil || content != "partial summary" {
+		t.Fatalf("generic Call = (%q, %v), want usable partial content", content, err)
+	}
+	if _, _, err := client.CallStrict(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1); err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("strict error = %v, want non-empty length truncation to fail", err)
 	}
 }
 
-func TestCallStreamRejectsNonEmptyLengthTruncation(t *testing.T) {
+func TestCallStreamPreservesOrDisclosesNonEmptyLengthTruncation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"partial\"},\"finish_reason\":\"length\"}]}\n\ndata: [DONE]\n\n"))
 	}))
 	defer srv.Close()
 
-	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5)
-	if _, _, err := client.CallStream(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1, nil); err == nil || !strings.Contains(err.Error(), "truncated") {
-		t.Fatalf("error = %v, want streamed length truncation to fail", err)
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+	content, _, err := client.CallStream(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1, nil)
+	if err != nil || content != "partial" {
+		t.Fatalf("generic CallStream = (%q, %v), want historical usable partial content", content, err)
+	}
+
+	var delivered strings.Builder
+	content, _, err = client.callStreamWithTruncationNotice(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "go"}},
+		0.1,
+		func(delta string) error {
+			delivered.WriteString(delta)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("disclosed stream truncation should remain usable: %v", err)
+	}
+	if content != delivered.String() || !strings.Contains(content, "partial") || !strings.Contains(content, "输出因长度限制被截断") {
+		t.Fatalf("returned=%q delivered=%q, want identical partial content plus disclosure", content, delivered.String())
 	}
 }
 
@@ -39,7 +61,7 @@ func TestCallWithToolsRejectsLengthTruncation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5)
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
 	_, _, err := client.CallWithTools(
 		context.Background(),
 		[]ChatMessage{{Role: "user", Content: "go"}},

--- a/internal/service/llm_truncation_test.go
+++ b/internal/service/llm_truncation_test.go
@@ -24,6 +24,49 @@ func TestCallUsesCallerSpecificLengthTruncationPolicy(t *testing.T) {
 	}
 }
 
+// A terminal deliverable (the agent Reduce) must survive a non-empty length
+// truncation with an explicit disclosure. Rejecting it, as CallStrict does,
+// leaves the caller with nothing to deliver and no way to shrink the retry.
+func TestCallDisclosingTruncationKeepsNonEmptyPartialAndFlagsIt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"partial merged summary"},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":50}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+	content, truncated, _, err := client.CallDisclosingTruncation(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1)
+	if err != nil {
+		t.Fatalf("disclosed truncation should remain usable: %v", err)
+	}
+	if !truncated {
+		t.Fatal("truncated flag = false, want the degradation reported to the caller")
+	}
+	if !strings.Contains(content, "partial merged summary") || !strings.Contains(content, "输出因长度限制被截断") {
+		t.Fatalf("content = %q, want partial content plus the shared disclosure notice", content)
+	}
+	if content != "partial merged summary"+TruncationNotice {
+		t.Fatalf("content = %q, want the streaming path's notice wording appended verbatim", content)
+	}
+}
+
+// Empty truncation has nothing to deliver and nothing to disclose against, so
+// it stays an error under every policy.
+func TestCallDisclosingTruncationStillRejectsEmptyTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":""},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":4096}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5, nil)
+	content, truncated, _, err := client.CallDisclosingTruncation(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1)
+	if err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("error = %v, want empty length truncation to fail", err)
+	}
+	if content != "" || truncated {
+		t.Fatalf("content=%q truncated=%v, want no bare disclosure emitted as a deliverable", content, truncated)
+	}
+}
+
 func TestCallStreamPreservesOrDisclosesNonEmptyLengthTruncation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/service/llm_truncation_test.go
+++ b/internal/service/llm_truncation_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCallRejectsNonEmptyLengthTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"partial summary"},"finish_reason":"length"}],"usage":{"total_tokens":100,"completion_tokens":50}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5)
+	if _, _, err := client.Call(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1); err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("error = %v, want non-empty length truncation to fail", err)
+	}
+}
+
+func TestCallStreamRejectsNonEmptyLengthTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"partial\"},\"finish_reason\":\"length\"}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5)
+	if _, _, err := client.CallStream(context.Background(), []ChatMessage{{Role: "user", Content: "go"}}, 0.1, nil); err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("error = %v, want streamed length truncation to fail", err)
+	}
+}
+
+func TestCallWithToolsRejectsLengthTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"tool_calls":[{"function":{"name":"resolve_topic","arguments":"{\"topic\":\"partial\"}"}}]},"finish_reason":"length"}],"usage":{"total_tokens":100}}`))
+	}))
+	defer srv.Close()
+
+	client := NewLLMClient(srv.URL, "key", "test-model", 5, 4096, false, 5)
+	_, _, err := client.CallWithTools(
+		context.Background(),
+		[]ChatMessage{{Role: "user", Content: "go"}},
+		[]Tool{{Type: "function", Function: ToolFunction{Name: "resolve_topic"}}},
+		"resolve_topic", 0.1,
+	)
+	if err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("error = %v, want tool length truncation to fail", err)
+	}
+}

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -650,12 +650,34 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }
 
+// isFatalMapError decides whether ONE chunk's Map failure should abort the whole
+// task instead of degrading that chunk.
+//
+// The match is deliberately narrow. It used to test the bare substring
+// "truncated", but internal/service/llm.go interpolates the upstream response
+// body verbatim into API errors ("LLM API error: status=400 body=..."), so any
+// upstream payload that merely CONTAINED the word — an error message, a field
+// name, a quoted snippet of the request — escalated one chunk's transient blip
+// into a task-wide abort. Only the two errors the Map wrapper itself produces
+// after exhausting its retries mean irrecoverable coverage loss:
+//
+//	service.ErrOutputTruncated / service.ErrStreamOutputTruncated, wrapped by
+//	  CallMap / CallMapStream as "output truncated on chunk N"
+//	"reasoning budget exhausted on chunk N"
+//
+// Everything else is a per-chunk failure the pipeline already handles.
+//
+// The truncation half is matched by errors.Is on the service sentinels rather
+// than by text, so it stays correct no matter how the wrapper's wording is
+// edited, and an unrelated error that merely quotes the word cannot satisfy it.
 func isFatalMapError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "reasoning budget exhausted") || strings.Contains(msg, "truncated")
+	if errors.Is(err, service.ErrOutputTruncated) || errors.Is(err, service.ErrStreamOutputTruncated) {
+		return true
+	}
+	return strings.Contains(err.Error(), "reasoning budget exhausted")
 }
 
 func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string), streamDelta func(string) error) (string, []model.Citation, int, int, string, error) {

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -650,6 +650,14 @@ func (p *Processor) markPersonalFailed(pr *model.PersonalResult, participant *mo
 	log.Printf("[personal-worker] task=%d marked failed (terminal), sanitizedMsg=%s", pr.TaskID, sanitized)
 }
 
+func isFatalMapError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "reasoning budget exhausted") || strings.Contains(msg, "truncated")
+}
+
 func (p *Processor) executePersonalPipeline(ctx context.Context, task model.SummaryTask, userID string, reportStage func(string), streamDelta func(string) error) (string, []model.Citation, int, int, string, error) {
 	totalStart := time.Now()
 	taskNo := task.TaskNo
@@ -1045,8 +1053,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 				timing.RecordLLMSince(taskNo, fmt.Sprintf("Map: 分块总结 chunk#%d", idx), callStart, tokens)
 				if err != nil {
 					log.Printf("[personal-worker] Map chunk %d failed: %v", idx, err)
-					isFatal := errors.Is(err, service.ErrReasoningBudgetExhausted) || errors.Is(err, service.ErrTokenLimitExhausted)
-					results[idx] = chunkResult{failed: true, fatal: isFatal}
+					results[idx] = chunkResult{failed: true, fatal: isFatalMapError(err)}
 				} else {
 					results[idx] = chunkResult{summary: summary, tokens: tokens, model: usedModel}
 				}
@@ -1069,7 +1076,7 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		}
 		if len(fatalChunks) > 0 {
 			return "", nil, 0, 0, "", fmt.Errorf(
-				"Map phase aborted: reasoning budget exhausted on chunk(s) %v", fatalChunks)
+				"Map phase aborted: output truncated or reasoning budget exhausted on chunk(s) %v", fatalChunks)
 		}
 
 		var chunkSummaries []string

--- a/internal/worker/personal_processor_test.go
+++ b/internal/worker/personal_processor_test.go
@@ -3,6 +3,7 @@
 package worker
 
 import (
+	"errors"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -14,6 +15,26 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestIsFatalMapError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "reasoning budget", err: errors.New("reasoning budget exhausted on chunk 2"), want: true},
+		{name: "non-stream truncation", err: errors.New("output truncated on chunk 3"), want: true},
+		{name: "stream truncation", err: errors.New("LLM streamed response truncated due to token limit"), want: true},
+		{name: "transient network", err: errors.New("connection reset by peer"), want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isFatalMapError(tc.err); got != tc.want {
+				t.Fatalf("isFatalMapError(%v) = %t, want %t", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestDecidePersonalMessages_NoTarget_AllMessages(t *testing.T) {
 	all := []pipeline.Message{

--- a/internal/worker/personal_processor_test.go
+++ b/internal/worker/personal_processor_test.go
@@ -4,6 +4,7 @@ package worker
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -24,9 +26,28 @@ func TestIsFatalMapError(t *testing.T) {
 	}{
 		{name: "nil", err: nil, want: false},
 		{name: "reasoning budget", err: errors.New("reasoning budget exhausted on chunk 2"), want: true},
-		{name: "non-stream truncation", err: errors.New("output truncated on chunk 3"), want: true},
-		{name: "stream truncation", err: errors.New("LLM streamed response truncated due to token limit"), want: true},
+		{name: "non-stream truncation", err: fmt.Errorf("output truncated on chunk 3: %w", service.ErrOutputTruncated), want: true},
+		{name: "stream truncation", err: fmt.Errorf("output truncated on chunk 3: %w", service.ErrStreamOutputTruncated), want: true},
 		{name: "transient network", err: errors.New("connection reset by peer"), want: false},
+		// PR #208 round-5 P2-5. isFatalMapError used to match the bare substring
+		// "truncated". internal/service/llm.go interpolates the upstream response
+		// body VERBATIM into API errors, so an upstream 400 whose body merely
+		// mentions truncation aborted the entire task instead of degrading one
+		// chunk. This is a per-chunk blip: the pipeline retries and, worst case,
+		// records one failed chunk.
+		{
+			name: "upstream body merely containing the word is not fatal",
+			err:  errors.New(`LLM API error: status=400 body={"error":{"message":"input was truncated by the gateway","type":"invalid_request_error"}}`),
+			want: false,
+		},
+		{
+			name: "upstream body naming a truncated field is not fatal",
+			err:  errors.New(`LLM API error: status=502 body={"detail":"upstream sent a truncated chunked response"}`),
+			want: false,
+		},
+		// The raw sentinel arriving unwrapped still counts: it is the same
+		// irrecoverable finish_reason=length, just not yet labelled with a chunk.
+		{name: "unwrapped truncation sentinel", err: service.ErrOutputTruncated, want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isFatalMapError(tc.err); got != tc.want {


### PR DESCRIPTION
Closes #217.

## Summary

- bound `summarize_chunk` Map concurrency with `AGENT_MAP_CONCURRENCY` while preserving result order, coverage accounting, cancellation, and panic containment
- keep Map summary bodies in a request-scoped store, return opaque `summary_handle` values, and require a successful Reduce over every handle before the final answer
- compact legacy summary tool history and handle length truncation by response shape: reject truncated tool arguments and non-stream Map/Reduce intermediates, while preserving usable streamed or content-only output with an explicit disclosure

## Testing

- `CGO_LDFLAGS=-L/home/mlamp/.local/lib go test -race -shuffle=on -count=1 -timeout 10m ./...`
- `CGO_LDFLAGS=-L/home/mlamp/.local/lib go vet ./...`
- `git diff --check`

