### PR TITLE
feat(agent): add gated per-request latency trace

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -39,6 +39,7 @@ All configuration is done via environment variables.
 | `MAX_MESSAGES_PER_PARTICIPANT` | Max messages per participant in map phase | No | `5000` |
 | `MAX_MESSAGES_PER_CHANNEL` | Max messages per channel (-1 = no limit) | No | `-1` |
 | `MAP_MAX_TOKENS` | Override map-phase token budget (0 = auto) | No | `0` |
+| `AGENT_TRACE` | Emit a per-request agent latency trace (`[agent-trace]` log lines): total wall clock split into planning / tools / unaccounted, per-step planner latency and prompt size, and slowest tool spans. Roughly a few dozen lines per request, so it is off by default and intended for diagnosing a specific slow request. Logs sizes, counts, durations, step numbers and registered tool names only — never message content, prompt text, tool arguments, or user/channel names. | No | `false` |
 | `CHARS_PER_TOKEN_CJK` | Characters per token for CJK text | No | `1` |
 | `CHARS_PER_TOKEN_ASCII` | Characters per token for ASCII text | No | `4` |
 | `SUMMARY_CHAT_CANDIDATE_LIMIT` | Candidate query limit (-1 = no limit) | No | `-1` |

--- a/internal/agent/llm.go
+++ b/internal/agent/llm.go
@@ -70,7 +70,8 @@ type chatResponse struct {
 		} `json:"message"`
 	} `json:"choices"`
 	Usage struct {
-		TotalTokens int `json:"total_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
 }
 
@@ -169,8 +170,9 @@ func (c *Client) attemptChat(ctx context.Context, model string, msgs []Message, 
 	}
 	msg := cr.Choices[0].Message
 	return AssistantTurn{
-		Content:   msg.Content,
-		ToolCalls: msg.ToolCalls,
-		Tokens:    cr.Usage.TotalTokens,
+		Content:          msg.Content,
+		ToolCalls:        msg.ToolCalls,
+		Tokens:           cr.Usage.TotalTokens,
+		CompletionTokens: cr.Usage.CompletionTokens,
 	}, llmfallback.Success, nil
 }

--- a/internal/agent/llm_fallback_test.go
+++ b/internal/agent/llm_fallback_test.go
@@ -52,6 +52,27 @@ func newFallbackTestServer(t *testing.T, primaryModel string, primaryFailStatus 
 	}))
 }
 
+func TestChatSeparatesTotalAndCompletionTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"choices":[{"message":{"content":"done","tool_calls":null}}],"usage":{"prompt_tokens":90,"completion_tokens":7,"total_tokens":97}}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-key", "primary", 5, 512, nil)
+	c.http = &http.Client{Timeout: 2 * time.Second}
+	turn, err := c.Chat(context.Background(), []Message{{Role: "user", Content: "hi"}}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if turn.Tokens != 97 {
+		t.Fatalf("Tokens = %d, want total_tokens 97", turn.Tokens)
+	}
+	if turn.CompletionTokens != 7 {
+		t.Fatalf("CompletionTokens = %d, want completion_tokens 7", turn.CompletionTokens)
+	}
+}
+
 func TestChat_FailoverToFallbackAfterRetriesExhausted(t *testing.T) {
 	primary := "gpt-5.6-sol"
 	fallback := "claude-sonnet-4-6"

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -41,6 +41,16 @@ func (r *Registry) Schemas() []Tool {
 	return out
 }
 
+// Has reports whether name belongs to the registered tool vocabulary. Trace
+// logging uses this guard so a model-hallucinated tool name derived from user
+// input never reaches logs as if it were trusted metadata.
+func (r *Registry) Has(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.tools[name]
+	return ok
+}
+
 // Dispatch 按名分发。未知工具/handler panic 都转成错误返回，绝不中断回环。
 func (r *Registry) Dispatch(ctx context.Context, name string, args json.RawMessage) (result string, err error) {
 	r.mu.RLock()

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -145,7 +145,7 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		turn, err := r.client.Chat(stepCtx, msgs, r.reg.Schemas())
 		planMs := time.Since(planStart).Milliseconds()
 		cancel()
-		trace.AddStep(step+1, planMs, promptChars, promptMsgs, turnTokens(turn, err))
+		trace.AddStep(step+1, planMs, promptChars, promptMsgs, turnCompletionTokens(turn, err))
 		if err != nil {
 			return "", nil, err
 		}
@@ -371,12 +371,12 @@ func extractToolCount(toolName, result string, idx, total int) int {
 	return 0
 }
 
-// turnTokens reports a turn's completion tokens, tolerating the error path
+// turnCompletionTokens reports a turn's completion tokens, tolerating the error path
 // (a failed turn has no usable token count, but its latency still matters and
 // the step is still recorded).
-func turnTokens(turn AssistantTurn, err error) int {
+func turnCompletionTokens(turn AssistantTurn, err error) int {
 	if err != nil {
 		return 0
 	}
-	return turn.Tokens
+	return turn.CompletionTokens
 }

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -131,8 +131,21 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		// ever needed, wrap it inside the tool handler itself — do NOT
 		// re-widen stepCtx here.
 		stepCtx, cancel := context.WithTimeout(ctx, r.policy.StepTimeout)
+		// Measure the planner turn and the size of what it was handed. The
+		// message list grows by every tool result, so a late hop can spend
+		// more wall clock re-reading accumulated output than the tools took
+		// to produce it; without both numbers that cost is invisible. The
+		// measurement itself is skipped when tracing is off.
+		trace := TraceFromContext(ctx)
+		var promptChars, promptMsgs int
+		if trace.Active() {
+			promptChars, promptMsgs = measurePrompt(msgs)
+		}
+		planStart := time.Now()
 		turn, err := r.client.Chat(stepCtx, msgs, r.reg.Schemas())
+		planMs := time.Since(planStart).Milliseconds()
 		cancel()
+		trace.AddStep(step+1, planMs, promptChars, promptMsgs, turnTokens(turn, err))
 		if err != nil {
 			return "", nil, err
 		}
@@ -193,7 +206,17 @@ func (r *Runner) RunWithHistory(ctx context.Context, system string, history []Me
 		// See the stepCtx setup comment above for why: LLM-backed tools like
 		// summarize_chunk run their own sequential LLM calls that legitimately
 		// exceed the 60s per-step planning budget.
+		toolsStart := time.Now()
 		results := r.runTools(ctx, turn.ToolCalls, step+1, r.policy.MaxSteps)
+		if trace.Active() {
+			toolNames := make([]string, 0, len(turn.ToolCalls))
+			for _, tc := range turn.ToolCalls {
+				if r.reg.Has(tc.Function.Name) {
+					toolNames = append(toolNames, tc.Function.Name)
+				}
+			}
+			trace.CloseStep(step+1, time.Since(toolsStart).Milliseconds(), toolNames)
+		}
 		for i, tc := range turn.ToolCalls {
 			toolMsg := Message{
 				Role:       "tool",
@@ -252,6 +275,11 @@ func (r *Runner) runTools(ctx context.Context, calls []ToolCall, step, ofSteps i
 			out, err := r.reg.Dispatch(ctx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
 
 			toolElapsed := time.Since(toolStart).Milliseconds()
+			// Tools in a hop run concurrently, so the hop's wall clock is set
+			// by the slowest one; record each so the straggler can be named.
+			if trace := TraceFromContext(ctx); trace.Active() && r.reg.Has(tc.Function.Name) {
+				trace.AddTool(tc.Function.Name, toolElapsed)
+			}
 
 			// Extract a cheap, safe integer count from the tool result (0 = none).
 			count := extractToolCount(tc.Function.Name, out, i, len(calls))
@@ -341,4 +369,14 @@ func extractToolCount(toolName, result string, idx, total int) int {
 	}
 
 	return 0
+}
+
+// turnTokens reports a turn's completion tokens, tolerating the error path
+// (a failed turn has no usable token count, but its latency still matters and
+// the step is still recorded).
+func turnTokens(turn AssistantTurn, err error) int {
+	if err != nil {
+		return 0
+	}
+	return turn.Tokens
 }

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -116,8 +116,8 @@ func TestRunner_Run(t *testing.T) {
 		{
 			name: "token budget injects wrap-up",
 			turns: []AssistantTurn{
-				{ToolCalls: []ToolCall{mkToolCall("c1", "alpha", `{}`)}, Tokens: 999},
-				{Content: "wrapped", Tokens: 1},
+				{ToolCalls: []ToolCall{mkToolCall("c1", "alpha", `{}`)}, Tokens: 999, CompletionTokens: 1},
+				{Content: "wrapped", Tokens: 1, CompletionTokens: 1},
 			},
 			reg:     regWithEcho("alpha"),
 			policy:  Policy{MaxSteps: 5, MaxTokens: 500, StepTimeout: time.Second},

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
@@ -370,6 +371,7 @@ func SummarizeChunkTool() (Tool, Handler) {
 		// off / no run / no spec → legacy generic prompt.
 		specGuidance := loadRunSpecGuidance(ctx)
 		var summaries []string
+		mapStart := time.Now()
 		for _, chunk := range chunks {
 			summary, processed, oversized, err := summarizeMessagesChunk(ctx, chunk, specGuidance)
 			if err != nil {
@@ -379,6 +381,11 @@ func SummarizeChunkTool() (Tool, Handler) {
 			cov.ProcessedCount += processed
 			cov.OversizedMessageCount += oversized
 		}
+		// summarize_chunk is itself an LLM pipeline, so its own cost needs a
+		// breakdown in the run trace — otherwise it shows up as one opaque
+		// tool span and a slow Map is indistinguishable from a slow planner.
+		TraceFromContext(ctx).AddSubPhase(fmt.Sprintf("map(%dchunks)", len(chunks)),
+			time.Since(mapStart).Milliseconds())
 		cov.DroppedCount = cov.InputCount - cov.ProcessedCount
 		cov.Truncated = cov.DroppedCount > 0
 		recordDroppedMessages(ctx, uid, runID, cov.DroppedCount)

--- a/internal/agent/trace.go
+++ b/internal/agent/trace.go
@@ -1,0 +1,276 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Per-request latency instrumentation for the agent path.
+//
+// Why this exists: the worker path has had structured stage timing for a long
+// time (internal/timing, ~26 call sites in personal_processor.go); the agent
+// path had none. Diagnosing a slow agent summary meant hand-correlating
+// "[llm] calling" log lines by wall-clock timestamp, which cannot separate a
+// planning turn from tool execution and cannot see how large a prompt the
+// planner was handed. This instrumentation makes prompt-growth and tool
+// stragglers measurable without logging prompt or message content.
+//
+// The trace is deliberately NOT internal/timing: that package writes per-task
+// report files keyed by task_no, which an interactive chat turn does not have.
+// This is an in-memory, per-request accumulator that emits one structured log
+// block at the end of the run.
+//
+// PRIVACY: this file must never log message content, prompt text, tool
+// arguments, user names, or channel names. Sizes, counts, durations, step
+// numbers, tool names and the session id only. The session id is an opaque
+// identifier already logged by the citation and handler paths; everything
+// else here is a number. Adding a field that carries content is a privacy
+// regression, not a debugging improvement.
+//
+// Everything is best-effort: a nil trace (tracing off, or no trace in
+// context) makes every method a no-op, so instrumentation never changes
+// control flow and costs nothing when disabled.
+
+// TraceEnvVar gates the trace. Off by default.
+//
+// Gated for cost, not secrecy: a run emits one line per planner step plus
+// three summary lines — a few dozen lines for a large summary — which is
+// useful when diagnosing one request and noise when multiplied by production
+// traffic. Read straight from the environment rather than through
+// config.Config, following agentStepTimeoutOverride's precedent in
+// profile.go: tracing must work in unit tests that build a runner without
+// initializing the whole deps container.
+const TraceEnvVar = "AGENT_TRACE"
+
+// TraceEnabled reports whether per-request agent tracing is on.
+// Accepts the standard strconv.ParseBool spellings (1/t/true/T/TRUE...).
+func TraceEnabled() bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(TraceEnvVar)))
+	return err == nil && enabled
+}
+
+// stepSpan records one planner turn plus the tool hop it triggered.
+type stepSpan struct {
+	Step int
+	// PlanningMs is the planner LLM round-trip.
+	PlanningMs int64
+	// PromptChars is the size of the message list handed to the planner. This
+	// is the number that explains a slow planning turn: tool results are
+	// appended to the list every hop, so hop N pays for every result from
+	// hops 1..N-1. It is a LENGTH, never the text.
+	PromptChars int
+	// PromptMsgs is how many messages were in that list.
+	PromptMsgs int
+	// OutTokens is the turn's reported completion tokens.
+	OutTokens int
+	// ToolsMs is the wall-clock of the tool hop (0 when the turn was the
+	// final answer).
+	ToolsMs int64
+	// Tools names the tools called in the hop, in dispatch order. Tool names
+	// are a fixed vocabulary from the registry, not user input.
+	Tools []string
+}
+
+// toolSpan is one named span with a duration.
+type toolSpan struct {
+	Name string
+	Ms   int64
+}
+
+// RunTrace accumulates one agent run's phase timings.
+//
+// Tool spans are recorded from the runner's worker pool, so the mutex is not
+// optional; step spans are appended from the single runner goroutine but
+// share the same lock for simplicity.
+type RunTrace struct {
+	mu        sync.Mutex
+	start     time.Time
+	sessionID string
+	steps     []stepSpan
+	tools     []toolSpan
+	// subPhases holds named sub-timings reported by tools themselves (e.g.
+	// the Map phase inside summarize_chunk), so a tool that is itself an LLM
+	// pipeline can explain its own cost instead of appearing as one opaque
+	// span.
+	subPhases []toolSpan
+}
+
+type contextKeyTrace struct{}
+
+// ContextKeyTrace carries the *RunTrace for the in-flight request.
+var ContextKeyTrace = contextKeyTrace{}
+
+// StartTrace attaches a fresh RunTrace to ctx when tracing is enabled.
+//
+// When disabled it returns ctx unchanged and a nil *RunTrace. Every method is
+// nil-safe, so callers never branch on the flag: the off path allocates
+// nothing and logs nothing.
+func StartTrace(ctx context.Context, sessionID string) (context.Context, *RunTrace) {
+	if !TraceEnabled() {
+		return ctx, nil
+	}
+	t := &RunTrace{start: time.Now(), sessionID: sessionID}
+	return context.WithValue(ctx, ContextKeyTrace, t), t
+}
+
+// TraceFromContext returns the request's trace, or nil when untraced.
+// Callers must tolerate nil; every RunTrace method is nil-safe.
+func TraceFromContext(ctx context.Context) *RunTrace {
+	if ctx == nil {
+		return nil
+	}
+	t, _ := ctx.Value(ContextKeyTrace).(*RunTrace)
+	return t
+}
+
+// Active reports whether this trace will record anything. Call sites use it
+// to skip the measurement work itself (not just the recording) when tracing
+// is off.
+func (t *RunTrace) Active() bool { return t != nil }
+
+// AddStep records a planner turn. promptChars/promptMsgs describe the message
+// list the planner was given, which is the input side of the cost.
+func (t *RunTrace) AddStep(step int, planningMs int64, promptChars, promptMsgs, outTokens int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.steps = append(t.steps, stepSpan{
+		Step:        step,
+		PlanningMs:  planningMs,
+		PromptChars: promptChars,
+		PromptMsgs:  promptMsgs,
+		OutTokens:   outTokens,
+	})
+}
+
+// CloseStep attaches the tool-hop wall clock to the most recent step.
+func (t *RunTrace) CloseStep(step int, toolsMs int64, tools []string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := len(t.steps) - 1; i >= 0; i-- {
+		if t.steps[i].Step == step {
+			t.steps[i].ToolsMs = toolsMs
+			t.steps[i].Tools = tools
+			return
+		}
+	}
+}
+
+// AddTool records one tool invocation. Safe to call concurrently.
+func (t *RunTrace) AddTool(name string, ms int64) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tools = append(t.tools, toolSpan{Name: name, Ms: ms})
+}
+
+// AddSubPhase records a named sub-timing inside a tool (e.g. "map").
+func (t *RunTrace) AddSubPhase(name string, ms int64) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.subPhases = append(t.subPhases, toolSpan{Name: name, Ms: ms})
+}
+
+// Report emits one structured line per run plus a per-step breakdown.
+//
+// The headline splits total wall clock three ways — planning / tools /
+// unaccounted — because that split is the actual diagnostic question: a run
+// dominated by planning needs prompt-size work (fewer/smaller tool results
+// fed back), a run dominated by tools needs tool-level parallelism, and a
+// large unaccounted remainder means the cost is outside the runner entirely
+// (persistence, citation building, the handler's own finalize work).
+func (t *RunTrace) Report(outcome string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	totalMs := time.Since(t.start).Milliseconds()
+	var planMs, toolMs int64
+	var maxPrompt int
+	for _, s := range t.steps {
+		planMs += s.PlanningMs
+		toolMs += s.ToolsMs
+		if s.PromptChars > maxPrompt {
+			maxPrompt = s.PromptChars
+		}
+	}
+
+	log.Printf("[agent-trace] session=%s outcome=%s total=%dms planning=%dms(%s) tools=%dms(%s) other=%dms(%s) steps=%d max_prompt=%dchars",
+		t.sessionID, outcome, totalMs,
+		planMs, pct(planMs, totalMs),
+		toolMs, pct(toolMs, totalMs),
+		totalMs-planMs-toolMs, pct(totalMs-planMs-toolMs, totalMs),
+		len(t.steps), maxPrompt)
+
+	for _, s := range t.steps {
+		log.Printf("[agent-trace]   step=%d planning=%dms prompt=%dchars/%dmsgs out_tokens=%d tools=%dms [%s]",
+			s.Step, s.PlanningMs, s.PromptChars, s.PromptMsgs, s.OutTokens, s.ToolsMs, strings.Join(s.Tools, ","))
+	}
+
+	// Slowest tool invocations first: with concurrent tools inside a hop, the
+	// hop's wall clock is set by one straggler, and this names it. Capped at
+	// 8 so a wide fan-out cannot turn one run into hundreds of log lines.
+	if len(t.tools) > 0 {
+		tools := make([]toolSpan, len(t.tools))
+		copy(tools, t.tools)
+		sort.SliceStable(tools, func(i, j int) bool { return tools[i].Ms > tools[j].Ms })
+		var b strings.Builder
+		for i, ts := range tools {
+			if i >= 8 {
+				fmt.Fprintf(&b, " …(+%d more)", len(tools)-i)
+				break
+			}
+			fmt.Fprintf(&b, " %s=%dms", ts.Name, ts.Ms)
+		}
+		log.Printf("[agent-trace]   tools(slowest first):%s", b.String())
+	}
+
+	if len(t.subPhases) > 0 {
+		var b strings.Builder
+		for _, sp := range t.subPhases {
+			fmt.Fprintf(&b, " %s=%dms", sp.Name, sp.Ms)
+		}
+		log.Printf("[agent-trace]   sub-phases:%s", b.String())
+	}
+
+}
+
+func pct(part, total int64) string {
+	if total <= 0 {
+		return "0%"
+	}
+	return fmt.Sprintf("%d%%", part*100/total)
+}
+
+// measurePrompt returns the total content size and message count of the list
+// handed to the planner. Tool-call arguments count toward the size because
+// they are part of the serialised request even though they are not in
+// Content — but only their LENGTH is taken, never their text.
+func measurePrompt(msgs []Message) (chars, count int) {
+	for _, m := range msgs {
+		chars += len(m.Content)
+		for _, tc := range m.ToolCalls {
+			chars += len(tc.Function.Arguments)
+		}
+	}
+	return chars, len(msgs)
+}

--- a/internal/agent/trace_test.go
+++ b/internal/agent/trace_test.go
@@ -107,6 +107,30 @@ func TestTraceReportsPhaseSplit(t *testing.T) {
 	}
 }
 
+func TestRunnerTraceReportsCompletionTokens(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	client := &fakeClient{turns: []AssistantTurn{{
+		Content:          "done",
+		Tokens:           321,
+		CompletionTokens: 17,
+	}}}
+	runner := NewRunner(client, NewRegistry(), NewPool(1), Policy{
+		MaxSteps: 1, MaxTokens: 1000, StepTimeout: time.Second,
+	})
+	ctx, tr := StartTrace(context.Background(), "sess-completion-tokens")
+	if _, _, err := runner.RunWithHistory(ctx, "system", nil, "hello"); err != nil {
+		t.Fatalf("RunWithHistory: %v", err)
+	}
+
+	out := captureLog(t, func() { tr.Report("ok") })
+	if !strings.Contains(out, "out_tokens=17") {
+		t.Fatalf("trace did not report completion_tokens:\n%s", out)
+	}
+	if strings.Contains(out, "out_tokens=321") {
+		t.Fatalf("trace mislabeled total_tokens as output tokens:\n%s", out)
+	}
+}
+
 // Hard privacy line: the trace records sizes, counts, durations, step names
 // and tool names — never content. This test feeds distinctive content into
 // every field that could plausibly leak and asserts none of it reaches the log.

--- a/internal/agent/trace_test.go
+++ b/internal/agent/trace_test.go
@@ -1,0 +1,226 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	old := log.Writer()
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(old)
+		log.SetFlags(flags)
+	})
+	fn()
+	return buf.String()
+}
+
+func TestTraceDisabledByDefault(t *testing.T) {
+	t.Setenv(TraceEnvVar, "")
+	if TraceEnabled() {
+		t.Fatal("tracing must be off by default")
+	}
+	ctx, tr := StartTrace(context.Background(), "sess-1")
+	if tr != nil {
+		t.Fatal("StartTrace returned a trace while disabled")
+	}
+	if TraceFromContext(ctx) != nil {
+		t.Fatal("a disabled trace must not be attached to ctx")
+	}
+	// Every method must be a safe no-op on the nil trace.
+	out := captureLog(t, func() {
+		tr.AddStep(1, 10, 100, 2, 3)
+		tr.CloseStep(1, 5, []string{"fetch_channel"})
+		tr.AddTool("fetch_channel", 5)
+		tr.AddSubPhase("map", 5)
+		tr.Report("ok")
+	})
+	if out != "" {
+		t.Fatalf("disabled trace logged %q", out)
+	}
+	if tr.Active() {
+		t.Fatal("nil trace reported Active")
+	}
+}
+
+func TestTraceEnabledSpellings(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "t"} {
+		t.Setenv(TraceEnvVar, v)
+		if !TraceEnabled() {
+			t.Errorf("TraceEnabled() = false for %q", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "nope", "  "} {
+		t.Setenv(TraceEnvVar, v)
+		if TraceEnabled() {
+			t.Errorf("TraceEnabled() = true for %q", v)
+		}
+	}
+}
+
+func TestTraceReportsPhaseSplit(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	ctx, tr := StartTrace(context.Background(), "sess-abc")
+	if tr == nil {
+		t.Fatal("StartTrace returned nil while enabled")
+	}
+	if TraceFromContext(ctx) != tr {
+		t.Fatal("trace not retrievable from ctx")
+	}
+
+	tr.AddStep(1, 120, 4096, 3, 40)
+	tr.CloseStep(1, 300, []string{"fetch_channel", "peek_channel"})
+	tr.AddStep(2, 90, 99336, 9, 55)
+	tr.AddTool("fetch_channel", 250)
+	tr.AddTool("peek_channel", 40)
+	tr.AddSubPhase("map(4chunks)", 210)
+
+	out := captureLog(t, func() { tr.Report("ok") })
+
+	for _, want := range []string{
+		"[agent-trace] session=sess-abc",
+		"outcome=ok",
+		"steps=2",
+		"max_prompt=99336chars",
+		"step=1 planning=120ms prompt=4096chars/3msgs",
+		"fetch_channel,peek_channel",
+		"step=2 planning=90ms prompt=99336chars/9msgs",
+		"tools(slowest first): fetch_channel=250ms peek_channel=40ms",
+		"sub-phases: map(4chunks)=210ms",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\ngot:\n%s", want, out)
+		}
+	}
+	// A few dozen lines per run, not hundreds.
+	if n := strings.Count(out, "\n"); n > 12 {
+		t.Errorf("report emitted %d lines; keep it small enough for production", n)
+	}
+}
+
+// Hard privacy line: the trace records sizes, counts, durations, step names
+// and tool names — never content. This test feeds distinctive content into
+// every field that could plausibly leak and asserts none of it reaches the log.
+func TestTraceNeverLogsContent(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	const (
+		secretBody = "SECRET_MESSAGE_BODY_张三的私密聊天内容"
+		secretArgs = `{"channel_id":"SECRET_CHANNEL_ID","keyword":"SECRET_KEYWORD"}`
+		secretUser = "SECRET_USER_NAME"
+	)
+
+	msgs := []Message{
+		{Role: "system", Content: "你是 Octo 智能总结 Agent " + secretUser},
+		{Role: "user", Content: secretBody},
+		{Role: "assistant", ToolCalls: []ToolCall{toolCallFixture("call_1", "search_messages", secretArgs)}},
+		{Role: "tool", Name: "search_messages", Content: secretBody + secretBody},
+	}
+
+	// measurePrompt must return only sizes, and those sizes must account for
+	// tool-call arguments (they are part of the serialised request).
+	chars, count := measurePrompt(msgs)
+	if count != 4 {
+		t.Fatalf("measurePrompt count = %d, want 4", count)
+	}
+	if chars <= len(secretBody) {
+		t.Fatalf("measurePrompt chars = %d, suspiciously small", chars)
+	}
+	// The tool-call arguments must be counted (they are part of the
+	// serialised request) — sizes in, text out.
+	if chars < len(secretArgs) {
+		t.Fatalf("measurePrompt chars = %d, did not account for tool-call arguments", chars)
+	}
+
+	ctx, tr := StartTrace(context.Background(), "sess-priv")
+	_ = ctx
+	tr.AddStep(1, 100, chars, count, 42)
+	tr.CloseStep(1, 200, []string{"search_messages"})
+	tr.AddTool("search_messages", 200)
+	tr.AddSubPhase("map(2chunks)", 150)
+
+	out := captureLog(t, func() { tr.Report("ok") })
+
+	for _, secret := range []string{secretBody, secretArgs, secretUser, "SECRET_CHANNEL_ID", "SECRET_KEYWORD", "私密"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("PRIVACY REGRESSION: trace log leaked %q\nlog:\n%s", secret, out)
+		}
+	}
+	// The size derived from that content is fine and must be present.
+	if !strings.Contains(out, "prompt=") {
+		t.Errorf("trace dropped the prompt size it is supposed to report:\n%s", out)
+	}
+}
+
+func TestTraceConcurrentToolSpans(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	_, tr := StartTrace(context.Background(), "sess-race")
+	done := make(chan struct{})
+	for i := 0; i < 16; i++ {
+		go func(i int) {
+			defer func() { done <- struct{}{} }()
+			tr.AddTool("fetch_channel", int64(i))
+			tr.AddSubPhase("map", int64(i))
+		}(i)
+	}
+	for i := 0; i < 16; i++ {
+		<-done
+	}
+	out := captureLog(t, func() { tr.Report("ok") })
+	if !strings.Contains(out, "tools(slowest first)") || !strings.Contains(out, "sub-phases:") {
+		t.Errorf("concurrent spans were lost:\n%s", out)
+	}
+}
+
+func TestTraceToolListIsCapped(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	_, tr := StartTrace(context.Background(), "sess-wide")
+	for i := 0; i < 40; i++ {
+		tr.AddTool("fetch_channel", int64(i))
+	}
+	out := captureLog(t, func() { tr.Report("ok") })
+	if !strings.Contains(out, "more)") {
+		t.Errorf("wide fan-out not truncated:\n%s", out)
+	}
+	if n := strings.Count(out, "fetch_channel="); n > 8 {
+		t.Errorf("logged %d tool spans, want at most 8", n)
+	}
+}
+
+func TestTraceSkipsModelHallucinatedToolNames(t *testing.T) {
+	t.Setenv(TraceEnvVar, "1")
+	const hallucinated = "SECRET_TOOL_NAME_FROM_MODEL"
+	client := &fakeClient{turns: []AssistantTurn{
+		{ToolCalls: []ToolCall{toolCallFixture("bad", hallucinated, `{}`)}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(client, NewRegistry(), NewPool(1), Policy{
+		MaxSteps: 2, MaxTokens: 1000, StepTimeout: time.Second,
+	})
+	ctx, tr := StartTrace(context.Background(), "sess-hallucinated")
+	_, _, _ = runner.RunWithHistory(ctx, "system", nil, "hello")
+
+	out := captureLog(t, func() { tr.Report("ok") })
+	if strings.Contains(out, hallucinated) {
+		t.Fatalf("trace logged an unregistered model-emitted tool name:\n%s", out)
+	}
+}
+
+// toolCallFixture builds a ToolCall; ToolCall.Function is an anonymous struct,
+// so it cannot be written as a composite literal at the call site.
+func toolCallFixture(id, name, args string) ToolCall {
+	var tc ToolCall
+	tc.ID = id
+	tc.Type = "function"
+	tc.Function.Name = name
+	tc.Function.Arguments = args
+	return tc
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -35,11 +35,12 @@ type ToolCall struct {
 	} `json:"function"`
 }
 
-// AssistantTurn 是单轮 LLM 结果的归一化视图：内容 + 全部工具调用 + 本轮消耗 token。
+// AssistantTurn 是单轮 LLM 结果的归一化视图：内容 + 全部工具调用 + 本轮 token 用量。
 type AssistantTurn struct {
-	Content   string
-	ToolCalls []ToolCall
-	Tokens    int
+	Content          string
+	ToolCalls        []ToolCall
+	Tokens           int // usage.total_tokens; retained for the runner's existing budget semantics.
+	CompletionTokens int // usage.completion_tokens; used by diagnostics that report model output size.
 }
 
 // ContextKeyUID is the context key for storing user ID in request context.

--- a/internal/api/handler/agent_chat.go
+++ b/internal/api/handler/agent_chat.go
@@ -705,8 +705,16 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 
 	history = agent.TruncateHistory(history, h.window)
 
+	// Per-request latency trace (AGENT_TRACE; no-op when off). Reported on
+	// BOTH paths: a timed-out run is exactly the one whose phase split needs
+	// explaining.
+	ctx, trace := agent.StartTrace(ctx, req.SessionID)
+	traceOutcome := "panic"
+	defer func() { trace.Report(traceOutcome) }()
+
 	reply, newMsgs, err := runner.RunWithHistory(ctx, system, history, req.Message)
 	if err != nil {
+		traceOutcome = "error"
 		// 真实错误只记服务端日志，避免向调用方泄漏上游 LLM 地址/网络/内部细节。
 		// Detail 走白名单：仅 context deadline / max steps / empty response 等
 		// 明确不含内部地址/IP/token 的 error 会被透传给客户端，其它一律为
@@ -721,6 +729,7 @@ func (h *AgentChatHandler) Chat(c *gin.Context) {
 	if err := h.store.AppendMessages(ctx, req.SessionID, uid, newMsgs); err != nil {
 		log.Printf("[agent] append messages error: %v", err)
 	}
+	traceOutcome = "ok"
 
 	respData := gin.H{
 		"reply":      reply,
@@ -1002,14 +1011,21 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 
 	history = agent.TruncateHistory(history, h.window)
 
+	// Per-request latency trace (AGENT_TRACE; no-op when off). Reported on
+	// BOTH paths: a timed-out run is exactly the one whose phase split needs
+	// explaining.
+	ctx, trace := agent.StartTrace(ctx, req.SessionID)
+	traceOutcome := "panic"
+	defer func() { trace.Report(traceOutcome) }()
+
 	// Run agent with history
 	reply, newMsgs, err := runner.RunWithHistory(ctx, system, history, req.Message)
 	if err != nil {
+		traceOutcome = "error"
 		log.Printf("[agent] chat runner error: %v", err)
 		h.writeSSEErrorViaSinkWithDetail(sink, 50000, "agent chat failed", safeErrorDetail(err))
 		return
 	}
-
 	// Persist messages on success (same as Chat). owner-scoped by uid（SUM-158 blocker 1）。
 	if err := h.store.AppendMessages(ctx, req.SessionID, uid, newMsgs); err != nil {
 		log.Printf("[agent] append messages error: %v", err)
@@ -1017,6 +1033,7 @@ func (h *AgentChatHandler) ChatStream(c *gin.Context) {
 
 	// Emit done event with final reply
 	h.writeSSEDoneViaSink(sink, reply, req.SessionID, v2RunID)
+	traceOutcome = "ok"
 }
 
 // writeSSEProgressViaSink writes a progress SSE event via the provided sink.


### PR DESCRIPTION
## Problem

The interactive agent path had no request-level phase timing. Diagnosing a slow summary required correlating unrelated log lines and could not distinguish planner latency, prompt growth, tool execution, or handler overhead.

## Change

- Add `AGENT_TRACE` (off by default).
- Record per-step planner latency, prompt character/message counts, output tokens, tool-hop wall time, slowest registered tool spans, and tool-internal sub-phases.
- Emit one bounded report at request completion.
- Report from a defer so errors and panics retain diagnostics and successful reports include history persistence / response finalization.
- Log only sizes, counts, durations, step numbers, session id, and registered tool names; never message text, prompt text, tool arguments, users, or channels.
- Skip model-hallucinated tool names that are not in the registry.
- Parse `usage.completion_tokens` separately for `out_tokens`; retain `usage.total_tokens` for the existing runner budget.

This PR is independent of the citation-cap work in #214.

## Verification

```text
CGO_LDFLAGS=-L/home/mlamp/.local/lib go test -race -count=1 -timeout 10m ./...  PASS
CGO_LDFLAGS=-L/home/mlamp/.local/lib go vet ./...                           PASS
git diff --check                                                            PASS
```

Closes #216
