### PR TITLE
feat(finishgate): disclose LLM-output truncation structurally, not as prose the model can drop

### DIFF
--- a/internal/agent/finishgate/gate.go
+++ b/internal/agent/finishgate/gate.go
@@ -26,9 +26,19 @@ const (
 	GapChannel    = "channel"    // an expected channel was not fetched
 	GapCoverage   = "coverage"   // channel coverage was never measured
 	GapTruncation = "truncation" // the fetched pool was truncated
-	GapDropped    = "dropped"    // messages were dropped before the model
-	GapCitation   = "citation"   // citation integrity did not hold
-	GapToolError  = "tool_error" // a critical tool failed
+	// GapOutputTruncation reports that the MODEL'S OWN OUTPUT hit its token
+	// ceiling and stopped mid-sentence. Deliberately NOT folded into
+	// GapTruncation: the two describe opposite halves of the pipeline and need
+	// opposite remediation. GapTruncation means "we did not read everything"
+	// (retry with a narrower time range, or raise the per-channel cap);
+	// GapOutputTruncation means "we read everything but could not WRITE it all"
+	// (retry with a lower detail level or fewer output sections). Raising the
+	// fetch cap on an output-truncated run makes it strictly worse. They can
+	// also co-occur, and a single boolean would report only one of them.
+	GapOutputTruncation = "output_truncation"
+	GapDropped          = "dropped"    // messages were dropped before the model
+	GapCitation         = "citation"   // citation integrity did not hold
+	GapToolError        = "tool_error" // a critical tool failed
 )
 
 // Gap is a structured disclosure of one coverage/quality shortfall, surfaced to
@@ -76,6 +86,25 @@ type RunState struct {
 	Truncated         bool
 	DroppedMessages   int
 	FailedChannels    []string
+
+	// OutputTruncated reports that a model completion on the answer path was cut
+	// off by finish_reason=length, i.e. the deliverable itself is unfinished.
+	//
+	// Its own field rather than a second writer to Truncated: the two facts come
+	// from different halves of the pipeline and carry different advice (see
+	// GapOutputTruncation). Folding them together would have made the existing
+	// "fetched message pool was truncated" wording wrong for every
+	// output-truncated run — telling a user to narrow a time range that was never
+	// the problem. It sits outside the coverage group above for the same reason:
+	// it is a property of the GENERATION, not of the fetch.
+	//
+	// Fed from the run row (output_truncated), set by the producing paths through
+	// the SAME store-and-column channel every other run fact uses
+	// (RecordChannelFetch / AddDroppedMessages). That is what makes the guarantee
+	// hold: the disclosure is assembled from persisted evidence OUTSIDE the
+	// model's control, so a planner that rewrites or drops the inline prose
+	// notice cannot suppress it.
+	OutputTruncated bool
 
 	// DiscoveredChannels are the channels the run deliberately NARROWED to when no
 	// spec pinned a scope — the open-scope case, where ExpectedChannels is empty
@@ -208,6 +237,13 @@ func Evaluate(s RunState) (Verdict, []Gap) {
 	}
 	if s.Truncated {
 		gaps = append(gaps, Gap{Kind: GapTruncation, Detail: "fetched message pool was truncated"})
+	}
+	// Independent of the pool check above, and unconditional on CoverageMeasured:
+	// an output truncation is a property of the GENERATION, not of the fetch, so
+	// it must be disclosed even on turns that legitimately fetched nothing (a
+	// confident rewrite can still overrun its token ceiling).
+	if s.OutputTruncated {
+		gaps = append(gaps, Gap{Kind: GapOutputTruncation, Detail: "model output was truncated at its token limit; the summary is unfinished"})
 	}
 	if s.DroppedMessages > 0 {
 		gaps = append(gaps, Gap{Kind: GapDropped, Detail: "messages were dropped before summarization"})

--- a/internal/agent/finishgate/gate_output_truncation_test.go
+++ b/internal/agent/finishgate/gate_output_truncation_test.go
@@ -1,0 +1,118 @@
+package finishgate
+
+import "testing"
+
+// Output truncation is the model's OWN completion hitting its token ceiling —
+// the summary text stops mid-sentence. It is a different fact from Truncated,
+// which means the fetched message pool was clipped before the model ever saw it.
+//
+// These tests pin the separation. The reason it matters is remediation: a pool
+// truncation is fixed by narrowing the time range or raising the per-channel
+// cap, an output truncation by lowering the detail level. Applying the first
+// remedy to the second problem makes it strictly worse, so a single boolean
+// with one detail string would necessarily give wrong advice for one of them.
+
+func TestEvaluateOutputTruncatedIsPartial(t *testing.T) {
+	s := completeState()
+	s.OutputTruncated = true
+
+	v, gaps := Evaluate(s)
+	if v != Partial {
+		t.Fatalf("verdict = %s, want PARTIAL", v)
+	}
+	if !hasKind(gaps, GapOutputTruncation) {
+		t.Fatalf("gaps = %v, want a %s gap", gaps, GapOutputTruncation)
+	}
+	// The pool was never truncated here; claiming it was would send the user to
+	// the wrong remedy.
+	if hasKind(gaps, GapTruncation) {
+		t.Fatalf("output truncation must not report a fetch-pool gap: %v", gaps)
+	}
+}
+
+// The two truncations are independent and can co-occur: a run may both clip its
+// input pool AND run out of output budget. A single shared boolean could only
+// ever report one of them; both must survive.
+func TestEvaluateBothTruncationsReportedSeparately(t *testing.T) {
+	s := completeState()
+	s.Truncated = true
+	s.OutputTruncated = true
+
+	v, gaps := Evaluate(s)
+	if v != Partial {
+		t.Fatalf("verdict = %s, want PARTIAL", v)
+	}
+	if !hasKind(gaps, GapTruncation) || !hasKind(gaps, GapOutputTruncation) {
+		t.Fatalf("both truncation kinds must be disclosed, got %v", gaps)
+	}
+
+	// And their details must differ — the whole point of the split is that the
+	// user is told which failure they hit.
+	var poolDetail, outputDetail string
+	for _, g := range gaps {
+		switch g.Kind {
+		case GapTruncation:
+			poolDetail = g.Detail
+		case GapOutputTruncation:
+			outputDetail = g.Detail
+		}
+	}
+	if poolDetail == outputDetail {
+		t.Fatalf("the two truncation gaps share detail %q; the split buys nothing", poolDetail)
+	}
+}
+
+// NO FALSE POSITIVES. gate.go's comments document a prior bug where one half of
+// a change reported the other half's correct behaviour as a defect. A run with
+// no truncation of either kind must stay COMPLETE — adding a disclosure path
+// must not make PARTIAL the standing verdict.
+func TestEvaluateNoOutputTruncationStaysComplete(t *testing.T) {
+	s := completeState()
+	s.OutputTruncated = false
+
+	v, gaps := Evaluate(s)
+	if v != Complete {
+		t.Fatalf("verdict = %s, want COMPLETE (gaps: %v)", v, gaps)
+	}
+	if len(gaps) != 0 {
+		t.Fatalf("clean run must disclose nothing, got %v", gaps)
+	}
+}
+
+// An output truncation is a property of the GENERATION, not of the fetch, so it
+// must be disclosed even on a turn that legitimately fetched nothing. A
+// confident rewrite (SS-08b) has its fetch tools physically removed —
+// FetchExpected=false, CoverageMeasured=false — and can still overrun its token
+// ceiling. Gating the output check behind CoverageMeasured would silence it on
+// exactly the turns that produce the longest prose.
+func TestEvaluateOutputTruncatedDisclosedOnFetchFreeTurn(t *testing.T) {
+	s := completeState()
+	s.FetchExpected = false
+	s.CoverageMeasured = false
+	s.ExpectedChannels = nil
+	s.AttemptedChannels = nil
+	s.SucceededChannels = nil
+
+	// Baseline: without the truncation this shape is COMPLETE by design.
+	if v, gaps := Evaluate(s); v != Complete {
+		t.Fatalf("baseline rewrite verdict = %s, want COMPLETE (gaps: %v)", v, gaps)
+	}
+
+	s.OutputTruncated = true
+	v, gaps := Evaluate(s)
+	if v != Partial {
+		t.Fatalf("verdict = %s, want PARTIAL", v)
+	}
+	if !hasKind(gaps, GapOutputTruncation) {
+		t.Fatalf("gaps = %v, want a %s gap", gaps, GapOutputTruncation)
+	}
+}
+
+func hasKind(gaps []Gap, kind string) bool {
+	for _, g := range gaps {
+		if g.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/llm.go
+++ b/internal/agent/llm.go
@@ -172,6 +172,10 @@ func (c *Client) attemptChat(ctx context.Context, model string, msgs []Message, 
 	}
 	choice := cr.Choices[0]
 	msg := choice.Message
+	// Set alongside the prose notice below, never instead of it: the notice tells
+	// the reader where the text stops, the flag lets the runner record a fact the
+	// model cannot edit away. See AssistantTurn.Truncated.
+	truncated := false
 	if choice.FinishReason == "length" {
 		if len(msg.ToolCalls) > 0 {
 			// Tool-call arguments can be syntactically present but cut off mid-JSON.
@@ -185,10 +189,12 @@ func (c *Client) attemptChat(ctx context.Context, model string, msgs []Message, 
 		// usable, so preserve it with an explicit disclosure instead of failing
 		// the whole request and discarding everything the model produced.
 		msg.Content += service.TruncationNotice
+		truncated = true
 	}
 	return AssistantTurn{
 		Content:   msg.Content,
 		ToolCalls: msg.ToolCalls,
 		Tokens:    cr.Usage.TotalTokens,
+		Truncated: truncated,
 	}, llmfallback.Success, nil
 }

--- a/internal/agent/output_truncation_record_test.go
+++ b/internal/agent/output_truncation_record_test.go
@@ -1,0 +1,294 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/finishgate"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// These tests cover the PRODUCING half of the truncation disclosure: the run
+// row must carry the fact by the time the run ends, so the finish gate can
+// disclose it structurally.
+//
+// The gap they close: PR #208 made a truncated Reduce detectable and appended
+// service.TruncationNotice to the merge_summaries tool result. But that result
+// is an INTERMEDIATE artifact handed back to the planner as context — the
+// planner writes the final answer, and nothing forces the notice through. The
+// test below models exactly that adversary: a planner that reads the truncated
+// merge and then writes a clean, confident summary with the notice stripped.
+
+// newTruncationRunDB builds an in-memory run store for the agent package.
+func newTruncationRunDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Skipf("CGO required for sqlite: %v", err)
+		return nil
+	}
+	if err := db.AutoMigrate(&model.AgentSummaryRun{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+// withReduceLLMAndDB is withReduceLLM plus a real summary DB, so the recording
+// path (which is a no-op without one) actually runs.
+func withReduceLLMAndDB(t *testing.T, url string, db *gorm.DB) {
+	t.Helper()
+	prev := func() (cfg config.Config) {
+		defer func() { _ = recover() }()
+		_, _, _, cfg = GetSummaryDeps()
+		return cfg
+	}()
+	cfg := prev
+	cfg.LLMApiURL = url
+	cfg.LLMApiKey = "test-key"
+	cfg.LLMModel = "test-model"
+	cfg.LLMTimeout = 5
+	cfg.LLMMaxToken = 4096
+	cfg.LLMEnableThinking = false
+	SetSummaryDeps(db, nil, nil, cfg)
+	t.Cleanup(func() { SetSummaryDeps(nil, nil, nil, prev) })
+}
+
+// noticeStrippingPlanner is the adversary. It performs Map then Reduce exactly
+// like truncationPlannerClient, but its FINAL ANSWER is its own clean prose: it
+// deliberately discards the truncation notice the Reduce disclosed to it.
+//
+// This is not a strawman. The notice reads as meta-commentary about the tool
+// call rather than as summary content, so a model asked for a polished final
+// answer has every reason to drop it.
+type noticeStrippingPlanner struct {
+	sawTruncatedMerge bool
+}
+
+func (c *noticeStrippingPlanner) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
+	var handles []string
+	merged := false
+	for _, msg := range msgs {
+		if msg.Role != "tool" {
+			continue
+		}
+		switch msg.Name {
+		case "summarize_chunk":
+			var result struct {
+				SummaryHandle string `json:"summary_handle"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.SummaryHandle != "" {
+				handles = append(handles, result.SummaryHandle)
+			}
+		case "merge_summaries":
+			var result struct {
+				MergedSummary string `json:"merged_summary"`
+				Truncated     bool   `json:"truncated"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.MergedSummary != "" {
+				merged = true
+				c.sawTruncatedMerge = result.Truncated
+			}
+		}
+	}
+	if merged {
+		// The whole point: a clean answer with the disclosure rewritten away.
+		return AssistantTurn{Content: "本周项目进展顺利，核心功能已全部交付，无风险项。"}, nil
+	}
+	if len(handles) > 0 {
+		args, _ := json.Marshal(map[string]interface{}{"summary_handles": handles})
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("reduce-call", "merge_summaries", string(args)),
+		}}, nil
+	}
+	return AssistantTurn{ToolCalls: []ToolCall{
+		mkToolCall("map-call", "summarize_chunk", `{}`),
+	}}, nil
+}
+
+func registerTruncationTools(reg *Registry) {
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "summarize_chunk"}},
+		func(ctx context.Context, _ json.RawMessage) (string, error) {
+			store, err := summaryHandleStoreFromContext(ctx)
+			if err != nil {
+				return "", err
+			}
+			handle, err := store.PutAtStep("局部总结正文", 3, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			data, _ := json.Marshal(map[string]interface{}{"summary_handle": handle, "chunk_count": 3})
+			return string(data), nil
+		})
+	reg.Register(MergeSummariesTool())
+}
+
+// cleanReduceServer answers with a COMPLETE response (finish_reason=stop). It is
+// the control for the truncated server: same shape, no degradation.
+func cleanReduceServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"choices": []map[string]interface{}{{
+			"message":       map[string]interface{}{"content": content},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]interface{}{"total_tokens": 128, "completion_tokens": 64},
+	})
+	if err != nil {
+		t.Fatalf("marshal stub response: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// runTruncationScenario drives a full agent run against the given LLM stub and
+// returns the final answer plus the run row the gate would later read.
+func runTruncationScenario(t *testing.T, srvURL string, client chatter) (string, *model.AgentSummaryRun) {
+	t.Helper()
+	db := newTruncationRunDB(t)
+	if db == nil {
+		return "", nil
+	}
+	withReduceLLMAndDB(t, srvURL, db)
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess1", "req-1", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	ctx = context.WithValue(ctx, ContextKeyUID, "u1")
+	ctx = context.WithValue(ctx, ContextKeyRunID, run.RunID)
+
+	reg := NewRegistry()
+	registerTruncationTools(reg)
+	runner := NewRunner(client, reg, NewPool(2), Policy{MaxSteps: 8, MaxTokens: 1 << 20, StepTimeout: 5 * time.Second})
+	out, _, err := runner.RunWithHistory(ctx, "system", nil, "summarize")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got, err := store.GetByID(ctx, "u1", run.RunID)
+	if err != nil {
+		t.Fatalf("reload run: %v", err)
+	}
+	return out, got
+}
+
+// REQUIREMENT 1: the disclosure must not be defeatable by the model.
+//
+// The Reduce truncates. The planner reads the disclosure and throws it away,
+// answering with confident, clean prose. The delivered text therefore carries NO
+// warning at all — and yet the run must still evaluate to PARTIAL with a
+// truncation gap, because the fact was latched on the run row where the model
+// cannot reach it.
+func TestOutputTruncationSurvivesPlannerDroppingTheNotice(t *testing.T) {
+	srv, _ := truncatedReduceServer(t, "合并结果：项目进展、风险与待办（正文在此被截断")
+	client := &noticeStrippingPlanner{}
+	out, run := runTruncationScenario(t, srv.URL, client)
+	if run == nil {
+		return
+	}
+
+	if !client.sawTruncatedMerge {
+		t.Fatal("test setup: the planner never saw a truncated merge result")
+	}
+	// Precondition for the whole test: the user-visible text really is clean.
+	if strings.Contains(out, "输出因长度限制被截断") {
+		t.Fatalf("test setup: the answer still carries the notice, so this proves nothing: %q", out)
+	}
+
+	if !run.OutputTruncated {
+		t.Fatal("run row was not marked output-truncated: the ONLY disclosure was prose the model just deleted, so the user receives a silently unfinished summary")
+	}
+
+	// And that fact must actually produce a gap through the real gate.
+	verdict, gaps := finishgate.Evaluate(finishgate.RunState{
+		ScopeResolved:            true,
+		HasUsableEvidence:        true,
+		SummaryGenerated:         true,
+		CitationValidationPassed: true,
+		FetchExpected:            true,
+		CoverageMeasured:         true,
+		OutputTruncated:          run.OutputTruncated,
+	})
+	if verdict != finishgate.Partial {
+		t.Fatalf("verdict = %s, want PARTIAL (gaps=%v)", verdict, gaps)
+	}
+	hasGap := false
+	for _, g := range gaps {
+		if g.Kind == finishgate.GapOutputTruncation {
+			hasGap = true
+		}
+	}
+	if !hasGap {
+		t.Fatalf("gaps = %v, want %s", gaps, finishgate.GapOutputTruncation)
+	}
+}
+
+// REQUIREMENT 4: the prose notice is NOT removed. Gate disclosure and inline
+// notice are complementary — the gate is structured and reliable, the inline
+// notice tells the reader WHERE the text stops. A planner that faithfully
+// relays the merge result must still deliver the notice.
+func TestOutputTruncationKeepsInlineNoticeForFaithfulPlanner(t *testing.T) {
+	srv, _ := truncatedReduceServer(t, "合并结果：项目进展、风险与待办（正文在此被截断")
+	client := &truncationPlannerClient{}
+	out, run := runTruncationScenario(t, srv.URL, client)
+	if run == nil {
+		return
+	}
+	if !strings.Contains(out, "输出因长度限制被截断") {
+		t.Fatalf("inline notice was lost; removing it is a regression: %q", out)
+	}
+	if !run.OutputTruncated {
+		t.Fatal("run row must be marked even when the prose notice survives: both disclosures, not either")
+	}
+}
+
+// REQUIREMENT 3: no false positives. An identical run whose Reduce completes
+// normally must leave output_truncated false, so the gate keeps reporting
+// COMPLETE. Without this control the feature could "pass" by marking every run.
+func TestNoOutputTruncationRecordedForCleanReduce(t *testing.T) {
+	srv := cleanReduceServer(t, "合并结果：项目进展、风险与待办，全文完整。")
+	client := &truncationPlannerClient{}
+	out, run := runTruncationScenario(t, srv.URL, client)
+	if run == nil {
+		return
+	}
+	if strings.Contains(out, "输出因长度限制被截断") {
+		t.Fatalf("a clean Reduce must not disclose a truncation: %q", out)
+	}
+	if run.OutputTruncated {
+		t.Fatal("clean run marked output-truncated: this would make PARTIAL the standing verdict for every healthy summary")
+	}
+
+	verdict, gaps := finishgate.Evaluate(finishgate.RunState{
+		ScopeResolved:            true,
+		HasUsableEvidence:        true,
+		SummaryGenerated:         true,
+		CitationValidationPassed: true,
+		FetchExpected:            true,
+		CoverageMeasured:         true,
+		OutputTruncated:          run.OutputTruncated,
+	})
+	if verdict != finishgate.Complete {
+		t.Fatalf("verdict = %s, want COMPLETE for a clean run (gaps=%v)", verdict, gaps)
+	}
+}

--- a/internal/agent/output_truncation_record_test.go
+++ b/internal/agent/output_truncation_record_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 )
 
-// These tests cover the PRODUCING half of the truncation disclosure: the run
-// row must carry the fact by the time the run ends, so the finish gate can
-// disclose it structurally.
+// These tests cover the PRODUCING half of the truncation disclosure: the final
+// assistant message carries the exact attempt-local fact, while the run row
+// keeps a conservative aggregate for legacy compatibility.
 //
 // The gap they close: PR #208 made a truncated Reduce detectable and appended
 // service.TruncationNotice to the merge_summaries tool result. But that result
@@ -196,12 +196,13 @@ func cleanReduceServer(t *testing.T, content string) *httptest.Server {
 }
 
 // runTruncationScenario drives a full agent run against the given LLM stub and
-// returns the final answer plus the run row the gate would later read.
-func runTruncationScenario(t *testing.T, srvURL string, client chatter) (string, *model.AgentSummaryRun) {
+// returns the final answer, conservative run aggregate, and exact final-message
+// metadata the gate will prefer once that message is persisted.
+func runTruncationScenario(t *testing.T, srvURL string, client chatter) (string, *model.AgentSummaryRun, Message) {
 	t.Helper()
 	db := newTruncationRunDB(t)
 	if db == nil {
-		return "", nil
+		return "", nil, Message{}
 	}
 	withReduceLLMAndDB(t, srvURL, db)
 	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
@@ -219,7 +220,7 @@ func runTruncationScenario(t *testing.T, srvURL string, client chatter) (string,
 	reg := NewRegistry()
 	registerTruncationTools(reg)
 	runner := NewRunner(client, reg, NewPool(2), Policy{MaxSteps: 8, MaxTokens: 1 << 20, StepTimeout: 5 * time.Second})
-	out, _, err := runner.RunWithHistory(ctx, "system", nil, "summarize")
+	out, newMsgs, err := runner.RunWithHistory(ctx, "system", nil, "summarize")
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -227,7 +228,10 @@ func runTruncationScenario(t *testing.T, srvURL string, client chatter) (string,
 	if err != nil {
 		t.Fatalf("reload run: %v", err)
 	}
-	return out, got
+	if len(newMsgs) == 0 {
+		t.Fatal("run returned no messages")
+	}
+	return out, got, newMsgs[len(newMsgs)-1]
 }
 
 // REQUIREMENT 1: the disclosure must not be defeatable by the model.
@@ -235,12 +239,12 @@ func runTruncationScenario(t *testing.T, srvURL string, client chatter) (string,
 // The Reduce truncates. The planner reads the disclosure and throws it away,
 // answering with confident, clean prose. The delivered text therefore carries NO
 // warning at all — and yet the run must still evaluate to PARTIAL with a
-// truncation gap, because the fact was latched on the run row where the model
-// cannot reach it.
+// truncation gap, because the fact was latched in structural state the model
+// cannot reach.
 func TestOutputTruncationSurvivesPlannerDroppingTheNotice(t *testing.T) {
 	srv, _ := truncatedReduceServer(t, "合并结果：项目进展、风险与待办（正文在此被截断")
 	client := &noticeStrippingPlanner{}
-	out, run := runTruncationScenario(t, srv.URL, client)
+	out, run, final := runTruncationScenario(t, srv.URL, client)
 	if run == nil {
 		return
 	}
@@ -255,6 +259,9 @@ func TestOutputTruncationSurvivesPlannerDroppingTheNotice(t *testing.T) {
 
 	if !run.OutputTruncated {
 		t.Fatal("run row was not marked output-truncated: the ONLY disclosure was prose the model just deleted, so the user receives a silently unfinished summary")
+	}
+	if final.RunID != run.RunID || !final.OutputTruncated {
+		t.Fatalf("final message metadata = {run:%q truncated:%t}, want {%q true}", final.RunID, final.OutputTruncated, run.RunID)
 	}
 
 	// And that fact must actually produce a gap through the real gate.
@@ -288,7 +295,7 @@ func TestOutputTruncationSurvivesPlannerDroppingTheNotice(t *testing.T) {
 func TestOutputTruncationKeepsInlineNoticeForFaithfulPlanner(t *testing.T) {
 	srv, _ := truncatedReduceServer(t, "合并结果：项目进展、风险与待办（正文在此被截断")
 	client := &truncationPlannerClient{}
-	out, run := runTruncationScenario(t, srv.URL, client)
+	out, run, final := runTruncationScenario(t, srv.URL, client)
 	if run == nil {
 		return
 	}
@@ -298,6 +305,9 @@ func TestOutputTruncationKeepsInlineNoticeForFaithfulPlanner(t *testing.T) {
 	if !run.OutputTruncated {
 		t.Fatal("run row must be marked even when the prose notice survives: both disclosures, not either")
 	}
+	if final.RunID != run.RunID || !final.OutputTruncated {
+		t.Fatalf("final message metadata = {run:%q truncated:%t}, want {%q true}", final.RunID, final.OutputTruncated, run.RunID)
+	}
 }
 
 // REQUIREMENT 3: no false positives. An identical run whose Reduce completes
@@ -306,7 +316,7 @@ func TestOutputTruncationKeepsInlineNoticeForFaithfulPlanner(t *testing.T) {
 func TestNoOutputTruncationRecordedForCleanReduce(t *testing.T) {
 	srv := cleanReduceServer(t, "合并结果：项目进展、风险与待办，全文完整。")
 	client := &truncationPlannerClient{}
-	out, run := runTruncationScenario(t, srv.URL, client)
+	out, run, final := runTruncationScenario(t, srv.URL, client)
 	if run == nil {
 		return
 	}
@@ -315,6 +325,9 @@ func TestNoOutputTruncationRecordedForCleanReduce(t *testing.T) {
 	}
 	if run.OutputTruncated {
 		t.Fatal("clean run marked output-truncated: this would make PARTIAL the standing verdict for every healthy summary")
+	}
+	if final.RunID != run.RunID || final.OutputTruncated {
+		t.Fatalf("clean final message metadata = {run:%q truncated:%t}, want {%q false}", final.RunID, final.OutputTruncated, run.RunID)
 	}
 
 	verdict, gaps := finishgate.Evaluate(finishgate.RunState{
@@ -399,6 +412,10 @@ func TestRejectedPrematureTruncatedAnswerDoesNotPoisonCleanFinal(t *testing.T) {
 			t.Fatalf("rejected truncated draft was persisted: %+v", newMsgs)
 		}
 	}
+	final := newMsgs[len(newMsgs)-1]
+	if final.RunID != run.RunID || final.OutputTruncated {
+		t.Fatalf("clean final message metadata = {run:%q truncated:%t}, want {%q false}", final.RunID, final.OutputTruncated, run.RunID)
+	}
 
 	got, err := store.GetByID(ctx, "u1", run.RunID)
 	if err != nil {
@@ -406,5 +423,59 @@ func TestRejectedPrematureTruncatedAnswerDoesNotPoisonCleanFinal(t *testing.T) {
 	}
 	if got.OutputTruncated {
 		t.Fatal("rejected truncated draft poisoned a later complete deliverable")
+	}
+}
+
+// A replay whose history already contains a persisted truncated answer from
+// this same run may reuse that partial text. The new attempt therefore inherits
+// the taint even when its own final LLM turn ends cleanly. A message from a
+// different run must not contaminate it.
+func TestRunWithHistoryCarriesOnlySameRunOutputTruncation(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		history   []Message
+		wantTaint bool
+	}{
+		{
+			name: "same run",
+			history: []Message{{
+				Role: "assistant", Content: "partial", RunID: "run-current", OutputTruncated: true,
+			}},
+			wantTaint: true,
+		},
+		{
+			name: "different run",
+			history: []Message{{
+				Role: "assistant", Content: "partial", RunID: "run-old", OutputTruncated: true,
+			}},
+			wantTaint: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), ContextKeyRunID, "run-current")
+			runner := NewRunner(&fakeClient{turns: []AssistantTurn{{Content: "clean final"}}}, NewRegistry(), NewPool(1), Policy{
+				MaxSteps: 1, MaxTokens: 1000, StepTimeout: time.Second,
+			})
+			_, newMsgs, err := runner.RunWithHistory(ctx, "system", tc.history, "retry")
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			final := newMsgs[len(newMsgs)-1]
+			if final.RunID != "run-current" || final.OutputTruncated != tc.wantTaint {
+				t.Fatalf("final metadata = {run:%q truncated:%t}, want {run-current %t}", final.RunID, final.OutputTruncated, tc.wantTaint)
+			}
+		})
+	}
+}
+
+func TestMessagePersistenceMetadataIsNotSerializedToTheModel(t *testing.T) {
+	b, err := json.Marshal(Message{
+		Role: "assistant", Content: "answer", RunID: "run-secret", OutputTruncated: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	if strings.Contains(string(b), "run-secret") || strings.Contains(string(b), "output_truncated") {
+		t.Fatalf("persistence metadata leaked into model payload: %s", b)
 	}
 }

--- a/internal/agent/output_truncation_record_test.go
+++ b/internal/agent/output_truncation_record_test.go
@@ -77,6 +77,44 @@ type noticeStrippingPlanner struct {
 	sawTruncatedMerge bool
 }
 
+// prematureTruncatedPlanner first tries to answer before its Map output has
+// been reduced. That truncated draft must be rejected without poisoning the
+// run; after a valid Reduce it returns a complete final answer.
+type prematureTruncatedPlanner struct {
+	calls int
+}
+
+func (c *prematureTruncatedPlanner) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
+	c.calls++
+	switch c.calls {
+	case 1:
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("map-call", "summarize_chunk", `{}`),
+		}}, nil
+	case 2:
+		return AssistantTurn{Content: "premature truncated draft", Truncated: true}, nil
+	case 3:
+		var handles []string
+		for _, msg := range msgs {
+			if msg.Role != "tool" || msg.Name != "summarize_chunk" {
+				continue
+			}
+			var result struct {
+				SummaryHandle string `json:"summary_handle"`
+			}
+			if json.Unmarshal([]byte(msg.Content), &result) == nil && result.SummaryHandle != "" {
+				handles = append(handles, result.SummaryHandle)
+			}
+		}
+		args, _ := json.Marshal(map[string]interface{}{"summary_handles": handles})
+		return AssistantTurn{ToolCalls: []ToolCall{
+			mkToolCall("reduce-call", "merge_summaries", string(args)),
+		}}, nil
+	default:
+		return AssistantTurn{Content: "complete final answer"}, nil
+	}
+}
+
 func (c *noticeStrippingPlanner) Chat(_ context.Context, msgs []Message, _ []Tool) (AssistantTurn, error) {
 	var handles []string
 	merged := false
@@ -290,5 +328,83 @@ func TestNoOutputTruncationRecordedForCleanReduce(t *testing.T) {
 	})
 	if verdict != finishgate.Complete {
 		t.Fatalf("verdict = %s, want COMPLETE for a clean run (gaps=%v)", verdict, gaps)
+	}
+}
+
+// A content-only planner turn can be rejected by the pending Map/Reduce gate.
+// Its content is discarded, so its truncation must not survive as a one-way
+// latch after the planner performs the required Reduce and delivers a clean
+// final answer.
+func TestRejectedPrematureTruncatedAnswerDoesNotPoisonCleanFinal(t *testing.T) {
+	db := newTruncationRunDB(t)
+	if db == nil {
+		return
+	}
+	withReduceLLMAndDB(t, "", db)
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess-premature", "req-premature", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	ctx = context.WithValue(ctx, ContextKeyUID, "u1")
+	ctx = context.WithValue(ctx, ContextKeyRunID, run.RunID)
+
+	reg := NewRegistry()
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "summarize_chunk"}},
+		func(ctx context.Context, _ json.RawMessage) (string, error) {
+			handleStore, err := summaryHandleStoreFromContext(ctx)
+			if err != nil {
+				return "", err
+			}
+			handle, err := handleStore.PutAtStep("map body", 1, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			return `{"summary_handle":"` + handle + `","chunk_count":1}`, nil
+		})
+	reg.Register(Tool{Type: "function", Function: ToolFunction{Name: "merge_summaries"}},
+		func(ctx context.Context, args json.RawMessage) (string, error) {
+			var req struct {
+				Handles []string `json:"summary_handles"`
+			}
+			if err := json.Unmarshal(args, &req); err != nil {
+				return "", err
+			}
+			handleStore, err := summaryHandleStoreFromContext(ctx)
+			if err != nil {
+				return "", err
+			}
+			resolved, err := handleStore.ResolveAllBefore(req.Handles, summaryToolStepFromContext(ctx))
+			if err != nil {
+				return "", err
+			}
+			handleStore.MarkReduced(resolved.Generation)
+			return `{"merged_summary":"complete merged summary","chunk_count":1}`, nil
+		})
+
+	client := &prematureTruncatedPlanner{}
+	runner := NewRunner(client, reg, NewPool(1), Policy{MaxSteps: 6, MaxTokens: 1 << 20, StepTimeout: time.Second})
+	out, newMsgs, err := runner.RunWithHistory(ctx, "system", nil, "summarize")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != "complete final answer" {
+		t.Fatalf("out = %q, want clean final answer", out)
+	}
+	for _, msg := range newMsgs {
+		if msg.Content == "premature truncated draft" {
+			t.Fatalf("rejected truncated draft was persisted: %+v", newMsgs)
+		}
+	}
+
+	got, err := store.GetByID(ctx, "u1", run.RunID)
+	if err != nil {
+		t.Fatalf("reload run: %v", err)
+	}
+	if got.OutputTruncated {
+		t.Fatal("rejected truncated draft poisoned a later complete deliverable")
 	}
 }

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -145,6 +145,21 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		}
 		totalTokens += turn.Tokens
 
+		// A planner turn cut off at its token ceiling is the FINAL ANSWER being
+		// unfinished (llm.go only flags content-only turns; a truncated tool-call
+		// turn is rejected there). The client already appended the prose notice to
+		// turn.Content, but that notice is inside model-authored text: a later step
+		// can rewrite it, and history compaction can drop it. Latch the fact on the
+		// run row so the finish gate discloses it structurally regardless.
+		//
+		// Recorded here rather than in the client so the transport stays free of
+		// run/DB concerns, and recorded on EVERY truncated turn rather than only the
+		// terminating one because an intermediate truncated turn still feeds its
+		// partial text into the conversation the final answer is built from.
+		if turn.Truncated {
+			recordOutputTruncatedFromContext(ctx)
+		}
+
 		// A final answer is not valid while this request still has Map outputs that
 		// have not passed through one successful Reduce covering every handle. The
 		// model can otherwise skip merge_summaries (or ignore its parse error) and

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -99,6 +99,22 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 	// the tool context. It deliberately shadows any store on the parent context so
 	// a reused context cannot leak handles or pending state across runner calls.
 	ctx = withSummaryHandleStore(ctx)
+	ctx, truncationTracker := withOutputTruncationTracker(ctx)
+
+	// A replay can see an already-persisted answer from an earlier attempt in
+	// session history. If that answer belongs to this same run and was truncated,
+	// conservatively carry the taint forward: the planner may reuse its partial
+	// text. If the earlier attempt never persisted a message, there is nothing to
+	// inherit and a clean replay remains clean.
+	runID, _ := ctx.Value(ContextKeyRunID).(string)
+	if runID != "" {
+		for i := range history {
+			if history[i].RunID == runID && history[i].OutputTruncated {
+				truncationTracker.mark()
+				break
+			}
+		}
+	}
 
 	userMsg := Message{Role: "user", Content: userInput}
 
@@ -221,7 +237,18 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 					StepHasTools: false, // No tool calls - final answer
 				})
 			}
-			newMsgs = append(newMsgs, Message{Role: "assistant", Content: turn.Content})
+			finalMsg := Message{
+				Role:            "assistant",
+				Content:         turn.Content,
+				RunID:           runID,
+				OutputTruncated: runID != "" && truncationTracker.value(),
+			}
+			newMsgs = append(newMsgs, finalMsg)
+			if runID != "" {
+				for i := range newMsgs {
+					newMsgs[i].RunID = runID
+				}
+			}
 			return turn.Content, newMsgs, nil
 		}
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -145,21 +145,6 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		}
 		totalTokens += turn.Tokens
 
-		// A planner turn cut off at its token ceiling is the FINAL ANSWER being
-		// unfinished (llm.go only flags content-only turns; a truncated tool-call
-		// turn is rejected there). The client already appended the prose notice to
-		// turn.Content, but that notice is inside model-authored text: a later step
-		// can rewrite it, and history compaction can drop it. Latch the fact on the
-		// run row so the finish gate discloses it structurally regardless.
-		//
-		// Recorded here rather than in the client so the transport stays free of
-		// run/DB concerns, and recorded on EVERY truncated turn rather than only the
-		// terminating one because an intermediate truncated turn still feeds its
-		// partial text into the conversation the final answer is built from.
-		if turn.Truncated {
-			recordOutputTruncatedFromContext(ctx)
-		}
-
 		// A final answer is not valid while this request still has Map outputs that
 		// have not passed through one successful Reduce covering every handle. The
 		// model can otherwise skip merge_summaries (or ignore its parse error) and
@@ -217,6 +202,15 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		}
 
 		if len(turn.ToolCalls) == 0 {
+			// A planner turn cut off at its token ceiling is recorded only once it
+			// has passed every acceptance gate and will actually be delivered. A
+			// premature answer rejected above is discarded rather than fed back into
+			// the conversation, so latching it would falsely mark a later complete
+			// Reduce/final answer as partial. The client has already appended the
+			// inline notice; this persisted fact is the model-proof disclosure channel.
+			if turn.Truncated {
+				recordOutputTruncatedFromContext(ctx)
+			}
 			stepElapsed := time.Since(stepStart).Milliseconds()
 			if r.OnEvent != nil {
 				r.OnEvent(Event{

--- a/internal/agent/summaryrun/store.go
+++ b/internal/agent/summaryrun/store.go
@@ -350,6 +350,31 @@ func (s *Store) RecordChannelFetch(ctx context.Context, userID, runID, channelID
 	})
 }
 
+// MarkOutputTruncated latches the fact that a model completion on this run's
+// answer path was cut off by finish_reason=length.
+//
+// LATCH, never clear. The Reduce may be retried, and the planner emits several
+// completions per run; a later untruncated call does not undo the fact that an
+// earlier one was truncated, because the truncated text may already have been
+// folded into what the user receives. Writing `false` would let a subsequent
+// clean call erase the disclosure — the exact silent-completeness failure this
+// path exists to prevent. Hence the guarded UPDATE below only ever flips 0 -> 1.
+//
+// Idempotent and lock-free: a single conditional UPDATE, so concurrent writers
+// (parallel Map/Reduce tool calls) converge without the row lock that
+// RecordChannelFetch needs for its read-modify-write JSON sets.
+func (s *Store) MarkOutputTruncated(ctx context.Context, userID, runID string) error {
+	if userID == "" || runID == "" {
+		return nil
+	}
+	return s.db.WithContext(ctx).Model(&model.AgentSummaryRun{}).
+		Where("run_id = ? AND user_id = ? AND output_truncated = ?", runID, userID, false).
+		Updates(map[string]interface{}{
+			"output_truncated": true,
+			"updated_at":       now(),
+		}).Error
+}
+
 // AddDroppedMessages atomically records messages discarded before the model.
 // It is owner-scoped and additive because summarize_chunk calls may run in
 // parallel for distinct handles.

--- a/internal/agent/summaryrun/store.go
+++ b/internal/agent/summaryrun/store.go
@@ -283,24 +283,6 @@ func (s *Store) ClearFailedStatusForReplay(ctx context.Context, userID, runID st
 		Updates(map[string]interface{}{"status": model.RunStatusRunning, "updated_at": now()}).Error
 }
 
-// ClearOutputTruncatedForReplay clears a truncation latch left by a PREVIOUS
-// attempt under the same idempotency tuple. A replay regenerates its answer from
-// scratch, so attempt A's truncated text cannot describe attempt B's deliverable.
-// Attempt B will latch the flag again if its own accepted answer or Reduce is
-// truncated.
-//
-// This is deliberately replay-scoped. Within one attempt the latch remains
-// one-way: a later clean re-Reduce must not erase an earlier truncated result
-// that the planner may already have folded into the delivered answer.
-func (s *Store) ClearOutputTruncatedForReplay(ctx context.Context, userID, runID string) error {
-	return s.db.WithContext(ctx).Model(&model.AgentSummaryRun{}).
-		Where("run_id = ? AND user_id = ? AND output_truncated = ?", runID, userID, true).
-		Updates(map[string]interface{}{
-			"output_truncated": false,
-			"updated_at":       now(),
-		}).Error
-}
-
 // SetFinishStatus records the finish-gate verdict (COMPLETE/PARTIAL/FAILED) on a
 // run. This is a terminal write (no optimistic CAS): the verdict is computed once
 // at finalize and does not race concurrent status transitions.
@@ -371,14 +353,12 @@ func (s *Store) RecordChannelFetch(ctx context.Context, userID, runID, channelID
 // MarkOutputTruncated latches the fact that a model completion on this run's
 // answer path was cut off by finish_reason=length.
 //
-// WITHIN-ATTEMPT LATCH. The Reduce may be retried, and the planner emits several
-// completions per attempt; a later untruncated call does not undo the fact that
-// an earlier one was truncated, because the truncated text may already have
-// been folded into what the user receives. Writing `false` from a clean call
-// would let it erase the disclosure — the exact silent-completeness failure this
-// path exists to prevent. Hence the guarded UPDATE below only ever flips 0 -> 1.
-// A new attempt reusing request_id is the sole reset boundary; see
-// ClearOutputTruncatedForReplay.
+// CONSERVATIVE RUN-LEVEL LATCH. The Reduce may be retried, the planner emits
+// several completions per attempt, and one run row may be reused by replay
+// attempts. A later clean call never clears the aggregate because truncated text
+// may already have been persisted or folded into a later answer. The exact
+// deliverable-level fact is stored on agent_message; this run-level latch remains
+// the compatibility fallback for legacy rows that predate that binding.
 //
 // Idempotent and lock-free: a single conditional UPDATE, so concurrent writers
 // (parallel Map/Reduce tool calls) converge without the row lock that

--- a/internal/agent/summaryrun/store.go
+++ b/internal/agent/summaryrun/store.go
@@ -283,6 +283,24 @@ func (s *Store) ClearFailedStatusForReplay(ctx context.Context, userID, runID st
 		Updates(map[string]interface{}{"status": model.RunStatusRunning, "updated_at": now()}).Error
 }
 
+// ClearOutputTruncatedForReplay clears a truncation latch left by a PREVIOUS
+// attempt under the same idempotency tuple. A replay regenerates its answer from
+// scratch, so attempt A's truncated text cannot describe attempt B's deliverable.
+// Attempt B will latch the flag again if its own accepted answer or Reduce is
+// truncated.
+//
+// This is deliberately replay-scoped. Within one attempt the latch remains
+// one-way: a later clean re-Reduce must not erase an earlier truncated result
+// that the planner may already have folded into the delivered answer.
+func (s *Store) ClearOutputTruncatedForReplay(ctx context.Context, userID, runID string) error {
+	return s.db.WithContext(ctx).Model(&model.AgentSummaryRun{}).
+		Where("run_id = ? AND user_id = ? AND output_truncated = ?", runID, userID, true).
+		Updates(map[string]interface{}{
+			"output_truncated": false,
+			"updated_at":       now(),
+		}).Error
+}
+
 // SetFinishStatus records the finish-gate verdict (COMPLETE/PARTIAL/FAILED) on a
 // run. This is a terminal write (no optimistic CAS): the verdict is computed once
 // at finalize and does not race concurrent status transitions.
@@ -353,12 +371,14 @@ func (s *Store) RecordChannelFetch(ctx context.Context, userID, runID, channelID
 // MarkOutputTruncated latches the fact that a model completion on this run's
 // answer path was cut off by finish_reason=length.
 //
-// LATCH, never clear. The Reduce may be retried, and the planner emits several
-// completions per run; a later untruncated call does not undo the fact that an
-// earlier one was truncated, because the truncated text may already have been
-// folded into what the user receives. Writing `false` would let a subsequent
-// clean call erase the disclosure — the exact silent-completeness failure this
+// WITHIN-ATTEMPT LATCH. The Reduce may be retried, and the planner emits several
+// completions per attempt; a later untruncated call does not undo the fact that
+// an earlier one was truncated, because the truncated text may already have
+// been folded into what the user receives. Writing `false` from a clean call
+// would let it erase the disclosure — the exact silent-completeness failure this
 // path exists to prevent. Hence the guarded UPDATE below only ever flips 0 -> 1.
+// A new attempt reusing request_id is the sole reset boundary; see
+// ClearOutputTruncatedForReplay.
 //
 // Idempotent and lock-free: a single conditional UPDATE, so concurrent writers
 // (parallel Map/Reduce tool calls) converge without the row lock that

--- a/internal/agent/tool_merge_summaries.go
+++ b/internal/agent/tool_merge_summaries.go
@@ -96,6 +96,13 @@ func MergeSummariesTool() (Tool, Handler) {
 			result["merged_summary"] = merged + service.TruncationNotice
 			result["truncated"] = true
 			result["truncation_notice"] = strings.TrimSpace(service.TruncationNotice)
+			// Also latch the fact on the run row. The three lines above disclose the
+			// truncation to the PLANNER; they cannot guarantee it reaches the USER,
+			// because the planner rewrites this tool result into its own final answer
+			// and may drop a notice that reads like meta-commentary. The run-row fact
+			// is read later by the finish gate, which assembles a structured gap the
+			// model has no way to edit. Both, not either.
+			recordOutputTruncatedFromContext(ctx)
 		}
 		data, err := json.Marshal(result)
 		if err != nil {

--- a/internal/agent/truncation_record.go
+++ b/internal/agent/truncation_record.go
@@ -40,7 +40,11 @@ import (
 // its bookkeeping write failed would trade a partial answer for no answer, which
 // the surrounding design explicitly refuses. A failed write is logged loudly.
 func recordOutputTruncated(ctx context.Context, uid, runID string) {
-	if !SummaryV2Enabled() || uid == "" || runID == "" {
+	if !SummaryV2Enabled() || runID == "" {
+		return
+	}
+	if uid == "" {
+		log.Printf("[truncation] skip output truncation record: missing uid for run=%s", runID)
 		return
 	}
 	summaryDB, _, _, _ := GetSummaryDeps()

--- a/internal/agent/truncation_record.go
+++ b/internal/agent/truncation_record.go
@@ -3,13 +3,42 @@ package agent
 import (
 	"context"
 	"log"
+	"sync/atomic"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 )
 
+type outputTruncationTracker struct {
+	truncated atomic.Bool
+}
+
+type contextKeyOutputTruncationTracker struct{}
+
+func (t *outputTruncationTracker) mark() {
+	if t != nil {
+		t.truncated.Store(true)
+	}
+}
+
+func (t *outputTruncationTracker) value() bool {
+	return t != nil && t.truncated.Load()
+}
+
+func withOutputTruncationTracker(ctx context.Context) (context.Context, *outputTruncationTracker) {
+	tracker := &outputTruncationTracker{}
+	return context.WithValue(ctx, contextKeyOutputTruncationTracker{}, tracker), tracker
+}
+
+func markAttemptOutputTruncated(ctx context.Context) {
+	if tracker, ok := ctx.Value(contextKeyOutputTruncationTracker{}).(*outputTruncationTracker); ok && tracker != nil {
+		tracker.mark()
+	}
+}
+
 // recordOutputTruncated latches "a model completion on this run's answer path
-// was cut off at its token limit" onto the run row, where the SS-07 finish gate
-// can read it (finishgate.RunState.OutputTruncated -> GapOutputTruncation).
+// was cut off at its token limit" onto the conservative run aggregate. The
+// attempt-local form is copied to the final assistant message for the SS-07
+// finish gate (finishgate.RunState.OutputTruncated -> GapOutputTruncation).
 //
 // WHY THIS EXISTS AT ALL — the disclosure must not be defeatable by the model.
 //
@@ -23,18 +52,20 @@ import (
 // is silently incomplete and LOOKS complete, which is the precise failure class
 // this area of the codebase exists to prevent.
 //
-// Routing the fact through the run row instead makes the disclosure structural:
-// it is assembled by finishgate.Evaluate from persisted evidence, outside the
-// generating model's control, so no rewrite of the prose can suppress it.
+// Routing the fact through persistence instead makes the disclosure structural:
+// an attempt-local tracker is copied onto the final assistant row (the exact
+// deliverable selected at save time), while the run row keeps a conservative
+// aggregate for legacy rows. finishgate.Evaluate consumes that persisted fact
+// outside the generating model's control, so no rewrite can suppress it.
 //
 // This does NOT replace the inline notice — the two are complementary. The gate
 // is reliable and machine-readable; the inline notice is what tells a reader
 // WHERE the text stops. Both are kept deliberately.
 //
-// Same channel as every other coverage fact (recordFetch in
-// tool_fetch_channel.go, recordDroppedMessages in tool_summarize_chunk.go): the
-// summaryrun store writes a run column that finalizeRun reads back. No second
-// mechanism — one definition per mapping.
+// The run write mirrors the other coverage facts (recordFetch in
+// tool_fetch_channel.go, recordDroppedMessages in tool_summarize_chunk.go). The
+// message binding is intentionally more precise: it travels with the final
+// assistant row and overrides the shared aggregate when that row is saved.
 //
 // Best-effort and never fatal. Failing a usable-but-degraded deliverable because
 // its bookkeeping write failed would trade a partial answer for no answer, which
@@ -60,11 +91,19 @@ func recordOutputTruncated(ctx context.Context, uid, runID string) {
 	}
 }
 
-// recordOutputTruncatedFromContext is the convenience form for call sites that
-// already carry uid/run_id in the tool context (the standard shape for tool
-// handlers and the planner loop).
+// recordOutputTruncatedFromContext is the convenience form shared by the
+// planner loop and tool handlers. Runner-level bookkeeping uses
+// ContextKeyRunOwnerID; tool handlers retain the narrower ContextKeyUID injected
+// by buildRegistryWithUID.
 func recordOutputTruncatedFromContext(ctx context.Context) {
-	uid, _ := ctx.Value(ContextKeyUID).(string)
+	// Mark the current Runner attempt before the best-effort DB write. Even if
+	// the run-row write fails, a successfully persisted final assistant message
+	// still carries the degradation and the save gate can disclose it.
+	markAttemptOutputTruncated(ctx)
+	uid, _ := ctx.Value(ContextKeyRunOwnerID).(string)
+	if uid == "" {
+		uid, _ = ctx.Value(ContextKeyUID).(string)
+	}
 	runID, _ := ctx.Value(ContextKeyRunID).(string)
 	recordOutputTruncated(ctx, uid, runID)
 }

--- a/internal/agent/truncation_record.go
+++ b/internal/agent/truncation_record.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"context"
+	"log"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
+)
+
+// recordOutputTruncated latches "a model completion on this run's answer path
+// was cut off at its token limit" onto the run row, where the SS-07 finish gate
+// can read it (finishgate.RunState.OutputTruncated -> GapOutputTruncation).
+//
+// WHY THIS EXISTS AT ALL — the disclosure must not be defeatable by the model.
+//
+// Before this, an LLM-output truncation was disclosed only as PROSE: the client
+// appends service.TruncationNotice, and merge_summaries puts it in the
+// `merged_summary` field of a TOOL RESULT. But a tool result is an INTERMEDIATE
+// artifact. It is fed back to the planner as context, and the planner — not the
+// tool — writes the final user-facing answer. Nothing forces the notice through:
+// it reads like meta-commentary rather than content, so a model polishing a
+// final answer will plausibly drop it. The user then receives a deliverable that
+// is silently incomplete and LOOKS complete, which is the precise failure class
+// this area of the codebase exists to prevent.
+//
+// Routing the fact through the run row instead makes the disclosure structural:
+// it is assembled by finishgate.Evaluate from persisted evidence, outside the
+// generating model's control, so no rewrite of the prose can suppress it.
+//
+// This does NOT replace the inline notice — the two are complementary. The gate
+// is reliable and machine-readable; the inline notice is what tells a reader
+// WHERE the text stops. Both are kept deliberately.
+//
+// Same channel as every other coverage fact (recordFetch in
+// tool_fetch_channel.go, recordDroppedMessages in tool_summarize_chunk.go): the
+// summaryrun store writes a run column that finalizeRun reads back. No second
+// mechanism — one definition per mapping.
+//
+// Best-effort and never fatal. Failing a usable-but-degraded deliverable because
+// its bookkeeping write failed would trade a partial answer for no answer, which
+// the surrounding design explicitly refuses. A failed write is logged loudly.
+func recordOutputTruncated(ctx context.Context, uid, runID string) {
+	if !SummaryV2Enabled() || uid == "" || runID == "" {
+		return
+	}
+	summaryDB, _, _, _ := GetSummaryDeps()
+	if summaryDB == nil {
+		return
+	}
+	// WithoutCancel, mirroring recordFetch: this records a DEGRADATION, and one
+	// live cause of degradation is a client that disconnected mid-answer, which
+	// cancels this ctx. The record must not fail for the same reason the run did.
+	recordCtx := context.WithoutCancel(ctx)
+	if err := summaryrun.NewStore(summaryDB).MarkOutputTruncated(recordCtx, uid, runID); err != nil {
+		log.Printf("[truncation] record output truncation failed run=%s: %v", runID, err)
+	}
+}
+
+// recordOutputTruncatedFromContext is the convenience form for call sites that
+// already carry uid/run_id in the tool context (the standard shape for tool
+// handlers and the planner loop).
+func recordOutputTruncatedFromContext(ctx context.Context) {
+	uid, _ := ctx.Value(ContextKeyUID).(string)
+	runID, _ := ctx.Value(ContextKeyRunID).(string)
+	recordOutputTruncated(ctx, uid, runID)
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -40,6 +40,18 @@ type AssistantTurn struct {
 	Content   string
 	ToolCalls []ToolCall
 	Tokens    int
+
+	// Truncated reports that this turn's content was cut off by
+	// finish_reason=length. It is only ever set on a CONTENT-ONLY turn, i.e. the
+	// planner's final user-facing answer: a truncated tool-call turn is rejected
+	// outright (its arguments may be cut mid-JSON) and an empty truncated turn is
+	// an error, so neither reaches a caller.
+	//
+	// Carried as a structural field rather than left implicit in the appended
+	// prose notice so the runner can record the degradation as a run fact. The
+	// prose alone is not enough: it lives inside model-authored text and can be
+	// rewritten away downstream.
+	Truncated bool
 }
 
 // ContextKeyUID is the context key for storing user ID in request context.

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -24,6 +24,13 @@ type Message struct {
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
 	Name       string     `json:"name,omitempty"`
+
+	// RunID and OutputTruncated are persistence-only metadata. They are never
+	// sent to the LLM. Binding the degradation to the final assistant message
+	// lets the save path judge the exact deliverable the user selected instead
+	// of a run-level bit shared by multiple HTTP replay attempts.
+	RunID           string `json:"-"`
+	OutputTruncated bool   `json:"-"`
 }
 
 type ToolCall struct {
@@ -59,6 +66,15 @@ type contextKeyUID struct{}
 
 // ContextKeyUID is exported for use by handler to inject uid into context.
 var ContextKeyUID = contextKeyUID{}
+
+// ContextKeyRunOwnerID carries the authenticated owner only for runner-level
+// bookkeeping such as output-truncation recording. It is intentionally
+// distinct from ContextKeyUID: putting the tool-authorization identity on the
+// root runner context would let future chat-profile tools inherit data access
+// without going through buildRegistryWithUID's explicit allowlist.
+type contextKeyRunOwnerID struct{}
+
+var ContextKeyRunOwnerID = contextKeyRunOwnerID{}
 
 // ContextKeySessionID is the context key for storing session ID in request context.
 type contextKeySessionID struct{}

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -615,6 +615,11 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, apiResponse{Code: 40100, Message: "missing auth context"})
 		return
 	}
+	// The runner itself (not only tool handlers) records planner-answer
+	// degradations against the owner-scoped summary run. Keep the authenticated
+	// identity on the request context passed to RunWithHistory; the per-tool UID
+	// wrapper below cannot supply values to the planner loop.
+	ctx = context.WithValue(ctx, agent.ContextKeyUID, uid)
 
 	// SS-03: persist the run/spec when V2 mode is enabled. Off → skipped entirely
 	// (byte-identical to pre-SS-03). Best-effort; never blocks the reply. The
@@ -915,6 +920,9 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 		h.writeSSEErrorViaSink(sink, 40100, "missing auth context")
 		return
 	}
+	// ChatStream must carry the same runner-level identity as Chat. Tool-local
+	// UID injection does not reach planner-turn bookkeeping in RunWithHistory.
+	ctx = context.WithValue(ctx, agent.ContextKeyUID, uid)
 
 	// SS-03: persist run/spec when V2 mode is enabled (see Chat). Off → skipped.
 	// The returned run_id is injected into the tool context for the citation pass.

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -514,14 +514,18 @@ func (h *AgentChatHandler) maybePersistSummaryRun(ctx context.Context, uid strin
 		// Idempotent replay: the run already exists (e.g. SSE downgrade reusing
 		// the same request_id). Reuse its run_id; do not re-persist the spec.
 		//
-		// But DO clear a status=failed latched by the previous attempt. The
-		// SS-07b fatal marker lives in the per-runner hook closure, so the new
-		// attempt's OnToolSuccess cannot clear a marker it never set; without this
-		// reset a clean regenerated summary inherits the earlier attempt's failure
-		// and finalizeRun discloses FAILED for a good deliverable. Best-effort:
-		// a reset failure only costs the stale verdict, never the reply.
+		// But DO clear attempt-scoped degradation latched by the previous attempt.
+		// The SS-07b fatal marker lives in the per-runner hook closure, so the new
+		// attempt's OnToolSuccess cannot clear a marker it never set. Likewise,
+		// output_truncated describes attempt A's discarded answer, not the fresh
+		// answer attempt B is about to generate. Without these resets a clean replay
+		// is disclosed as FAILED or PARTIAL. Best-effort: reset failures only cost a
+		// stale verdict, never the reply.
 		if err := h.runStore.ClearFailedStatusForReplay(ctx, uid, run.RunID); err != nil {
 			log.Printf("[agent] v2 clear failed status on replay (run=%s): %v", run.RunID, err)
+		}
+		if err := h.runStore.ClearOutputTruncatedForReplay(ctx, uid, run.RunID); err != nil {
+			log.Printf("[agent] v2 clear output truncation on replay (run=%s): %v", run.RunID, err)
 		}
 		return run.RunID
 	}

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -514,18 +514,17 @@ func (h *AgentChatHandler) maybePersistSummaryRun(ctx context.Context, uid strin
 		// Idempotent replay: the run already exists (e.g. SSE downgrade reusing
 		// the same request_id). Reuse its run_id; do not re-persist the spec.
 		//
-		// But DO clear attempt-scoped degradation latched by the previous attempt.
+		// Clear only the task-flow failure latched by the previous attempt.
 		// The SS-07b fatal marker lives in the per-runner hook closure, so the new
-		// attempt's OnToolSuccess cannot clear a marker it never set. Likewise,
-		// output_truncated describes attempt A's discarded answer, not the fresh
-		// answer attempt B is about to generate. Without these resets a clean replay
-		// is disclosed as FAILED or PARTIAL. Best-effort: reset failures only cost a
-		// stale verdict, never the reply.
+		// attempt's OnToolSuccess cannot clear a marker it never set. Output
+		// truncation is deliberately NOT cleared here: attempt B may fail before it
+		// persists a replacement, leaving attempt A's message as the deliverable.
+		// Each final assistant row carries its own attempt-local truncation fact, so
+		// the save path can judge the selected message without mutating shared state
+		// at replay entry. Best-effort: a status reset failure only costs the stale
+		// verdict, never the reply.
 		if err := h.runStore.ClearFailedStatusForReplay(ctx, uid, run.RunID); err != nil {
 			log.Printf("[agent] v2 clear failed status on replay (run=%s): %v", run.RunID, err)
-		}
-		if err := h.runStore.ClearOutputTruncatedForReplay(ctx, uid, run.RunID); err != nil {
-			log.Printf("[agent] v2 clear output truncation on replay (run=%s): %v", run.RunID, err)
 		}
 		return run.RunID
 	}
@@ -620,10 +619,10 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 		return
 	}
 	// The runner itself (not only tool handlers) records planner-answer
-	// degradations against the owner-scoped summary run. Keep the authenticated
-	// identity on the request context passed to RunWithHistory; the per-tool UID
-	// wrapper below cannot supply values to the planner loop.
-	ctx = context.WithValue(ctx, agent.ContextKeyUID, uid)
+	// degradations against the owner-scoped summary run. Use the bookkeeping-only
+	// key here: ContextKeyUID remains confined to buildRegistryWithUID so adding a
+	// future tool to the chat profile cannot silently widen its data-access scope.
+	ctx = context.WithValue(ctx, agent.ContextKeyRunOwnerID, uid)
 
 	// SS-03: persist the run/spec when V2 mode is enabled. Off → skipped entirely
 	// (byte-identical to pre-SS-03). Best-effort; never blocks the reply. The
@@ -924,9 +923,9 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 		h.writeSSEErrorViaSink(sink, 40100, "missing auth context")
 		return
 	}
-	// ChatStream must carry the same runner-level identity as Chat. Tool-local
-	// UID injection does not reach planner-turn bookkeeping in RunWithHistory.
-	ctx = context.WithValue(ctx, agent.ContextKeyUID, uid)
+	// ChatStream must carry the same runner-level bookkeeping identity as Chat.
+	// Tool authorization still uses the narrower buildRegistryWithUID wrapper.
+	ctx = context.WithValue(ctx, agent.ContextKeyRunOwnerID, uid)
 
 	// SS-03: persist run/spec when V2 mode is enabled (see Chat). Off → skipped.
 	// The returned run_id is injected into the tool context for the citation pass.

--- a/internal/api/handler/agent_chat_test.go
+++ b/internal/api/handler/agent_chat_test.go
@@ -316,7 +316,7 @@ func TestRowsDescToMessagesAsc(t *testing.T) {
 	tc := `[{"id":"call_1","type":"function","function":{"name":"foo","arguments":"{}"}}]`
 	// 模拟 DB Order("id DESC") 取回：最近(id=4)在前，最旧(id=1)在后。
 	descRows := []model.AgentMessage{
-		{ID: 4, SessionID: "s", Role: "assistant", Content: "reply2"},
+		{ID: 4, SessionID: "s", Role: "assistant", Content: "reply2", RunID: "run-2", OutputTruncated: true},
 		{ID: 3, SessionID: "s", Role: "user", Content: "q2"},
 		{ID: 2, SessionID: "s", Role: "assistant", Content: "", ToolCalls: &tc},
 		{ID: 1, SessionID: "s", Role: "user", Content: "q1"},
@@ -344,6 +344,9 @@ func TestRowsDescToMessagesAsc(t *testing.T) {
 	// tool_calls 应被反序列化到第 2 条 assistant（原 id=2）。
 	if len(msgs[1].ToolCalls) != 1 || msgs[1].ToolCalls[0].Function.Name != "foo" {
 		t.Fatalf("tool_calls not restored on ascending msg[1]: %+v", msgs[1].ToolCalls)
+	}
+	if msgs[3].RunID != "run-2" || !msgs[3].OutputTruncated {
+		t.Fatalf("deliverable metadata not restored on ascending msg[3]: %+v", msgs[3])
 	}
 }
 

--- a/internal/api/handler/agent_finalize_run_cgo_test.go
+++ b/internal/api/handler/agent_finalize_run_cgo_test.go
@@ -34,7 +34,7 @@ func newFinalizeTestDB(t *testing.T) *gorm.DB {
 		t.Skipf("CGO required for sqlite: %v", err)
 		return nil
 	}
-	if err := db.AutoMigrate(&model.AgentSummaryRun{}, &model.AgentSummarySpec{}, &model.AgentEvidenceArtifact{}); err != nil {
+	if err := db.AutoMigrate(&model.AgentSummaryRun{}, &model.AgentSummarySpec{}, &model.AgentEvidenceArtifact{}, &model.AgentMessage{}); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	return db

--- a/internal/api/handler/agent_message_repo.go
+++ b/internal/api/handler/agent_message_repo.go
@@ -63,10 +63,12 @@ func rowsDescToMessagesAsc(rows []model.AgentMessage) ([]agent.Message, error) {
 	msgs := make([]agent.Message, 0, len(rows))
 	for i := range rows {
 		m := agent.Message{
-			Role:       rows[i].Role,
-			Content:    rows[i].Content,
-			ToolCallID: rows[i].ToolCallID,
-			Name:       rows[i].Name,
+			Role:            rows[i].Role,
+			Content:         rows[i].Content,
+			ToolCallID:      rows[i].ToolCallID,
+			Name:            rows[i].Name,
+			RunID:           rows[i].RunID,
+			OutputTruncated: rows[i].OutputTruncated,
 		}
 		// tool_calls 仅 assistant 轮非空；反序列化失败则整条历史不可信，直接报错。
 		if rows[i].ToolCalls != nil && *rows[i].ToolCalls != "" {
@@ -91,13 +93,15 @@ func (r *agentMessageRepo) AppendMessages(ctx context.Context, sessionID, userID
 	rows := make([]model.AgentMessage, 0, len(msgs))
 	for i := range msgs {
 		row := model.AgentMessage{
-			SessionID:  sessionID,
-			UserID:     userID,
-			Role:       msgs[i].Role,
-			Content:    msgs[i].Content,
-			ToolCallID: msgs[i].ToolCallID,
-			Name:       msgs[i].Name,
-			CreatedAt:  now,
+			SessionID:       sessionID,
+			UserID:          userID,
+			Role:            msgs[i].Role,
+			Content:         msgs[i].Content,
+			ToolCallID:      msgs[i].ToolCallID,
+			Name:            msgs[i].Name,
+			RunID:           msgs[i].RunID,
+			OutputTruncated: msgs[i].OutputTruncated,
+			CreatedAt:       now,
 		}
 		if len(msgs[i].ToolCalls) > 0 {
 			b, err := json.Marshal(msgs[i].ToolCalls)

--- a/internal/api/handler/agent_output_truncation_cgo_test.go
+++ b/internal/api/handler/agent_output_truncation_cgo_test.go
@@ -179,13 +179,10 @@ func TestFinalizeRunCleanRunStaysCompleteWithoutOutputTruncation(t *testing.T) {
 	}
 }
 
-// MarkOutputTruncated is a LATCH. The Reduce may be retried and the planner
-// emits several completions per run; a later clean call must not erase the fact
-// that an earlier one was truncated, because that truncated text may already
-// have been folded into what the user receives. A store method that wrote the
-// boolean unconditionally would let the last writer win and silently drop the
-// disclosure.
-func TestMarkOutputTruncatedLatchesAndIsIdempotent(t *testing.T) {
+// MarkOutputTruncated is idempotent and owner-scoped. The within-attempt latch
+// semantics are covered by the rejected-premature and repeated-Reduce tests;
+// the replay-only reset boundary is covered separately below.
+func TestMarkOutputTruncatedIsIdempotentAndOwnerScoped(t *testing.T) {
 	db := newFinalizeTestDB(t)
 	if db == nil {
 		return
@@ -221,5 +218,85 @@ func TestMarkOutputTruncatedLatchesAndIsIdempotent(t *testing.T) {
 	// error (it simply matches no row).
 	if err := store.MarkOutputTruncated(ctx, "u2", run.RunID); err != nil {
 		t.Fatalf("cross-owner mark should be a silent no-op, got: %v", err)
+	}
+}
+
+// A repeated request_id starts a NEW generation attempt on the SAME run row.
+// Attempt A's output is discarded on the SSE fallback/retry path, so its
+// output_truncated latch must not poison attempt B's clean deliverable. The
+// reset belongs exactly at maybePersistSummaryRun's created=false branch; the
+// latch remains one-way everywhere inside one attempt.
+func TestReplayClearsStaleOutputTruncationAndCanRelatch(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	h := &AgentChatHandler{runStore: store}
+	req := agentChatRequest{
+		Message:   "总结项目进展",
+		SessionID: "sess-trunc-replay",
+		RequestID: "req-trunc-replay",
+		SelectedChannels: []selectedChannel{{
+			ChannelID: "ch-1", ChannelType: "group", Name: "项目群",
+		}},
+	}
+
+	// Attempt A creates the run and delivers a truncated result.
+	runID := h.maybePersistSummaryRun(ctx, "u1", req, true)
+	if runID == "" {
+		t.Fatal("first attempt did not create a run")
+	}
+	if err := store.RecordChannelFetch(ctx, "u1", runID, "ch-1", true, false); err != nil {
+		t.Fatalf("record coverage: %v", err)
+	}
+	if err := store.MarkOutputTruncated(ctx, "u1", runID); err != nil {
+		t.Fatalf("mark attempt A truncated: %v", err)
+	}
+
+	// The reset is owner-scoped: an unrelated user cannot clear the latch.
+	if err := store.ClearOutputTruncatedForReplay(ctx, "someone-else", runID); err != nil {
+		t.Fatalf("foreign replay reset: %v", err)
+	}
+	if got, err := store.GetByID(ctx, "u1", runID); err != nil {
+		t.Fatalf("get after foreign reset: %v", err)
+	} else if !got.OutputTruncated {
+		t.Fatal("a foreign user cleared the owner's truncation latch")
+	}
+
+	// Attempt B reuses request_id. The handler recognises created=false and
+	// clears only the previous attempt's latch before generating fresh output.
+	if replayRunID := h.maybePersistSummaryRun(ctx, "u1", req, true); replayRunID != runID {
+		t.Fatalf("replay run_id = %q, want %q", replayRunID, runID)
+	}
+	got, err := store.GetByID(ctx, "u1", runID)
+	if err != nil {
+		t.Fatalf("get replay run: %v", err)
+	}
+	if got.OutputTruncated {
+		t.Fatal("attempt B inherited attempt A's output_truncated latch")
+	}
+
+	// A complete attempt B must now be judged COMPLETE rather than inheriting a
+	// false output_truncation gap from attempt A.
+	verdict, gaps := (&AgentSummaryHandler{db: db}).finalizeRun(
+		ctx, "u1", req.SessionID, req.RequestID, "项目进展完整 [1]。", []model.Citation{{Index: 1}},
+	)
+	if verdict != finishgate.Complete {
+		t.Fatalf("clean replay verdict = %s, want COMPLETE (gaps=%v)", verdict, gaps)
+	}
+	if hasGapKind(gaps, finishgate.GapOutputTruncation) {
+		t.Fatalf("clean replay inherited stale output_truncation gap: %v", gaps)
+	}
+
+	// The reset is not permanent: attempt B still latches its own truncation.
+	if err := store.MarkOutputTruncated(ctx, "u1", runID); err != nil {
+		t.Fatalf("relatch attempt B: %v", err)
+	}
+	if got, err := store.GetByID(ctx, "u1", runID); err != nil {
+		t.Fatalf("get after relatch: %v", err)
+	} else if !got.OutputTruncated {
+		t.Fatal("attempt B could not latch its own output truncation")
 	}
 }

--- a/internal/api/handler/agent_output_truncation_cgo_test.go
+++ b/internal/api/handler/agent_output_truncation_cgo_test.go
@@ -4,7 +4,10 @@
 package handler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,6 +28,24 @@ func (*handlerTruncatedPlanner) Chat(context.Context, []agent.Message, []agent.T
 	return agent.AssistantTurn{Content: "truncated final answer", Truncated: true}, nil
 }
 
+type handlerSequencePlanner struct {
+	turns []agent.AssistantTurn
+	errs  []error
+	call  int
+}
+
+func (p *handlerSequencePlanner) Chat(context.Context, []agent.Message, []agent.Tool) (agent.AssistantTurn, error) {
+	i := p.call
+	p.call++
+	if i < len(p.errs) && p.errs[i] != nil {
+		return agent.AssistantTurn{}, p.errs[i]
+	}
+	if i >= len(p.turns) {
+		return agent.AssistantTurn{}, errors.New("unexpected planner call")
+	}
+	return p.turns[i], nil
+}
+
 // This pins the production wiring the lower-level agent tests cannot prove:
 // both HTTP handlers must put the authenticated uid and persisted run id on the
 // exact context handed to Runner.RunWithHistory.
@@ -42,7 +63,8 @@ func TestAgentChatHandlersRecordPlannerOutputTruncation(t *testing.T) {
 	runner := agent.NewRunner(&handlerTruncatedPlanner{}, reg, agent.NewPool(1), agent.Policy{
 		MaxSteps: 1, MaxTokens: 1000, StepTimeout: time.Second,
 	})
-	handler := newAgentChatHandlerWithRunner(runner, "test-system", newFakeHistoryStore(), 10)
+	historyStore := newFakeHistoryStore()
+	handler := newAgentChatHandlerWithRunner(runner, "test-system", historyStore, 10)
 	handler.runStore = store
 	router := setupAgentChatRouter(handler)
 
@@ -72,6 +94,17 @@ func TestAgentChatHandlersRecordPlannerOutputTruncation(t *testing.T) {
 			}
 			if !run.OutputTruncated {
 				t.Fatal("planner truncation was not recorded through the real handler context")
+			}
+			history, err := historyStore.LoadHistory(context.Background(), tc.sessionID, testAgentChatUID)
+			if err != nil {
+				t.Fatalf("load persisted history: %v", err)
+			}
+			if len(history) == 0 {
+				t.Fatal("handler did not persist the final assistant message")
+			}
+			final := history[len(history)-1]
+			if final.RunID != run.RunID || !final.OutputTruncated {
+				t.Fatalf("final assistant metadata = {run:%q truncated:%t}, want {%q true}", final.RunID, final.OutputTruncated, run.RunID)
 			}
 		})
 	}
@@ -142,6 +175,72 @@ func TestFinalizeRunDisclosesOutputTruncationDespiteCleanAnswer(t *testing.T) {
 	// send the user off to narrow a time range that was never the problem.
 	if hasGapKind(gaps, finishgate.GapTruncation) {
 		t.Fatalf("gaps = %v: an OUTPUT truncation must not be reported as a fetch-pool truncation", gaps)
+	}
+}
+
+// The assistant-row flag is the authoritative source for new messages. This
+// remains safe even if the older best-effort run-row write was lost: content and
+// its degradation flag are inserted together by AppendMessages.
+func TestFinalizeRunUsesMessageBoundOutputTruncation(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess-msg-bound", "req-msg-bound", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := db.Model(&model.AgentSummaryRun{}).Where("run_id = ?", run.RunID).
+		Update("spec_id", "spec-1").Error; err != nil {
+		t.Fatalf("set spec_id: %v", err)
+	}
+	if err := store.RecordChannelFetch(ctx, "u1", run.RunID, "ch-1", true, false); err != nil {
+		t.Fatalf("record coverage: %v", err)
+	}
+
+	msg := model.AgentMessage{RunID: run.RunID, OutputTruncated: true}
+	verdict, gaps := (&AgentSummaryHandler{db: db}).finalizeRunForMessage(
+		ctx, "u1", "sess-msg-bound", "req-msg-bound", "外表完整但实际截断的总结。", nil, msg,
+	)
+	if verdict != finishgate.Partial || !hasGapKind(gaps, finishgate.GapOutputTruncation) {
+		t.Fatalf("message-bound verdict = %s gaps=%v, want PARTIAL with output_truncation", verdict, gaps)
+	}
+	if got, err := store.GetByID(ctx, "u1", run.RunID); err != nil {
+		t.Fatalf("reload run: %v", err)
+	} else if got.OutputTruncated {
+		t.Fatal("test precondition broken: run aggregate should remain false")
+	}
+}
+
+func TestResolveAgentMessageRequestIDUsesPersistedRunBinding(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess-bound", "req-bound", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	msg := model.AgentMessage{RunID: run.RunID}
+
+	if got, err := resolveAgentMessageRequestID(ctx, db, "u1", "sess-bound", "", msg); err != nil || got != "req-bound" {
+		t.Fatalf("derive request id = %q err=%v, want req-bound", got, err)
+	}
+	if got, err := resolveAgentMessageRequestID(ctx, db, "u1", "sess-bound", "req-bound", msg); err != nil || got != "req-bound" {
+		t.Fatalf("matching request id = %q err=%v, want req-bound", got, err)
+	}
+	if _, err := resolveAgentMessageRequestID(ctx, db, "u1", "sess-bound", "req-other", msg); !errors.Is(err, errAgentMessageRunMismatch) {
+		t.Fatalf("explicit mismatch err=%v, want errAgentMessageRunMismatch", err)
+	}
+	if _, err := resolveAgentMessageRequestID(ctx, db, "u1", "sess-other", "", msg); !errors.Is(err, errAgentMessageRunMismatch) {
+		t.Fatalf("session mismatch err=%v, want errAgentMessageRunMismatch", err)
+	}
+	if got, err := resolveAgentMessageRequestID(ctx, db, "u1", "sess-bound", "legacy-req", model.AgentMessage{}); err != nil || got != "legacy-req" {
+		t.Fatalf("legacy fallback = %q err=%v, want legacy-req", got, err)
 	}
 }
 
@@ -221,67 +320,176 @@ func TestMarkOutputTruncatedIsIdempotentAndOwnerScoped(t *testing.T) {
 	}
 }
 
-// A repeated request_id starts a NEW generation attempt on the SAME run row.
-// Attempt A's output is discarded on the SSE fallback/retry path, so its
-// output_truncated latch must not poison attempt B's clean deliverable. The
-// reset belongs exactly at maybePersistSummaryRun's created=false branch; the
-// latch remains one-way everywhere inside one attempt.
-func TestReplayClearsStaleOutputTruncationAndCanRelatch(t *testing.T) {
+func postOutputTruncationChat(t *testing.T, router http.Handler, sessionID, requestID string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"message":"总结项目进展","session_id":"` + sessionID + `","request_id":"` + requestID + `","profile":"summary","selected_channels":[{"chat_id":"ch-1","chat_type":"group","name":"项目群"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/chat", body)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// A replay that FAILS must not mutate the degradation attached to the previous
+// persisted deliverable. This is the exact SSE window from the CR: attempt A's
+// assistant row commits, the done event is lost, attempt B starts and fails,
+// then save still resolves A and must report its truncation.
+func TestReplayFailureKeepsPreviousMessageOutputTruncation(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(
+		&model.AgentSummaryRun{},
+		&model.AgentSummarySpec{},
+		&model.AgentEvidenceArtifact{},
+		&model.AgentCitationManifest{},
+	); err != nil {
+		t.Fatalf("migrate V2 tables: %v", err)
+	}
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+	agent.SetSummaryDeps(db, nil, nil, config.Config{})
+	t.Cleanup(func() { agent.SetSummaryDeps(nil, nil, nil, config.Config{}) })
+
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	planner := &handlerSequencePlanner{
+		turns: []agent.AssistantTurn{
+			{Content: "截断但外表完整的回复。", Truncated: true},
+			{},
+		},
+		errs: []error{nil, errors.New("attempt B failed")},
+	}
+	runner := agent.NewRunner(planner, agent.NewRegistry(), agent.NewPool(1), agent.Policy{
+		MaxSteps: 1, MaxTokens: 1000, StepTimeout: time.Second,
+	})
+	h := newAgentChatHandlerWithRunner(runner, "test-system", newAgentMessageRepo(db), 10)
+	h.db = db
+	h.runStore = store
+	router := setupAgentChatRouter(h)
+	const sessionID = "sess-trunc-replay-fail"
+	const requestID = "req-trunc-replay-fail"
+
+	if w := postOutputTruncationChat(t, router, sessionID, requestID); w.Code != http.StatusOK {
+		t.Fatalf("attempt A status = %d, body=%s", w.Code, w.Body.String())
+	}
+	run, err := store.GetByRequest(ctx, testAgentChatUID, sessionID, requestID)
+	if err != nil {
+		t.Fatalf("get run after attempt A: %v", err)
+	}
+	if err := store.RecordChannelFetch(ctx, testAgentChatUID, run.RunID, "ch-1", true, false); err != nil {
+		t.Fatalf("record coverage: %v", err)
+	}
+
+	if w := postOutputTruncationChat(t, router, sessionID, requestID); w.Code != http.StatusInternalServerError {
+		t.Fatalf("attempt B status = %d, want 500, body=%s", w.Code, w.Body.String())
+	}
+
+	draft, err := loadAgentMessageForSave(db, sessionID, testAgentChatUID, 0)
+	if err != nil {
+		t.Fatalf("load persisted attempt A: %v", err)
+	}
+	if draft.RunID != run.RunID || !draft.OutputTruncated {
+		t.Fatalf("persisted A metadata = {run:%q truncated:%t}, want {%q true}", draft.RunID, draft.OutputTruncated, run.RunID)
+	}
+
+	// Exercise the real save endpoint, not just finalizeRunForMessage. The
+	// currently deployed client omits request_id on save, so the handler must
+	// derive it from A's persisted RunID before building citations/finalizing.
+	saveBody, err := json.Marshal(map[string]interface{}{
+		"session_id":          sessionID,
+		"origin_channel_id":   "ch-1",
+		"origin_channel_type": 1,
+	})
+	if err != nil {
+		t.Fatalf("encode save request: %v", err)
+	}
+	saveHandler := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	w := httptest.NewRecorder()
+	saveReq := httptest.NewRequest(http.MethodPost, "/api/v1/summaries/agent", bytes.NewReader(saveBody))
+	saveReq.Header.Set("Content-Type", "application/json")
+	saveReq.Header.Set("Token", testAgentChatUID)
+	saveReq.Header.Set("X-Space-Id", "test-space")
+	setupAgentSummaryRouter(saveHandler).ServeHTTP(w, saveReq)
+	if w.Code != http.StatusOK {
+		t.Fatalf("save after failed replay status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Data struct {
+			FinishStatus string           `json:"finish_status"`
+			Gaps         []finishgate.Gap `json:"gaps"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode save response: %v", err)
+	}
+	if response.Data.FinishStatus != string(finishgate.Partial) || !hasGapKind(response.Data.Gaps, finishgate.GapOutputTruncation) {
+		t.Fatalf("failed replay save response = %s, want PARTIAL with output_truncation", w.Body.String())
+	}
+	var saved model.PersonalResult
+	if err := db.First(&saved).Error; err != nil {
+		t.Fatalf("load saved deliverable: %v", err)
+	}
+	if saved.Content != draft.Content {
+		t.Fatalf("saved content = %q, want attempt A %q", saved.Content, draft.Content)
+	}
+}
+
+// If attempt A recorded only the conservative run latch but never persisted a
+// message, a successful clean attempt B is the first real deliverable. Its
+// message-bound false value must override the stale run aggregate and restore a
+// COMPLETE verdict.
+func TestCleanReplayMessageOverridesAbandonedRunLatch(t *testing.T) {
 	db := newFinalizeTestDB(t)
 	if db == nil {
 		return
 	}
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+	agent.SetSummaryDeps(db, nil, nil, config.Config{})
+	t.Cleanup(func() { agent.SetSummaryDeps(nil, nil, nil, config.Config{}) })
+
 	store := summaryrun.NewStore(db)
 	ctx := context.Background()
-	h := &AgentChatHandler{runStore: store}
+	const sessionID = "sess-trunc-replay-clean"
+	const requestID = "req-trunc-replay-clean"
 	req := agentChatRequest{
 		Message:   "总结项目进展",
-		SessionID: "sess-trunc-replay",
-		RequestID: "req-trunc-replay",
+		SessionID: sessionID,
+		RequestID: requestID,
 		SelectedChannels: []selectedChannel{{
 			ChannelID: "ch-1", ChannelType: "group", Name: "项目群",
 		}},
 	}
-
-	// Attempt A creates the run and delivers a truncated result.
-	runID := h.maybePersistSummaryRun(ctx, "u1", req, true)
+	h := &AgentChatHandler{runStore: store}
+	runID := h.maybePersistSummaryRun(ctx, testAgentChatUID, req, true)
 	if runID == "" {
-		t.Fatal("first attempt did not create a run")
+		t.Fatal("attempt A did not create a run")
 	}
-	if err := store.RecordChannelFetch(ctx, "u1", runID, "ch-1", true, false); err != nil {
+	if err := store.MarkOutputTruncated(ctx, testAgentChatUID, runID); err != nil {
+		t.Fatalf("mark abandoned attempt A truncated: %v", err)
+	}
+
+	planner := &handlerSequencePlanner{turns: []agent.AssistantTurn{{Content: "完整回复 [1]。"}}}
+	runner := agent.NewRunner(planner, agent.NewRegistry(), agent.NewPool(1), agent.Policy{
+		MaxSteps: 1, MaxTokens: 1000, StepTimeout: time.Second,
+	})
+	h = newAgentChatHandlerWithRunner(runner, "test-system", newAgentMessageRepo(db), 10)
+	h.db = db
+	h.runStore = store
+	if w := postOutputTruncationChat(t, setupAgentChatRouter(h), sessionID, requestID); w.Code != http.StatusOK {
+		t.Fatalf("attempt B status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if err := store.RecordChannelFetch(ctx, testAgentChatUID, runID, "ch-1", true, false); err != nil {
 		t.Fatalf("record coverage: %v", err)
 	}
-	if err := store.MarkOutputTruncated(ctx, "u1", runID); err != nil {
-		t.Fatalf("mark attempt A truncated: %v", err)
-	}
 
-	// The reset is owner-scoped: an unrelated user cannot clear the latch.
-	if err := store.ClearOutputTruncatedForReplay(ctx, "someone-else", runID); err != nil {
-		t.Fatalf("foreign replay reset: %v", err)
-	}
-	if got, err := store.GetByID(ctx, "u1", runID); err != nil {
-		t.Fatalf("get after foreign reset: %v", err)
-	} else if !got.OutputTruncated {
-		t.Fatal("a foreign user cleared the owner's truncation latch")
-	}
-
-	// Attempt B reuses request_id. The handler recognises created=false and
-	// clears only the previous attempt's latch before generating fresh output.
-	if replayRunID := h.maybePersistSummaryRun(ctx, "u1", req, true); replayRunID != runID {
-		t.Fatalf("replay run_id = %q, want %q", replayRunID, runID)
-	}
-	got, err := store.GetByID(ctx, "u1", runID)
+	draft, err := loadAgentMessageForSave(db, sessionID, testAgentChatUID, 0)
 	if err != nil {
-		t.Fatalf("get replay run: %v", err)
+		t.Fatalf("load clean attempt B: %v", err)
 	}
-	if got.OutputTruncated {
-		t.Fatal("attempt B inherited attempt A's output_truncated latch")
+	if draft.RunID != runID || draft.OutputTruncated {
+		t.Fatalf("persisted B metadata = {run:%q truncated:%t}, want {%q false}", draft.RunID, draft.OutputTruncated, runID)
 	}
 
-	// A complete attempt B must now be judged COMPLETE rather than inheriting a
-	// false output_truncation gap from attempt A.
-	verdict, gaps := (&AgentSummaryHandler{db: db}).finalizeRun(
-		ctx, "u1", req.SessionID, req.RequestID, "项目进展完整 [1]。", []model.Citation{{Index: 1}},
+	verdict, gaps := (&AgentSummaryHandler{db: db}).finalizeRunForMessage(
+		ctx, testAgentChatUID, sessionID, requestID, draft.Content, []model.Citation{{Index: 1}}, draft,
 	)
 	if verdict != finishgate.Complete {
 		t.Fatalf("clean replay verdict = %s, want COMPLETE (gaps=%v)", verdict, gaps)
@@ -290,13 +498,4 @@ func TestReplayClearsStaleOutputTruncationAndCanRelatch(t *testing.T) {
 		t.Fatalf("clean replay inherited stale output_truncation gap: %v", gaps)
 	}
 
-	// The reset is not permanent: attempt B still latches its own truncation.
-	if err := store.MarkOutputTruncated(ctx, "u1", runID); err != nil {
-		t.Fatalf("relatch attempt B: %v", err)
-	}
-	if got, err := store.GetByID(ctx, "u1", runID); err != nil {
-		t.Fatalf("get after relatch: %v", err)
-	} else if !got.OutputTruncated {
-		t.Fatal("attempt B could not latch its own output truncation")
-	}
 }

--- a/internal/api/handler/agent_output_truncation_cgo_test.go
+++ b/internal/api/handler/agent_output_truncation_cgo_test.go
@@ -5,14 +5,77 @@ package handler
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/finishgate"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 )
+
+type handlerTruncatedPlanner struct{}
+
+func (*handlerTruncatedPlanner) Chat(context.Context, []agent.Message, []agent.Tool) (agent.AssistantTurn, error) {
+	return agent.AssistantTurn{Content: "truncated final answer", Truncated: true}, nil
+}
+
+// This pins the production wiring the lower-level agent tests cannot prove:
+// both HTTP handlers must put the authenticated uid and persisted run id on the
+// exact context handed to Runner.RunWithHistory.
+func TestAgentChatHandlersRecordPlannerOutputTruncation(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+	agent.SetSummaryDeps(db, nil, nil, config.Config{})
+	t.Cleanup(func() { agent.SetSummaryDeps(nil, nil, nil, config.Config{}) })
+
+	store := summaryrun.NewStore(db)
+	reg := agent.NewRegistry()
+	runner := agent.NewRunner(&handlerTruncatedPlanner{}, reg, agent.NewPool(1), agent.Policy{
+		MaxSteps: 1, MaxTokens: 1000, StepTimeout: time.Second,
+	})
+	handler := newAgentChatHandlerWithRunner(runner, "test-system", newFakeHistoryStore(), 10)
+	handler.runStore = store
+	router := setupAgentChatRouter(handler)
+
+	tests := []struct {
+		name      string
+		path      string
+		sessionID string
+		requestID string
+	}{
+		{name: "chat", path: "/api/v1/agent/chat", sessionID: "sess-handler-chat", requestID: "req-handler-chat"},
+		{name: "stream", path: "/api/v1/agent/chat/stream", sessionID: "sess-handler-stream", requestID: "req-handler-stream"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			body := strings.NewReader(`{"message":"summarize","session_id":"` + tc.sessionID + `","request_id":"` + tc.requestID + `","profile":"summary"}`)
+			req := httptest.NewRequest(http.MethodPost, tc.path, body)
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+			}
+
+			run, err := store.GetByRequest(context.Background(), testAgentChatUID, tc.sessionID, tc.requestID)
+			if err != nil {
+				t.Fatalf("get run: %v", err)
+			}
+			if !run.OutputTruncated {
+				t.Fatal("planner truncation was not recorded through the real handler context")
+			}
+		})
+	}
+}
 
 // THE LOAD-BEARING TEST: the truncation disclosure must not be defeatable by
 // the model.

--- a/internal/api/handler/agent_output_truncation_cgo_test.go
+++ b/internal/api/handler/agent_output_truncation_cgo_test.go
@@ -1,0 +1,162 @@
+//go:build cgo
+// +build cgo
+
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/finishgate"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
+)
+
+// THE LOAD-BEARING TEST: the truncation disclosure must not be defeatable by
+// the model.
+//
+// The failure this guards against is specific. When a Reduce is length-
+// truncated, merge_summaries appends service.TruncationNotice to the
+// `merged_summary` field of a TOOL RESULT. That tool result is not the
+// deliverable — it is context handed back to the planner, which then writes the
+// final user-facing answer in its own words. Nothing forces the notice through.
+// It reads like meta-commentary rather than content, so a model producing a
+// polished final answer will plausibly drop it, and the user receives a summary
+// that is silently unfinished while looking complete.
+//
+// So: simulate exactly that. The run is marked output-truncated (as the
+// producing paths do), and the content passed to finalizeRun is a clean final
+// answer containing NO notice — the model rewrote it away. The verdict must
+// still be PARTIAL with a truncation gap, because the gate assembles its
+// disclosure from the persisted run row, outside the model's control.
+func TestFinalizeRunDisclosesOutputTruncationDespiteCleanAnswer(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess1", "req-trunc", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := db.Model(&model.AgentSummaryRun{}).Where("run_id = ?", run.RunID).
+		Update("spec_id", "spec-1").Error; err != nil {
+		t.Fatalf("set spec_id: %v", err)
+	}
+	// Full, clean coverage: every channel in scope was fetched successfully and
+	// nothing was dropped. The ONLY defect in this run is that the model's own
+	// output was cut off, so any gap reported here must come from that fact.
+	if err := store.RecordChannelFetch(ctx, "u1", run.RunID, "ch-1", true, false); err != nil {
+		t.Fatalf("record fetch: %v", err)
+	}
+
+	// The producing side (merge_summaries / the planner loop) latches the fact.
+	if err := store.MarkOutputTruncated(ctx, "u1", run.RunID); err != nil {
+		t.Fatalf("mark output truncated: %v", err)
+	}
+
+	// The model's final answer. Note what is NOT here: no TruncationNotice, no
+	// hint of degradation, no ellipsis. This is a confident, well-formed summary
+	// — precisely what a planner emits after quietly discarding the notice.
+	cleanAnswer := "本周项目进展顺利，核心功能已全部交付 [1]。"
+	if strings.Contains(cleanAnswer, strings.TrimSpace(service.TruncationNotice)) {
+		t.Fatal("test setup is wrong: the answer must contain NO prose notice")
+	}
+
+	h := &AgentSummaryHandler{db: db}
+	verdict, gaps := h.finalizeRun(ctx, "u1", "sess1", "req-trunc", cleanAnswer, []model.Citation{{Index: 1}})
+
+	if verdict != finishgate.Partial {
+		t.Fatalf("verdict = %s, want PARTIAL: the model dropped the prose notice, so the gate is the only thing standing between the user and a silently unfinished summary (gaps=%v)", verdict, gaps)
+	}
+	if !hasGapKind(gaps, finishgate.GapOutputTruncation) {
+		t.Fatalf("gaps = %v, want a %s gap assembled from the run row rather than from model-authored text", gaps, finishgate.GapOutputTruncation)
+	}
+	// Coverage was perfect; the disclosure must name the right failure and not
+	// send the user off to narrow a time range that was never the problem.
+	if hasGapKind(gaps, finishgate.GapTruncation) {
+		t.Fatalf("gaps = %v: an OUTPUT truncation must not be reported as a fetch-pool truncation", gaps)
+	}
+}
+
+// NO FALSE POSITIVES (requirement 3). The same run shape with nothing truncated
+// must stay COMPLETE. gate.go documents a prior bug where a new disclosure path
+// reported correct behaviour as a defect; this is the guard against repeating it
+// and it is the exact control for the test above — identical setup minus the
+// MarkOutputTruncated call.
+func TestFinalizeRunCleanRunStaysCompleteWithoutOutputTruncation(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess1", "req-clean", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := db.Model(&model.AgentSummaryRun{}).Where("run_id = ?", run.RunID).
+		Update("spec_id", "spec-1").Error; err != nil {
+		t.Fatalf("set spec_id: %v", err)
+	}
+	if err := store.RecordChannelFetch(ctx, "u1", run.RunID, "ch-1", true, false); err != nil {
+		t.Fatalf("record fetch: %v", err)
+	}
+
+	h := &AgentSummaryHandler{db: db}
+	verdict, gaps := h.finalizeRun(ctx, "u1", "sess1", "req-clean", "本周项目进展顺利 [1]。", []model.Citation{{Index: 1}})
+	if verdict != finishgate.Complete {
+		t.Fatalf("verdict = %s, want COMPLETE for a run with no truncation anywhere (gaps=%v)", verdict, gaps)
+	}
+	if len(gaps) != 0 {
+		t.Fatalf("a clean run must disclose nothing, got %v", gaps)
+	}
+}
+
+// MarkOutputTruncated is a LATCH. The Reduce may be retried and the planner
+// emits several completions per run; a later clean call must not erase the fact
+// that an earlier one was truncated, because that truncated text may already
+// have been folded into what the user receives. A store method that wrote the
+// boolean unconditionally would let the last writer win and silently drop the
+// disclosure.
+func TestMarkOutputTruncatedLatchesAndIsIdempotent(t *testing.T) {
+	db := newFinalizeTestDB(t)
+	if db == nil {
+		return
+	}
+	store := summaryrun.NewStore(db)
+	ctx := context.Background()
+	run, _, err := store.CreateOrGetRun(ctx, "u1", "sess1", "req-latch", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	if got, err := store.GetByID(ctx, "u1", run.RunID); err != nil {
+		t.Fatalf("get run: %v", err)
+	} else if got.OutputTruncated {
+		t.Fatal("a fresh run must not be marked output-truncated")
+	}
+
+	// Mark twice: the second call is a no-op, not an error.
+	for i := 0; i < 2; i++ {
+		if err := store.MarkOutputTruncated(ctx, "u1", run.RunID); err != nil {
+			t.Fatalf("mark #%d: %v", i+1, err)
+		}
+	}
+	got, err := store.GetByID(ctx, "u1", run.RunID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if !got.OutputTruncated {
+		t.Fatal("output_truncated must stay latched after repeated marks")
+	}
+
+	// Owner scoping: another user's mark must not touch this run, and must not
+	// error (it simply matches no row).
+	if err := store.MarkOutputTruncated(ctx, "u2", run.RunID); err != nil {
+		t.Fatalf("cross-owner mark should be a silent no-op, got: %v", err)
+	}
+}

--- a/internal/api/handler/agent_output_truncation_cgo_test.go
+++ b/internal/api/handler/agent_output_truncation_cgo_test.go
@@ -392,7 +392,9 @@ func TestReplayFailureKeepsPreviousMessageOutputTruncation(t *testing.T) {
 
 	// Exercise the real save endpoint, not just finalizeRunForMessage. The
 	// currently deployed client omits request_id on save, so the handler must
-	// derive it from A's persisted RunID before building citations/finalizing.
+	// derive it from A's persisted RunID for binding validation/finalization.
+	// Citation building deliberately keeps the original empty request_id and
+	// therefore preserves the legacy recompute contract.
 	saveBody, err := json.Marshal(map[string]interface{}{
 		"session_id":          sessionID,
 		"origin_channel_id":   "ch-1",

--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -569,7 +569,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			UpdatedAt:        now,
 		}
 		// Build citations from session tool traces (fallback to empty array on error)
-		cits, cerr := h.buildCitationsForSessionWithDB(c.Request.Context(), tx, req.SessionID, content, userID, resolvedRequestID)
+		cits, cerr := h.buildCitationsForSessionWithDB(c.Request.Context(), tx, req.SessionID, content, userID, req.RequestID)
 		if cerr != nil {
 			log.Printf("[handler] buildCitationsForSession failed session=%s: %v (fallback to empty)", req.SessionID, cerr)
 			cits = nil

--- a/internal/api/handler/agent_summary.go
+++ b/internal/api/handler/agent_summary.go
@@ -105,9 +105,9 @@ type createAgentSummaryReq struct {
 	// (方便日后做衍生关系追溯),不影响本次生成的 content/citations。
 	ReferencedTaskIDs []int64 `json:"referenced_task_ids,omitempty"`
 	// RequestID 可选:必须是生成当前最新 assistant 内容的同一 agent chat
-	// 轮次的 request_id (SS-03 idempotency key)。当前 AgentMessage 尚未持久化
-	// run_id，服务端无法验证跨轮错配；该绑定由客户端负责，SS-08 再持久化
-	// 校验。缺省/未知 → 与 legacy 一致的重算路径。
+	// 轮次的 request_id (SS-03 idempotency key)。新消息通过持久化的 run_id
+	// 在服务端验证；缺省时由该绑定反查。旧消息没有 run_id，继续走 legacy
+	// request_id 路径。
 	RequestID string `json:"request_id,omitempty"`
 	// AgentMessageID + SnapshotVersion form the trusted draft reference the
 	// design (section 6.5) requires. Both are optional in BE-2 for backward
@@ -381,6 +381,24 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "读取 session 产出失败"})
 		return
 	}
+	resolvedRequestID := req.RequestID
+	if agent.SummaryV2Enabled() {
+		resolvedRequestID, err = resolveAgentMessageRequestID(
+			c.Request.Context(), h.db, userID, req.SessionID, req.RequestID, draftMsg,
+		)
+		if err != nil {
+			if errors.Is(err, errAgentMessageRunMismatch) {
+				// Reject before the transaction creates a task or deletes the session.
+				// A PARTIAL verdict after commit would still persist the wrong content /
+				// citation manifest pairing and destroy the recoverable draft.
+				c.JSON(http.StatusConflict, apiResponse{Code: 40901, Message: "agent_draft_stale: 消息与生成请求不匹配,请刷新草稿"})
+				return
+			}
+			log.Printf("[handler] CreateAgentSummary resolve message run failed session=%s message_id=%d: %v", req.SessionID, draftMsg.ID, err)
+			c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "读取 agent 生成记录失败"})
+			return
+		}
+	}
 	content := draftMsg.Content
 	resolvedAgentMessageID := draftMsg.ID
 
@@ -551,7 +569,7 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 			UpdatedAt:        now,
 		}
 		// Build citations from session tool traces (fallback to empty array on error)
-		cits, cerr := h.buildCitationsForSessionWithDB(c.Request.Context(), tx, req.SessionID, content, userID, req.RequestID)
+		cits, cerr := h.buildCitationsForSessionWithDB(c.Request.Context(), tx, req.SessionID, content, userID, resolvedRequestID)
 		if cerr != nil {
 			log.Printf("[handler] buildCitationsForSession failed session=%s: %v (fallback to empty)", req.SessionID, cerr)
 			cits = nil
@@ -683,8 +701,8 @@ func (h *AgentSummaryHandler) CreateAgentSummary(c *gin.Context) {
 	// The verdict is an internal, non-blocking quality signal; off / missing or
 	// unknown request_id → no-op.
 	if agent.SummaryV2Enabled() {
-		if v, gaps := h.finalizeRun(c.Request.Context(), userID, req.SessionID, req.RequestID, content, savedCitations); v != "" {
-			log.Printf("[handler] agent summary finish verdict=%s gaps=%d session=%s request=%s (recorded, non-blocking)", v, len(gaps), req.SessionID, req.RequestID)
+		if v, gaps := h.finalizeRunForMessage(c.Request.Context(), userID, req.SessionID, resolvedRequestID, content, savedCitations, draftMsg); v != "" {
+			log.Printf("[handler] agent summary finish verdict=%s gaps=%d session=%s request=%s (recorded, non-blocking)", v, len(gaps), req.SessionID, resolvedRequestID)
 			finishVerdict, finishGaps = v, gaps
 		}
 	}

--- a/internal/api/handler/agent_summary_be2_test.go
+++ b/internal/api/handler/agent_summary_be2_test.go
@@ -11,6 +11,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 
 	"gorm.io/gorm"
@@ -169,6 +171,56 @@ func TestCreateAgentSummary_BE2_MessageIDToolCall_404(t *testing.T) {
 	}, nil)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for tool-call id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateAgentSummary_BE2_MessageRunMismatchRejectedBeforeSave(t *testing.T) {
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(&model.AgentSummaryRun{}); err != nil {
+		t.Fatalf("migrate summary run: %v", err)
+	}
+	store := summaryrun.NewStore(db)
+	runA, _, err := store.CreateOrGetRun(context.Background(), "test-user", "sess-run-mismatch", "req-a", model.ScopePolicyClosed)
+	if err != nil {
+		t.Fatalf("create run A: %v", err)
+	}
+	if _, _, err := store.CreateOrGetRun(context.Background(), "test-user", "sess-run-mismatch", "req-b", model.ScopePolicyClosed); err != nil {
+		t.Fatalf("create run B: %v", err)
+	}
+	msg := seedAssistantMessage(t, db, "test-user", "sess-run-mismatch", "answer from run A")
+	if err := db.Model(&msg).Update("run_id", runA.RunID).Error; err != nil {
+		t.Fatalf("bind message to run A: %v", err)
+	}
+
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	w := doAgentSave(t, setupAgentSummaryRouter(h), map[string]interface{}{
+		"session_id":          "sess-run-mismatch",
+		"request_id":          "req-b",
+		"origin_channel_id":   "chan-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    msg.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("mismatch status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["code"] != float64(40901) {
+		t.Fatalf("mismatch code = %v, want 40901", resp["code"])
+	}
+	var taskCount, messageCount int64
+	if err := db.Model(&model.SummaryTask{}).Count(&taskCount).Error; err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if err := db.Model(&model.AgentMessage{}).Where("id = ?", msg.ID).Count(&messageCount).Error; err != nil {
+		t.Fatalf("count draft: %v", err)
+	}
+	if taskCount != 0 || messageCount != 1 {
+		t.Fatalf("mismatch mutated state: tasks=%d draft_rows=%d, want 0/1", taskCount, messageCount)
 	}
 }
 

--- a/internal/api/handler/agent_summary_citations.go
+++ b/internal/api/handler/agent_summary_citations.go
@@ -310,16 +310,32 @@ func contentHasCitationSequence(content string) bool {
 	return false
 }
 
-// finalizeRun computes the SS-07 finish verdict (COMPLETE/PARTIAL/FAILED) for
-// the exact request that produced the saved content and persists it. It is
-// best-effort and flag-gated by the caller. A missing/unknown request_id is a
-// no-op: selecting "the latest run in the session" is unsafe because a late
-// status update on an older run can move its updated_at past the generating run.
+// finalizeRun is the legacy/test entry point for rows that are not yet bound to
+// a run id on agent_message. It falls back to the conservative run-level output
+// truncation latch.
+func (h *AgentSummaryHandler) finalizeRun(ctx context.Context, uid, sessionID, requestID, content string, cits []model.Citation) (finishgate.Verdict, []finishgate.Gap) {
+	return h.finalizeRunForDeliverable(ctx, uid, sessionID, requestID, content, cits, "", false)
+}
+
+// finalizeRunForMessage computes the finish verdict for the exact persisted
+// assistant message selected by the save path. New V2 messages carry their run
+// id and attempt-local output-truncation fact on the same row as the content;
+// legacy rows have an empty run id and use the run-level fallback above.
+func (h *AgentSummaryHandler) finalizeRunForMessage(ctx context.Context, uid, sessionID, requestID, content string, cits []model.Citation, msg model.AgentMessage) (finishgate.Verdict, []finishgate.Gap) {
+	return h.finalizeRunForDeliverable(ctx, uid, sessionID, requestID, content, cits, msg.RunID, msg.OutputTruncated)
+}
+
+// finalizeRunForDeliverable computes the SS-07 finish verdict
+// (COMPLETE/PARTIAL/FAILED) for the exact request and deliverable, then persists
+// it. It is best-effort and flag-gated by the caller. A missing/unknown
+// request_id is a no-op: selecting "the latest run in the session" is unsafe
+// because a late status update on an older run can move its updated_at past the
+// generating run.
 //
 // Returns the verdict and gaps so the caller can surface them. A request with no
 // run row returns ("", nil) and the save proceeds unchanged; only a genuine
 // lookup FAILURE reports an unverified PARTIAL.
-func (h *AgentSummaryHandler) finalizeRun(ctx context.Context, uid, sessionID, requestID, content string, cits []model.Citation) (finishgate.Verdict, []finishgate.Gap) {
+func (h *AgentSummaryHandler) finalizeRunForDeliverable(ctx context.Context, uid, sessionID, requestID, content string, cits []model.Citation, deliverableRunID string, deliverableOutputTruncated bool) (finishgate.Verdict, []finishgate.Gap) {
 	if h.db == nil || requestID == "" {
 		return "", nil
 	}
@@ -349,6 +365,26 @@ func (h *AgentSummaryHandler) finalizeRun(ctx context.Context, uid, sessionID, r
 		}}
 	}
 
+	outputTruncated := run.OutputTruncated
+	if deliverableRunID != "" {
+		// Message-bound evidence is authoritative even when the shared run-level
+		// aggregate was latched by an abandoned replay attempt. Both targeted
+		// message_id saves and the legacy latest-assistant lookup therefore judge
+		// the same row whose content is being persisted.
+		if deliverableRunID != run.RunID {
+			log.Printf("[finish] selected message/run mismatch session=%s request=%s message_run=%s resolved_run=%s", sessionID, requestID, deliverableRunID, run.RunID)
+			gaps := []finishgate.Gap{{
+				Kind:   finishgate.GapToolError,
+				Detail: "selected deliverable does not match the summary run",
+			}}
+			if err := runStore.SetFinishStatus(ctx, uid, run.RunID, string(finishgate.Partial)); err != nil {
+				log.Printf("[finish] persist mismatched finish_status failed run=%s: %v", run.RunID, err)
+			}
+			return finishgate.Partial, gaps
+		}
+		outputTruncated = deliverableOutputTruncated
+	}
+
 	state := finishgate.RunState{
 		ScopeResolved:            run.SpecID != "",
 		SummaryGenerated:         content != "",
@@ -360,7 +396,7 @@ func (h *AgentSummaryHandler) finalizeRun(ctx context.Context, uid, sessionID, r
 		FailedChannels:           decodeFinishChannelIDs(run.FailedChannels),
 		DiscoveredChannels:       decodeFinishChannelIDs(run.DiscoveredChannels),
 		Truncated:                run.CoverageTruncated,
-		OutputTruncated:          run.OutputTruncated,
+		OutputTruncated:          outputTruncated,
 		DroppedMessages:          run.DroppedMessages,
 	}
 

--- a/internal/api/handler/agent_summary_citations.go
+++ b/internal/api/handler/agent_summary_citations.go
@@ -360,6 +360,7 @@ func (h *AgentSummaryHandler) finalizeRun(ctx context.Context, uid, sessionID, r
 		FailedChannels:           decodeFinishChannelIDs(run.FailedChannels),
 		DiscoveredChannels:       decodeFinishChannelIDs(run.DiscoveredChannels),
 		Truncated:                run.CoverageTruncated,
+		OutputTruncated:          run.OutputTruncated,
 		DroppedMessages:          run.DroppedMessages,
 	}
 

--- a/internal/api/handler/agent_summary_citations_handler_cgo_test.go
+++ b/internal/api/handler/agent_summary_citations_handler_cgo_test.go
@@ -1,0 +1,76 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/finishgate"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// A save may omit request_id even when its selected assistant message is
+// bound to a V2 run. The derived request id is for validating/finalizing that
+// message only; it must not silently switch citation building from the legacy
+// recompute to the run's frozen manifest.
+func TestCreateAgentSummary_OmittedRequestIDKeepsLegacyCitationRecompute(t *testing.T) {
+	db := setupAgentSummaryTestDB(t)
+	if err := db.AutoMigrate(
+		&model.AgentSummaryRun{},
+		&model.AgentSummarySpec{},
+		&model.AgentEvidenceArtifact{},
+		&model.AgentCitationManifest{},
+	); err != nil {
+		t.Fatalf("migrate V2 tables: %v", err)
+	}
+	seedV2Scenario(t, db)
+	t.Setenv("AGENT_SUMMARY_V2_MODE", "on")
+
+	draft := model.AgentMessage{
+		UserID:    "test-user",
+		SessionID: "session-1",
+		Role:      "assistant",
+		Content:   "Charlie said [3]",
+		RunID:     "run-v2-1",
+	}
+	if err := db.Create(&draft).Error; err != nil {
+		t.Fatalf("seed assistant draft: %v", err)
+	}
+
+	h := NewAgentSummaryHandler(db, nil, "", "", "", 0, 0)
+	w := doAgentSave(t, setupAgentSummaryRouter(h), map[string]interface{}{
+		"session_id":          draft.SessionID,
+		"origin_channel_id":   "channel-1",
+		"origin_channel_type": 1,
+		"agent_message_id":    draft.ID,
+		"snapshot_version":    1,
+	}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("save status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Data struct {
+			FinishStatus string `json:"finish_status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode save response: %v", err)
+	}
+	if response.Data.FinishStatus != string(finishgate.Partial) {
+		t.Fatalf("finish_status = %q, want derived request_id to finalize as PARTIAL", response.Data.FinishStatus)
+	}
+
+	var saved model.PersonalResult
+	if err := db.First(&saved).Error; err != nil {
+		t.Fatalf("load saved deliverable: %v", err)
+	}
+	citations := saved.GetCitations()
+	if len(citations) != 1 {
+		t.Fatalf("saved citations = %d, want recomputed Charlie citation", len(citations))
+	}
+	if citations[0].Index != 3 || citations[0].Sender != "Charlie" {
+		t.Fatalf("saved citation = %+v, want recomputed [3]=Charlie", citations[0])
+	}
+}

--- a/internal/api/handler/agent_summary_save.go
+++ b/internal/api/handler/agent_summary_save.go
@@ -33,6 +33,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 
 	"gorm.io/gorm"
@@ -44,6 +45,11 @@ import (
 // the existing binding to decide replay vs mismatch (parallels
 // errBotIdempotencyConflict in bot_summary_create.go).
 var errAgentSaveIdempotencyConflict = errors.New("agent save idempotency conflict")
+
+// errAgentMessageRunMismatch is returned only after the message itself has
+// passed the owner/session/role checks. It therefore means the selected draft's
+// persisted run binding is stale or conflicts with the caller's request_id.
+var errAgentMessageRunMismatch = errors.New("agent message does not match summary run")
 
 // Reuse the bot handler's Idempotency-Key regex + length cap so the two
 // user-facing endpoints share one canonical validation rule. Declared here as
@@ -103,6 +109,30 @@ func loadAgentMessageForSave(db *gorm.DB, sessionID, userID string, messageID in
 		return model.AgentMessage{}, err
 	}
 	return msg, nil
+}
+
+// resolveAgentMessageRequestID makes the server-persisted message→run binding
+// authoritative before any deliverable rows are written. New messages can
+// derive a missing request_id and reject an explicit mismatch; legacy messages
+// (RunID empty) preserve the previous request_id-based behaviour.
+func resolveAgentMessageRequestID(ctx context.Context, db *gorm.DB, userID, sessionID, requestID string, msg model.AgentMessage) (string, error) {
+	if msg.RunID == "" {
+		return requestID, nil
+	}
+	run, err := summaryrun.NewStore(db).GetByID(ctx, userID, msg.RunID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", fmt.Errorf("%w: bound run not found", errAgentMessageRunMismatch)
+		}
+		return "", err
+	}
+	if run.SessionID != sessionID {
+		return "", fmt.Errorf("%w: session differs", errAgentMessageRunMismatch)
+	}
+	if requestID != "" && requestID != run.RequestID {
+		return "", fmt.Errorf("%w: request differs", errAgentMessageRunMismatch)
+	}
+	return run.RequestID, nil
 }
 
 // canonicalAgentSaveRequestHash returns a deterministic sha256 fingerprint of

--- a/internal/db/migrations_parse_test.go
+++ b/internal/db/migrations_parse_test.go
@@ -37,3 +37,25 @@ func TestSummarySourceUniqueMigrationPinsBinaryCollationBeforeDedup(t *testing.T
 		t.Fatalf("dedup join must use byte-exact, NO PAD utf8mb4_0900_bin comparison")
 	}
 }
+
+func TestOutputTruncationMigrationBindsRunAndMessage(t *testing.T) {
+	runRaw, err := migrationsql.FS.ReadFile("20260822-01-add-run-output-truncated.sql")
+	if err != nil {
+		t.Fatalf("read run migration: %v", err)
+	}
+	if !strings.Contains(string(runRaw), "ALTER TABLE `agent_summary_run`") ||
+		!strings.Contains(string(runRaw), "ADD COLUMN `output_truncated`") {
+		t.Fatal("run migration must add agent_summary_run.output_truncated")
+	}
+
+	messageRaw, err := migrationsql.FS.ReadFile("20260824-01-bind-output-truncation-to-agent-message.sql")
+	if err != nil {
+		t.Fatalf("read message migration: %v", err)
+	}
+	messageSQL := string(messageRaw)
+	if !strings.Contains(messageSQL, "ALTER TABLE `agent_message`") ||
+		!strings.Contains(messageSQL, "ADD COLUMN `run_id`") ||
+		!strings.Contains(messageSQL, "ADD COLUMN `output_truncated`") {
+		t.Fatal("message migration must bind run_id and output_truncated to agent_message")
+	}
+}

--- a/internal/model/agent_message.go
+++ b/internal/model/agent_message.go
@@ -11,15 +11,20 @@ import "time"
 //   - 不同用户偶然使用相同 session_id 字面值是允许的——查询按 (user_id, session_id) 过滤，
 //     各自看到自己的历史；handler 层 owner check 是安全兜底。
 type AgentMessage struct {
-	ID         int64     `gorm:"primaryKey;autoIncrement" json:"id"`
-	SessionID  string    `gorm:"column:session_id;type:varchar(128);not null" json:"session_id"`
-	UserID     string    `gorm:"column:user_id;type:varchar(64);not null;index:idx_user_session_created,priority:1" json:"user_id"`
-	Role       string    `gorm:"column:role;type:varchar(16);not null" json:"role"`
-	Content    string    `gorm:"column:content;type:mediumtext" json:"content"`
-	ToolCalls  *string   `gorm:"column:tool_calls;type:json" json:"tool_calls"`
-	ToolCallID string    `gorm:"column:tool_call_id;type:varchar(128)" json:"tool_call_id"`
-	Name       string    `gorm:"column:name;type:varchar(128)" json:"name"`
-	CreatedAt  time.Time `gorm:"column:created_at;not null" json:"created_at"`
+	ID         int64   `gorm:"primaryKey;autoIncrement" json:"id"`
+	SessionID  string  `gorm:"column:session_id;type:varchar(128);not null" json:"session_id"`
+	UserID     string  `gorm:"column:user_id;type:varchar(64);not null;index:idx_user_session_created,priority:1" json:"user_id"`
+	Role       string  `gorm:"column:role;type:varchar(16);not null" json:"role"`
+	Content    string  `gorm:"column:content;type:mediumtext" json:"content"`
+	ToolCalls  *string `gorm:"column:tool_calls;type:json" json:"tool_calls"`
+	ToolCallID string  `gorm:"column:tool_call_id;type:varchar(128)" json:"tool_call_id"`
+	Name       string  `gorm:"column:name;type:varchar(128)" json:"name"`
+	// RunID and OutputTruncated bind generation-quality evidence to the exact
+	// assistant deliverable selected by the save endpoint. Legacy rows have an
+	// empty RunID and fall back to the run-level aggregate.
+	RunID           string    `gorm:"column:run_id;type:varchar(64);not null;default:''" json:"-"`
+	OutputTruncated bool      `gorm:"column:output_truncated;not null;default:false" json:"-"`
+	CreatedAt       time.Time `gorm:"column:created_at;not null" json:"created_at"`
 }
 
 func (AgentMessage) TableName() string { return "agent_message" }

--- a/internal/model/agent_summary_run.go
+++ b/internal/model/agent_summary_run.go
@@ -68,7 +68,20 @@ type AgentSummaryRun struct {
 	SucceededChannels string `gorm:"column:succeeded_channels;type:json" json:"succeeded_channels"`
 	FailedChannels    string `gorm:"column:failed_channels;type:json" json:"failed_channels"`
 	CoverageTruncated bool   `gorm:"column:coverage_truncated;not null;default:false" json:"coverage_truncated"`
-	DroppedMessages   int    `gorm:"column:dropped_messages;not null;default:0" json:"dropped_messages"`
+
+	// OutputTruncated records that a model completion on this run's ANSWER path
+	// hit finish_reason=length. Distinct from CoverageTruncated, which is about
+	// the fetched message pool: this one says the text we produced is unfinished,
+	// not that the input was clipped. The finish gate maps them to different gap
+	// kinds because the remediation differs (lower detail level vs narrower
+	// range).
+	//
+	// Persisted rather than passed in-process because the fact is produced deep
+	// inside a tool handler / the planner loop while the gate runs later, in the
+	// save path — and, critically, because a persisted fact cannot be edited away
+	// by the model that generated the text.
+	OutputTruncated bool `gorm:"column:output_truncated;not null;default:false" json:"output_truncated"`
+	DroppedMessages int  `gorm:"column:dropped_messages;not null;default:0" json:"dropped_messages"`
 
 	// FetchExpected records whether this turn was supposed to gather data at all.
 	// A confident rewrite (SS-08b) has the fetch tools physically removed, so it

--- a/internal/model/agent_summary_run.go
+++ b/internal/model/agent_summary_run.go
@@ -76,10 +76,10 @@ type AgentSummaryRun struct {
 	// kinds because the remediation differs (lower detail level vs narrower
 	// range).
 	//
-	// Persisted rather than passed in-process because the fact is produced deep
-	// inside a tool handler / the planner loop while the gate runs later, in the
-	// save path — and, critically, because a persisted fact cannot be edited away
-	// by the model that generated the text.
+	// This run-level value is a conservative aggregate across replay attempts and
+	// the compatibility fallback for legacy agent_message rows. New assistant
+	// messages also persist their attempt-local value, which is authoritative for
+	// the exact deliverable selected by the save path.
 	OutputTruncated bool `gorm:"column:output_truncated;not null;default:false" json:"output_truncated"`
 	DroppedMessages int  `gorm:"column:dropped_messages;not null;default:0" json:"dropped_messages"`
 

--- a/migrations/sql/20260822-01-add-run-output-truncated.sql
+++ b/migrations/sql/20260822-01-add-run-output-truncated.sql
@@ -1,0 +1,34 @@
+-- +migrate Up
+-- Truncation disclosure (stacked on PR #208): record that the MODEL'S OWN
+-- OUTPUT hit its token ceiling, on the run row.
+--
+-- Why a NEW file rather than an edit to 20260820-01: sql-migrate keys applied
+-- migrations by FILE NAME in `gorp_migrations` and does no checksum comparison
+-- (internal/db/migrate.go uses EmbedFileSystemMigrationSource). 20260820-01 has
+-- shipped, so any environment that has started summary-api since then already
+-- recorded that id and will skip the file forever -- a column added inside it
+-- would never exist in a deployed DB while the model struct lists it, giving
+-- Error 1054 on every run INSERT. Migrations are immutable once merged.
+--
+-- Why NOT reuse `coverage_truncated`: that column means "the fetched message
+-- pool was clipped" (we did not READ everything). This one means "the generated
+-- text stopped mid-sentence" (we read everything but could not WRITE it all).
+-- The remediation is opposite -- narrow the time range vs lower the detail
+-- level -- and raising the fetch cap on an output-truncated run makes it worse.
+-- They can co-occur, so one boolean would necessarily misreport a case.
+--
+-- TINYINT NOT NULL DEFAULT 0 (an INT default is legal on a non-empty table, so
+-- there is no reason to accept the nullable form the JSON columns needed).
+-- Defaulting to 0 is the safe direction here, unlike fetch_expected: it means
+-- legacy rows disclose nothing extra rather than every legacy row disclosing a
+-- truncation that never happened.
+--
+-- Serialized by the existing GET_LOCK('smart_summary_migration') in
+-- internal/db/migrate.go.
+
+ALTER TABLE `agent_summary_run`
+    ADD COLUMN `output_truncated` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'a model completion on the answer path hit finish_reason=length; the deliverable is unfinished';
+
+-- +migrate Down
+ALTER TABLE `agent_summary_run`
+    DROP COLUMN `output_truncated`;

--- a/migrations/sql/20260824-01-bind-output-truncation-to-agent-message.sql
+++ b/migrations/sql/20260824-01-bind-output-truncation-to-agent-message.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+-- Bind output-truncation evidence to the exact persisted assistant message.
+-- A single agent_summary_run can be reused by multiple HTTP replay attempts;
+-- its run-level latch cannot identify which attempt produced the message later
+-- selected for save. Storing the run id and flag on agent_message makes that
+-- association explicit and prevents both stale false-PARTIAL and unsafe
+-- false-COMPLETE verdicts.
+--
+-- Empty run_id is the rolling-upgrade marker for legacy rows. The save path
+-- falls back to agent_summary_run.output_truncated only for those rows. New V2
+-- assistant messages always carry run_id plus their attempt-local flag.
+
+ALTER TABLE `agent_message`
+    ADD COLUMN `run_id` VARCHAR(64) NOT NULL DEFAULT '' COMMENT 'agent_summary_run that produced this message; empty for legacy rows',
+    ADD COLUMN `output_truncated` TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'this assistant deliverable inherited or directly hit finish_reason=length';
+
+-- +migrate Down
+ALTER TABLE `agent_message`
+    DROP COLUMN `output_truncated`,
+    DROP COLUMN `run_id`;


### PR DESCRIPTION
> [!IMPORTANT]
> #208 is merged. This branch is rebased onto `main@a2277111`. Review these six PR commits: `45f4088`, `801b425`, `0b75fe7`, `442aea6`, `1c74bbe`, and `821380c`.

## What

Makes LLM output truncation a structural fact that the generating model cannot edit away, while binding the verdict to the exact assistant message saved as the deliverable.

- Adds the conservative `agent_summary_run.output_truncated` latch and migration `20260822-01`.
- Adds `agent_message.run_id` + `agent_message.output_truncated` and migration `20260824-01`.
- Tracks truncation independently inside each `Runner.RunWithHistory` call and persists it with the final assistant message.
- Records non-empty `finish_reason=length` output from delivered planner answers and terminal Reduce output.
- Carries the selected message's flag through `RunState` into `finishgate` as its own `output_truncation` gap; legacy rows fall back to the run-level latch.
- Validates the selected message→run binding before the save transaction. A missing save `request_id` is derived from the persisted run; an explicit mismatch returns `40901` without creating a task or deleting the draft.
- Keeps input-pool truncation and output truncation separate because their remediation differs and both may occur in one run.

## Replay safety

The prior replay-entry reset was removed. The run-level flag is now monotonic and conservative; the message row is the attempt identity because content and its truncation flag are committed together.

- Attempt A persisted truncated → attempt B fails: save still selects A and returns `PARTIAL` with `output_truncation`.
- Attempt A latched the run but persisted no message → clean attempt B: B's message-level `false` overrides the stale run aggregate and can return `COMPLETE`.
- A late run-level write cannot overwrite the flag stored with B's message.
- A same-run replay that reads a previously persisted truncated answer conservatively carries that taint forward; another run cannot contaminate it.

## Safety boundaries

- Map / `summarize_chunk` truncation remains a hard rejection; it is never downgraded into a partial result.
- A planner draft rejected by the pending Map/Reduce gate is not recorded as delivered truncation.
- Runner bookkeeping uses a dedicated owner context key; tool authorization remains confined to the existing profile-specific wrapper.
- The worker pipeline is intentionally unchanged because it does not own `agent_summary_run` rows or pass through this finish gate.

## Validation

- `CGO_ENABLED=0 go test ./...` ✅
- `CGO_ENABLED=1 CGO_LDFLAGS=-L/home/mlamp/.local/lib go test -race -shuffle=on -count=1 -timeout 10m ./...` ✅
- `CGO_ENABLED=1 CGO_LDFLAGS=-L/home/mlamp/.local/lib go vet ./...` ✅
- `git diff --check` ✅
- Handler-level regression covers the exact CR path: A is persisted truncated, B replays and fails, then the real save API persists A and returns `PARTIAL`.
- Additional tests cover clean replay after an abandoned attempt, message/run mismatch rejection before mutation, owner isolation, same-run history propagation, DB mapping, and migration presence.

## Merge status

The base dependency #208 is merged. Sprint metadata is intentionally left for merge time.
