### PR TITLE
feat(llm): make primary-to-fallback model switches observable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -24,9 +24,19 @@ All configuration is done via environment variables.
 | `LLM_TEMPERATURE` | Sampling temperature for LLM | No | `0.3` |
 | `LLM_ENABLE_THINKING` | Enable extended thinking mode | No | `false` |
 | `API_PORT` | Port for the public API server | No | `8080` |
-| `API_INTERNAL_PORT` | Port for the API internal server | No | `8081` |
-| `WORKER_INTERNAL_PORT` | Port for the worker internal server | No | `8082` |
-| `WORKER_LISTEN_ADDR` | Listen address for worker server | No | `0.0.0.0` |
+| `API_INTERNAL_PORT` | Port for the API internal server. **Must not be published outside the cluster/container network** — see the warning below. | No | `8081` |
+| `WORKER_INTERNAL_PORT` | Port for the worker internal server. **Must not be published outside the cluster/container network** — see the warning below. | No | `8082` |
+| `WORKER_LISTEN_ADDR` | Listen address for worker server. The default binds all interfaces; narrow it to `127.0.0.1` for a single-host deployment. | No | `0.0.0.0` |
+
+> **The internal listeners are unauthenticated.** Both `API_INTERNAL_PORT` and
+> `WORKER_INTERNAL_PORT` serve `/internal/*` with no credential check. That
+> surface includes the *mutating* `/internal/worker-trigger` and
+> `/internal/task-event`, and the read-only `/internal/metrics` scrape endpoint
+> (model identifiers and per-path failure volumes). A separate HTTP engine is
+> not an access-control boundary: restrict these ports to the cluster/container
+> network with a network policy, security group, or by binding
+> `WORKER_LISTEN_ADDR` to a private interface. Do not expose them through an
+> ingress or `docker run -p`.
 | `WORKER_MAX_CONCURRENT_TASKS` | Max concurrent worker tasks | No | `20` |
 | `WORKER_MAP_CONCURRENCY` | Concurrency for map-phase LLM calls | No | `5` |
 | `AGENT_MAP_CONCURRENCY` | How many Map-phase chunk summaries ONE `summarize_chunk` tool call runs in parallel (agent path only). Clamped to `[1, 5]`; unset/0/negative resolve to the default. Deliberately separate from `WORKER_MAP_CONCURRENCY`: the agent runner already executes up to 4 tool calls from a single LLM turn concurrently (`agent.NewPool(4)`), so the two knobs MULTIPLY — at the default the ceiling of in-flight Map completions from one user request is 4×3=12. Set to `1` to take a dedicated serial path identical to the pre-concurrency loop (rollback without redeploying). | No | `3` |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -27,16 +27,6 @@ All configuration is done via environment variables.
 | `API_INTERNAL_PORT` | Port for the API internal server. **Must not be published outside the cluster/container network** — see the warning below. | No | `8081` |
 | `WORKER_INTERNAL_PORT` | Port for the worker internal server. **Must not be published outside the cluster/container network** — see the warning below. | No | `8082` |
 | `WORKER_LISTEN_ADDR` | Listen address for worker server. The default binds all interfaces; narrow it to `127.0.0.1` for a single-host deployment. | No | `0.0.0.0` |
-
-> **The internal listeners are unauthenticated.** Both `API_INTERNAL_PORT` and
-> `WORKER_INTERNAL_PORT` serve `/internal/*` with no credential check. That
-> surface includes the *mutating* `/internal/worker-trigger` and
-> `/internal/task-event`, and the read-only `/internal/metrics` scrape endpoint
-> (model identifiers and per-path failure volumes). A separate HTTP engine is
-> not an access-control boundary: restrict these ports to the cluster/container
-> network with a network policy, security group, or by binding
-> `WORKER_LISTEN_ADDR` to a private interface. Do not expose them through an
-> ingress or `docker run -p`.
 | `WORKER_MAX_CONCURRENT_TASKS` | Max concurrent worker tasks | No | `20` |
 | `WORKER_MAP_CONCURRENCY` | Concurrency for map-phase LLM calls | No | `5` |
 | `AGENT_MAP_CONCURRENCY` | How many Map-phase chunk summaries ONE `summarize_chunk` tool call runs in parallel (agent path only). Clamped to `[1, 5]`; unset/0/negative resolve to the default. Deliberately separate from `WORKER_MAP_CONCURRENCY`: the agent runner already executes up to 4 tool calls from a single LLM turn concurrently (`agent.NewPool(4)`), so the two knobs MULTIPLY — at the default the ceiling of in-flight Map completions from one user request is 4×3=12. Set to `1` to take a dedicated serial path identical to the pre-concurrency loop (rollback without redeploying). | No | `3` |
@@ -82,5 +72,21 @@ The following model identifiers are tested and supported:
 | `qwen3.6-flash` | Alibaba Cloud | Fast inference |
 | `deepseek-v4-flash` | DeepSeek | Fast inference |
 | `deepseek-v4-pro` | DeepSeek | Higher capability |
+
+> **The internal listeners are unauthenticated.** Both `API_INTERNAL_PORT` and
+> `WORKER_INTERNAL_PORT` serve `/internal/*` with no credential check. That
+> surface includes the *mutating* `/internal/worker-trigger` and
+> `/internal/task-event`, and the read-only `/internal/metrics` scrape endpoint
+> (model identifiers and per-path failure volumes). A separate HTTP engine is
+> not an access-control boundary.
+>
+> Restrict both ports at the network layer — a Kubernetes NetworkPolicy, a
+> security group, or simply not publishing them. Do not expose them through an
+> ingress or `docker run -p`.
+>
+> Note the asymmetry: the worker can additionally be narrowed with
+> `WORKER_LISTEN_ADDR=127.0.0.1`, but **the API internal listener has no
+> bind-address knob** — it binds all interfaces unconditionally. For the API
+> port, the network-layer control is the only one available.
 
 The system automatically adjusts token budgets and tokenization ratios based on the selected model.

--- a/cmd/summary-api/main.go
+++ b/cmd/summary-api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,6 +17,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/auth"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmobs"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
@@ -23,6 +25,11 @@ import (
 
 func main() {
 	cfg := config.Load()
+
+	// Instrument every llmfallback.Run in this process (agent chat, agent
+	// tools, worker Map/Reduce, API refine). Must run before any LLM client
+	// is constructed so no call path starts unmonitored.
+	llmobs.Install(slog.Default().With(slog.String("component", "api")))
 
 	// Apply config to pipeline package-level variables
 	if cfg.MaxSafetyLimit > 0 {

--- a/cmd/summary-worker/main.go
+++ b/cmd/summary-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,6 +12,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/db"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmobs"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/notify"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
@@ -20,6 +22,11 @@ import (
 
 func main() {
 	cfg := config.Load()
+
+	// Instrument every llmfallback.Run in this process (agent chat, agent
+	// tools, worker Map/Reduce, API refine). Must run before any LLM client
+	// is constructed so no call path starts unmonitored.
+	llmobs.Install(slog.Default().With(slog.String("component", "worker")))
 
 	// Apply config to pipeline package-level variables
 	if cfg.MaxSafetyLimit > 0 {

--- a/internal/agent/llm.go
+++ b/internal/agent/llm.go
@@ -99,6 +99,7 @@ func (c *Client) Chat(ctx context.Context, msgs []Message, tools []Tool) (Assist
 		Models:          models,
 		PerModelTimeout: c.timeout,
 		MaxAttempts:     3,
+		Path:            llmfallback.PathAgentChat,
 	}, func(ctx context.Context, model string) (AssistantTurn, llmfallback.Outcome, error) {
 		return c.attemptChat(ctx, model, msgs, tools)
 	})

--- a/internal/agent/tool_merge_summaries.go
+++ b/internal/agent/tool_merge_summaries.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 )
 
@@ -159,6 +160,10 @@ func mergeSummariesWithLLM(ctx context.Context, combined string, specGuidance st
 		{Role: "user", Content: combined},
 	}
 
-	content, truncated, _, err := client.CallDisclosingTruncation(ctx, msgs, 0.1)
+	// Tag the path so this tool's LLM traffic is attributable in metrics
+	// instead of landing in path="unknown" (the generic service client cannot
+	// know which caller drove it).
+	content, truncated, _, err := client.CallDisclosingTruncation(
+		llmfallback.WithPath(ctx, llmfallback.PathAgentTool), msgs, 0.1)
 	return content, truncated, err
 }

--- a/internal/agent/tool_narrow_channels.go
+++ b/internal/agent/tool_narrow_channels.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 )
@@ -53,7 +54,8 @@ func NarrowChannelsByTopicTool() (Tool, Handler) {
 		llmFn := func(ctx context.Context, prompt string) (string, error) {
 			client := service.NewLLMClient(cfg.LLMApiURL, cfg.LLMApiKey, cfg.LLMModel, cfg.LLMTimeout, cfg.LLMMaxToken, cfg.LLMEnableThinking, 30, cfg.LLMFallbackModels)
 			msgs := []service.ChatMessage{{Role: "user", Content: prompt}}
-			content, _, err := client.Call(ctx, msgs, 0.3)
+			content, _, err := client.Call(
+				llmfallback.WithPath(ctx, llmfallback.PathAgentTool), msgs, 0.3)
 			return content, err
 		}
 

--- a/internal/agent/tool_summarize_chunk.go
+++ b/internal/agent/tool_summarize_chunk.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/agent/summaryrun"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
@@ -484,7 +485,8 @@ func summarizeMessagesChunk(ctx context.Context, chunk []map[string]interface{},
 		{Role: "user", Content: formatted},
 	}
 
-	content, _, err := client.CallStrict(ctx, msgs, 0.3)
+	content, _, err := client.CallStrict(
+		llmfallback.WithPath(ctx, llmfallback.PathAgentTool), msgs, 0.3)
 	if err != nil {
 		return "", processed, oversized, fmt.Errorf("call LLM: %w", err)
 	}

--- a/internal/api/handler/edit.go
+++ b/internal/api/handler/edit.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
@@ -272,7 +273,8 @@ func (h *EditHandler) RefineSummary(c *gin.Context) {
 		return
 	}
 
-	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	llmCtx, cancel := context.WithTimeout(
+		llmfallback.WithPath(c.Request.Context(), llmfallback.PathAPIRefine), 90*time.Second)
 	defer cancel()
 	newContent, tokens, usedModel, err := h.llm.CallWithModel(llmCtx, []service.ChatMessage{
 		{Role: "system", Content: buildRefineSystemPrompt()},
@@ -438,7 +440,8 @@ func (h *EditHandler) RefineSummaryStream(c *gin.Context) {
 		w.Flush()
 	}
 
-	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	llmCtx, cancel := context.WithTimeout(
+		llmfallback.WithPath(c.Request.Context(), llmfallback.PathAPIRefine), 90*time.Second)
 	defer cancel()
 	newContent, tokens, usedModel, err := h.llm.CallStreamWithModel(llmCtx, []service.ChatMessage{
 		{Role: "system", Content: buildRefineSystemPrompt()},

--- a/internal/api/handler/personal_refine.go
+++ b/internal/api/handler/personal_refine.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
@@ -105,7 +106,8 @@ func (h *PersonalHandler) RefinePersonalSummary(c *gin.Context) {
 		return
 	}
 
-	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	llmCtx, cancel := context.WithTimeout(
+		llmfallback.WithPath(c.Request.Context(), llmfallback.PathAPIRefine), 90*time.Second)
 	defer cancel()
 	newContent, tokens, usedModel, err := h.llm.CallWithModel(llmCtx, []service.ChatMessage{
 		{Role: "system", Content: buildRefineSystemPrompt()},
@@ -330,7 +332,8 @@ func (h *PersonalHandler) RefinePersonalSummaryStream(c *gin.Context) {
 		w.Flush()
 	}
 
-	llmCtx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	llmCtx, cancel := context.WithTimeout(
+		llmfallback.WithPath(c.Request.Context(), llmfallback.PathAPIRefine), 90*time.Second)
 	defer cancel()
 	newContent, tokens, usedModel, err := h.llm.CallStreamWithModel(llmCtx, []service.ChatMessage{
 		{Role: "system", Content: buildRefineSystemPrompt()},

--- a/internal/api/router/metrics_route_test.go
+++ b/internal/api/router/metrics_route_test.go
@@ -75,7 +75,15 @@ func concretePath(pattern string) string {
 // serve the installed metric set with the content type a Prometheus scraper
 // expects.
 func TestMetricsRendersExposition(t *testing.T) {
+	// Install writes process-wide state. Without this cleanup it leaked into
+	// every later test in the package — the same hazard ResetDefaultForTest was
+	// added to close, and the reason TestMetricsBeforeInstallDoesNotPanic has to
+	// defend itself explicitly.
 	llmobs.Install(nil)
+	t.Cleanup(func() {
+		llmfallback.SetDefaultObserver(nil)
+		llmobs.ResetDefaultForTest()
+	})
 
 	internal, _ := SetupInternal(nil)
 	w := httptest.NewRecorder()

--- a/internal/api/router/metrics_route_test.go
+++ b/internal/api/router/metrics_route_test.go
@@ -1,0 +1,131 @@
+package router
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmobs"
+)
+
+// TestMetricsIsInternalOnly is the security-rule acceptance from the brief: the
+// scrape endpoint reports model identifiers and failure volumes, which are
+// operational details. The internal router is bound to its own listener
+// (API_INTERNAL_PORT / WORKER_INTERNAL_PORT) that deployments do not publish,
+// so the endpoint must exist there and must NOT exist on the public engine.
+func TestMetricsIsInternalOnly(t *testing.T) {
+	internal, _ := SetupInternal(nil)
+	if !hasRoute(internal, http.MethodGet, "/internal/metrics") {
+		t.Error("/internal/metrics is not mounted on the internal router")
+	}
+
+	// Install a metric set with a recognisable series, then check no public GET
+	// route can return it.
+	//
+	// This deliberately does NOT filter routes by name. Matching on
+	// strings.Contains(path, "metrics") tests what a route is CALLED, not what it
+	// serves: a handler rendering the same exposition at, say,
+	// /api/v1/debug/telemetry would pass a name check untouched. Drive the routes
+	// and inspect the bodies instead.
+	llmobs.Install(nil)
+	t.Cleanup(func() { llmfallback.SetDefaultObserver(nil) })
+	llmobs.Default().ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAgentChat, Model: "canary-model",
+		Position: llmfallback.PositionPrimary, OK: true,
+	})
+
+	public := SetupPublic(nil, nil, nil, nil, nil, "", 0, false, 0, nil, "", "", "", 0, 0, nil)
+	for _, r := range public.Routes() {
+		if r.Method != http.MethodGet {
+			continue
+		}
+		// Route patterns carry :params / *wildcards; give them a value so the
+		// request actually dispatches instead of 404-ing on the pattern itself.
+		path := concretePath(r.Path)
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		public.ServeHTTP(w, req)
+
+		body := w.Body.String()
+		for _, marker := range []string{"llm_attempts_total", "llm_calls_total", "canary-model"} {
+			if strings.Contains(body, marker) {
+				t.Errorf("public route %s %s leaked metric content (%q); the scrape must stay on the internal listener",
+					r.Method, r.Path, marker)
+			}
+		}
+	}
+}
+
+// concretePath substitutes a placeholder for gin's :param and *wildcard
+// segments so a route pattern can be requested.
+func concretePath(pattern string) string {
+	segs := strings.Split(pattern, "/")
+	for i, s := range segs {
+		if strings.HasPrefix(s, ":") || strings.HasPrefix(s, "*") {
+			segs[i] = "probe"
+		}
+	}
+	return strings.Join(segs, "/")
+}
+
+// TestMetricsRendersExposition covers the wiring end to end: the handler must
+// serve the installed metric set with the content type a Prometheus scraper
+// expects.
+func TestMetricsRendersExposition(t *testing.T) {
+	llmobs.Install(nil)
+
+	internal, _ := SetupInternal(nil)
+	w := httptest.NewRecorder()
+	internal.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/internal/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain exposition format", ct)
+	}
+	if !strings.Contains(w.Body.String(), "# TYPE llm_attempts_total counter") {
+		t.Errorf("body does not carry the metric families:\n%s", w.Body.String())
+	}
+}
+
+// TestMetricsBeforeInstallDoesNotPanic covers the ordering hazard: a scrape can
+// arrive before (or without) llmobs.Install having run, and a 500 on the
+// monitoring endpoint would itself look like an outage.
+func TestMetricsBeforeInstallDoesNotPanic(t *testing.T) {
+	// This used to be wrapped in `if llmobs.Default() == nil`, which made the
+	// whole body dead in a full-package run: an earlier test installs a
+	// process-wide default that cannot be un-installed, so under -shuffle=on the
+	// assertion ran or not by coin flip. Reset the default for the duration of
+	// this test instead, so the nil guard is exercised every time.
+	llmfallback.SetDefaultObserver(nil)
+	llmobs.ResetDefaultForTest()
+	t.Cleanup(func() { llmfallback.SetDefaultObserver(nil) })
+
+	if llmobs.Default() != nil {
+		t.Fatal("precondition: the default metric set should be cleared for this test")
+	}
+
+	internal, _ := SetupInternal(nil)
+	w := httptest.NewRecorder()
+	internal.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/internal/metrics", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d before Install; want a benign empty 200 — a 500 on the monitoring endpoint reads as an outage", w.Code)
+	}
+	if body := w.Body.String(); body != "" {
+		t.Errorf("body = %q before Install; want empty", body)
+	}
+}
+
+func hasRoute(e *gin.Engine, method, path string) bool {
+	for _, r := range e.Routes() {
+		if r.Method == method && r.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/handler"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/api/ws"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmobs"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/streaming"
@@ -178,6 +179,15 @@ func SetupInternal(hub *ws.Hub, streamHub ...*streaming.Hub) (*gin.Engine, *hand
 	intH := handler.NewInternalHandler(hub)
 	r.GET("/internal/healthz", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+	// Prometheus scrape target. Deliberately on the INTERNAL router only: it
+	// exposes model identifiers and failure volumes, which are operational
+	// details that should not be reachable from the public listener.
+	r.GET("/internal/metrics", func(c *gin.Context) {
+		c.Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		if m := llmobs.Default(); m != nil {
+			m.WritePrometheus(c.Writer)
+		}
 	})
 	r.POST("/internal/task-event", intH.TaskEvent)
 	r.POST("/internal/worker-trigger", intH.WorkerTrigger)

--- a/internal/llmfallback/context.go
+++ b/internal/llmfallback/context.go
@@ -1,0 +1,62 @@
+package llmfallback
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type pathCtxKey struct{}
+
+// WithPath tags ctx with the logical call site, so a generic entry point like
+// LLMClient.Call reports whether it was serving worker Map, worker Reduce or an
+// API refine without every signature growing a path parameter.
+//
+// Config.Path, when set, wins over the context value.
+func WithPath(ctx context.Context, p Path) context.Context {
+	return context.WithValue(ctx, pathCtxKey{}, p)
+}
+
+// PathFromContext returns the path tagged by WithPath, or PathUnknown.
+func PathFromContext(ctx context.Context) Path {
+	if ctx == nil {
+		return PathUnknown
+	}
+	if p, ok := ctx.Value(pathCtxKey{}).(Path); ok && p != "" {
+		return p
+	}
+	return PathUnknown
+}
+
+// defaultObserver is the process-wide Observer used when Config.Observer is
+// nil. Telemetry is a cross-cutting concern here: routing it through every
+// constructor would mean four call sites that can each silently forget to wire
+// it, which is exactly how a fallback goes unmonitored. Set it once from a
+// composition root (cmd/summary-api, cmd/summary-worker) before serving.
+var defaultObserver atomic.Pointer[Observer]
+
+// SetDefaultObserver installs the process-wide Observer. Passing nil clears it.
+// Safe to call concurrently, but intended to run once at startup.
+func SetDefaultObserver(o Observer) {
+	if o == nil {
+		defaultObserver.Store(nil)
+		return
+	}
+	defaultObserver.Store(&o)
+}
+
+func (c Config) observer() Observer {
+	if c.Observer != nil {
+		return c.Observer
+	}
+	if p := defaultObserver.Load(); p != nil {
+		return *p
+	}
+	return noopObserver{}
+}
+
+func (c Config) pathFor(ctx context.Context) Path {
+	if c.Path != "" {
+		return c.Path
+	}
+	return PathFromContext(ctx)
+}

--- a/internal/llmfallback/fallback.go
+++ b/internal/llmfallback/fallback.go
@@ -17,6 +17,7 @@ package llmfallback
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -95,6 +96,14 @@ type Config struct {
 	// Backoff returns the sleep before retry attempt n (n >= 1). Nil defaults
 	// to exponential 1s, 2s, 4s… Tests pass a zero-backoff to run fast.
 	Backoff func(attempt int) time.Duration
+	// Path labels which call site drove this Run, for metrics/logs. Optional;
+	// defaults to PathUnknown.
+	Path Path
+	// Observer receives attempt/switch/result events. Optional; nil installs a
+	// no-op. Not free: a nil observer still costs the timing calls Run makes
+	// around each attempt (measured ~14ns -> ~200ns per Run, zero allocations),
+	// which is noise against a network round trip but is not "nothing".
+	Observer Observer
 }
 
 func (c Config) backoff(attempt int) time.Duration {
@@ -114,8 +123,18 @@ func Run[T any](ctx context.Context, cfg Config, attempt Attempt[T]) (T, string,
 	if maxAttempts < 1 {
 		maxAttempts = 1
 	}
+	obs, path := cfg.observer(), cfg.pathFor(ctx)
+	start := time.Now()
+	switches := 0
+
+	// Report the misconfiguration too. This used to return before any observer
+	// call, so a deployment with an empty model list failed every request while
+	// llm_calls_total stayed flat — the one case where a silent counter is
+	// least affordable.
 	if len(cfg.Models) == 0 {
-		return zero, "", fmt.Errorf("llmfallback: no models configured")
+		err := fmt.Errorf("llmfallback: no models configured")
+		obs.ObserveResult(ResultEvent{Path: path, Duration: time.Since(start), Err: err})
+		return zero, "", err
 	}
 
 	var lastErr error
@@ -123,38 +142,122 @@ func Run[T any](ctx context.Context, cfg Config, attempt Attempt[T]) (T, string,
 		// Respect caller cancellation before opening the next model's budget.
 		if err := ctx.Err(); err != nil {
 			if lastErr != nil {
-				return zero, "", fmt.Errorf("%w (last: %v)", err, lastErr)
+				err = fmt.Errorf("%w (last: %v)", err, lastErr)
 			}
+			obs.ObserveResult(ResultEvent{
+				Path: path, Switches: switches, Cancelled: true,
+				Duration: time.Since(start), Err: err,
+			})
 			return zero, "", err
 		}
 		if i > 0 {
 			log.Printf("[llmfallback] falling back from %q to %q: %s",
 				cfg.Models[i-1], model, SafeErrorForLog(lastErr, 200))
+			switches++
+			obs.ObserveSwitch(SwitchEvent{
+				Path:     path,
+				From:     cfg.Models[i-1],
+				To:       model,
+				FromPos:  PositionOf(i - 1),
+				Reason:   reasonFor(lastErr),
+				Attempts: attemptsSpent(lastErr, maxAttempts),
+				Err:      lastErr,
+			})
 		}
 		hasNext := i < len(cfg.Models)-1
 
-		val, outcome, err := runModel(ctx, model, maxAttempts, hasNext, cfg, attempt)
+		val, outcome, err := runModel(ctx, model, maxAttempts, hasNext, cfg, attempt, obs, path, PositionOf(i))
 		switch outcome {
 		case Success:
+			obs.ObserveResult(ResultEvent{
+				Path: path, Model: model, Position: PositionOf(i),
+				Switches: switches, OK: true, Duration: time.Since(start),
+			})
 			return val, model, nil
 		case Terminal:
+			obs.ObserveResult(ResultEvent{
+				Path: path, Model: model, Position: PositionOf(i),
+				Switches: switches, Duration: time.Since(start), Err: err,
+			})
 			return val, model, err
 		}
 		// runModel exhausted retries or hit TryNextModel → advance.
 		lastErr = err
 	}
 
-	if len(cfg.Models) == 1 {
-		return zero, "", lastErr
+	if len(cfg.Models) > 1 {
+		lastErr = fmt.Errorf("all %d model(s) failed: %w", len(cfg.Models), lastErr)
 	}
-	return zero, "", fmt.Errorf("all %d model(s) failed: %w", len(cfg.Models), lastErr)
+	obs.ObserveResult(ResultEvent{Path: path, Switches: switches, Duration: time.Since(start), Err: lastErr})
+	return zero, "", lastErr
+}
+
+// budgetStarvedErr marks the error returned when the deadline guard abandons a
+// model's remaining retries. It is a distinct type so ObserveSwitch can report
+// ReasonBudgetStarved — a configuration problem — separately from a genuine
+// upstream failure, without parsing error strings.
+type budgetStarvedErr struct {
+	model   string
+	budget  time.Duration
+	spent   int
+	wrapped error
+}
+
+func (e *budgetStarvedErr) Error() string {
+	if e.wrapped != nil {
+		return fmt.Sprintf("insufficient budget for another %s attempt on %q after %d attempt(s): %v",
+			e.budget, e.model, e.spent, e.wrapped)
+	}
+	return fmt.Sprintf("insufficient budget for another %s attempt on %q after %d attempt(s)",
+		e.budget, e.model, e.spent)
+}
+
+func (e *budgetStarvedErr) Unwrap() error { return e.wrapped }
+
+// reasonFor classifies why a model was abandoned, for the switch metric.
+func reasonFor(err error) SwitchReason {
+	var starved *budgetStarvedErr
+	switch {
+	case err == nil:
+		return ReasonRetriesExhausted
+	case errors.As(err, &starved):
+		return ReasonBudgetStarved
+	// Deliberately NOT special-cased here: an error wrapping
+	// context.DeadlineExceeded. Every production call site gives each attempt
+	// its own request timeout (agent/llm.go attemptChat, service/llm.go
+	// CallWithTools), so a merely slow upstream trips the INNER deadline while
+	// the parent Run context is still healthy. Classifying on the sentinel
+	// reported those as "cancelled" and emptied retries_exhausted during
+	// exactly the incident this metric exists for. Genuine caller cancellation
+	// never reaches this function: Run returns at the top of the model loop
+	// before any switch is observed.
+	case isDenied(err):
+		return ReasonDenied
+	default:
+		return ReasonRetriesExhausted
+	}
+}
+
+// attemptsSpent reports how many attempts were actually spent on the abandoned
+// model, so the switch metric distinguishes "gave up after 1" (the starvation
+// signature) from "gave up after the full budget".
+func attemptsSpent(err error, maxAttempts int) int {
+	var starved *budgetStarvedErr
+	if errors.As(err, &starved) {
+		return starved.spent
+	}
+	var denied *deniedErr
+	if errors.As(err, &denied) {
+		return denied.spent
+	}
+	return maxAttempts
 }
 
 // runModel runs the per-model retry loop. Returns Success (with value),
 // Terminal (stop everything), or TryNextModel (advance to the next model,
 // either because retries were exhausted on RetrySameModel or because the
 // attempt classified TryNextModel).
-func runModel[T any](ctx context.Context, model string, maxAttempts int, hasNext bool, cfg Config, attempt Attempt[T]) (T, Outcome, error) {
+func runModel[T any](ctx context.Context, model string, maxAttempts int, hasNext bool, cfg Config, attempt Attempt[T], obs Observer, path Path, position string) (T, Outcome, error) {
 	var zero T
 	var lastErr error
 	for a := 0; a < maxAttempts; a++ {
@@ -170,10 +273,9 @@ func runModel[T any](ctx context.Context, model string, maxAttempts int, hasNext
 				if dl, ok := ctx.Deadline(); ok {
 					remaining := time.Until(dl)
 					if remaining > delay && remaining < delay+2*cfg.PerModelTimeout {
-						if lastErr == nil {
-							lastErr = fmt.Errorf("insufficient budget for another %s attempt on %q", cfg.PerModelTimeout, model)
+						return zero, TryNextModel, &budgetStarvedErr{
+							model: model, budget: cfg.PerModelTimeout, spent: a, wrapped: lastErr,
 						}
-						return zero, TryNextModel, lastErr
 					}
 				}
 			}
@@ -183,7 +285,13 @@ func runModel[T any](ctx context.Context, model string, maxAttempts int, hasNext
 			case <-time.After(delay):
 			}
 		}
+		attemptStart := time.Now()
 		val, outcome, err := attempt(ctx, model)
+		obs.ObserveAttempt(AttemptEvent{
+			Path: path, Model: model, Position: position,
+			Attempt: a + 1, MaxAttempts: maxAttempts,
+			Outcome: outcome, Duration: time.Since(attemptStart), Err: err,
+		})
 		switch outcome {
 		case Success:
 			// Never let an inconsistent attempt result (Success plus error)
@@ -195,12 +303,32 @@ func runModel[T any](ctx context.Context, model string, maxAttempts int, hasNext
 		case Terminal:
 			return val, Terminal, err
 		case TryNextModel:
-			return zero, TryNextModel, err
+			return zero, TryNextModel, &deniedErr{model: model, spent: a + 1, wrapped: err}
 		case RetrySameModel:
 			lastErr = err
 		}
 	}
 	return zero, TryNextModel, fmt.Errorf("model %q failed after %d attempt(s): %w", model, maxAttempts, lastErr)
+}
+
+// deniedErr marks an attempt-classified TryNextModel (today: HTTP 403 account
+// denial) so the switch metric can separate "this credential is refused" from
+// "upstream is overloaded". The two need different responders.
+type deniedErr struct {
+	model   string
+	spent   int
+	wrapped error
+}
+
+func (e *deniedErr) Error() string {
+	return fmt.Sprintf("model %q refused the credential after %d attempt(s): %v", e.model, e.spent, e.wrapped)
+}
+
+func (e *deniedErr) Unwrap() error { return e.wrapped }
+
+func isDenied(err error) bool {
+	var d *deniedErr
+	return errors.As(err, &d)
 }
 
 // SafeTextForLog flattens and bounds upstream-controlled text before it is

--- a/internal/llmfallback/fallback.go
+++ b/internal/llmfallback/fallback.go
@@ -145,7 +145,7 @@ func Run[T any](ctx context.Context, cfg Config, attempt Attempt[T]) (T, string,
 				err = fmt.Errorf("%w (last: %v)", err, lastErr)
 			}
 			obs.ObserveResult(ResultEvent{
-				Path: path, Switches: switches, Cancelled: true,
+				Path: path, Switches: switches, End: endOf(ctx),
 				Duration: time.Since(start), Err: err,
 			})
 			return zero, "", err
@@ -175,8 +175,13 @@ func Run[T any](ctx context.Context, cfg Config, attempt Attempt[T]) (T, string,
 			})
 			return val, model, nil
 		case Terminal:
+			// endOf matters here too: both real clients turn a caller-cancelled
+			// in-flight request into exactly this exit (they check the PARENT
+			// ctx, so Terminal here means "the caller's context is dead"), and
+			// without it a closed tab was counted result="failed" WITH a
+			// position — invisible against genuine 400s on the same series.
 			obs.ObserveResult(ResultEvent{
-				Path: path, Model: model, Position: PositionOf(i),
+				Path: path, Model: model, Position: PositionOf(i), End: endOf(ctx),
 				Switches: switches, Duration: time.Since(start), Err: err,
 			})
 			return val, model, err
@@ -188,8 +193,37 @@ func Run[T any](ctx context.Context, cfg Config, attempt Attempt[T]) (T, string,
 	if len(cfg.Models) > 1 {
 		lastErr = fmt.Errorf("all %d model(s) failed: %w", len(cfg.Models), lastErr)
 	}
-	obs.ObserveResult(ResultEvent{Path: path, Switches: switches, Duration: time.Since(start), Err: lastErr})
+	// The loop-end exit is reached on cancellation too: runModel returns
+	// TryNextModel with ctx.Err() when the caller goes away during a backoff
+	// sleep, and with no next model the loop simply ends here. In the default
+	// single-model deployment that made a closed tab emit the ERROR
+	// "exhausted every configured model" — the exact record this is meant to
+	// keep for real outages.
+	obs.ObserveResult(ResultEvent{
+		Path: path, Switches: switches, End: endOf(ctx),
+		Duration: time.Since(start), Err: lastErr,
+	})
 	return zero, "", lastErr
+}
+
+// endOf classifies how the caller's context ended a run, if it did.
+//
+// It keys on the sentinel rather than on ctx.Err() != nil because those are two
+// different incidents: context.Canceled means the caller walked away and nobody
+// should be paged, while context.DeadlineExceeded means OUR budget expired —
+// usually because upstream was slow — which is exactly what an operator needs
+// to see. This is the same distinction reasonFor makes for SwitchReason; it was
+// missing one layer up, so a run that timed out was filed under a label whose
+// documentation says "do not alert on it".
+func endOf(ctx context.Context) RunEnd {
+	switch {
+	case errors.Is(ctx.Err(), context.Canceled):
+		return RunEndCancelled
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return RunEndTimedOut
+	default:
+		return RunEndNone
+	}
 }
 
 // budgetStarvedErr marks the error returned when the deadline guard abandons a

--- a/internal/llmfallback/observer.go
+++ b/internal/llmfallback/observer.go
@@ -1,0 +1,125 @@
+package llmfallback
+
+import "time"
+
+// Path identifies which logical call site drove a Run. It is a low-cardinality
+// label: keep it to the fixed set below so metrics series stay bounded. Never
+// derive it from request data (task ids, chunk indexes, user ids).
+type Path string
+
+const (
+	PathUnknown      Path = "unknown"
+	PathAgentChat    Path = "agent_chat"
+	PathAgentTool    Path = "agent_tool"
+	PathWorkerMap    Path = "worker_map"
+	PathWorkerReduce Path = "worker_reduce"
+	PathAPIRefine    Path = "api_refine"
+	PathToolCall     Path = "tool_call"
+)
+
+// SwitchReason explains why Run advanced from one model to the next. The three
+// reasons demand different remediations, so they must not be collapsed into a
+// single "fallback happened" counter:
+//
+//   - ReasonDenied: the account/credential is refused for this model (403).
+//     Will not self-heal; someone has to fix billing/IAM/SCP.
+//   - ReasonRetriesExhausted: genuine upstream overload/outage (429/5xx) that
+//     survived the per-model retry budget. Usually transient.
+//   - ReasonBudgetStarved: the runner gave up the remaining same-model retries
+//     because the parent deadline could not fit them plus a fallback attempt.
+//     This is a CONFIGURATION signal, not an upstream one: it means the
+//     deployment's step deadline is too tight for MaxAttempts*PerModelTimeout,
+//     so the primary is being abandoned early on every transient blip.
+type SwitchReason string
+
+const (
+	ReasonDenied           SwitchReason = "denied"
+	ReasonRetriesExhausted SwitchReason = "retries_exhausted"
+	ReasonBudgetStarved    SwitchReason = "budget_starved"
+)
+
+// Position labels a model by its rank in the configured list.
+const (
+	PositionPrimary  = "primary"
+	PositionFallback = "fallback"
+)
+
+// PositionOf maps a model index to a bounded position label.
+func PositionOf(i int) string {
+	if i == 0 {
+		return PositionPrimary
+	}
+	return PositionFallback
+}
+
+// AttemptEvent reports the result of one upstream request.
+type AttemptEvent struct {
+	Path     Path
+	Model    string
+	Position string
+	// Attempt is 1-based within the current model's retry budget.
+	Attempt int
+	// MaxAttempts is that budget, so a consumer can tell "failed, will retry"
+	// from "failed on the last attempt". Without it the retry log claimed a
+	// retry was coming even on the final attempt, when the next step is
+	// abandoning the model.
+	MaxAttempts int
+	Outcome     Outcome
+	Duration    time.Duration
+	Err         error
+}
+
+// SwitchEvent reports Run advancing from one model to the next. This is the
+// event that makes silent quality drift visible.
+type SwitchEvent struct {
+	Path     Path
+	From     string
+	To       string
+	FromPos  string
+	Reason   SwitchReason
+	Attempts int // attempts spent on From before giving up
+	Err      error
+}
+
+// ResultEvent reports the terminal outcome of a whole Run.
+type ResultEvent struct {
+	Path Path
+	// Model is the model that produced the result (empty when every model
+	// failed).
+	Model string
+	// Position is the rank of Model; empty when every model failed.
+	Position string
+	// Switches counts how many times Run advanced to another model.
+	Switches int
+	// OK is true when a model returned a usable result.
+	OK bool
+	// Cancelled is true when the caller's context ended the run rather than an
+	// upstream failure — an SSE client closing the tab, a shutdown, a parent
+	// timeout. Without this, an ordinary disconnect is indistinguishable from
+	// "every configured model failed": both arrive with OK=false and an empty
+	// Model, which is the series a real provider outage lands on.
+	Cancelled bool
+	Duration  time.Duration
+	Err       error
+}
+
+// Observer receives Run's lifecycle events. Implementations MUST be safe for
+// concurrent use (the worker runs Map chunks in parallel) and MUST NOT block —
+// they run on the request path. A nil Observer disables instrumentation.
+//
+// Keeping this an interface owned by llmfallback lets the metrics backend live
+// in a separate package, so this leaf package stays dependency-free and a
+// future swap to prometheus/client_golang is a drop-in at the composition root.
+type Observer interface {
+	ObserveAttempt(AttemptEvent)
+	ObserveSwitch(SwitchEvent)
+	ObserveResult(ResultEvent)
+}
+
+// noopObserver is used when Config.Observer is nil so Run needs no nil checks
+// on the hot path.
+type noopObserver struct{}
+
+func (noopObserver) ObserveAttempt(AttemptEvent) {}
+func (noopObserver) ObserveSwitch(SwitchEvent)   {}
+func (noopObserver) ObserveResult(ResultEvent)   {}

--- a/internal/llmfallback/observer.go
+++ b/internal/llmfallback/observer.go
@@ -93,15 +93,34 @@ type ResultEvent struct {
 	Switches int
 	// OK is true when a model returned a usable result.
 	OK bool
-	// Cancelled is true when the caller's context ended the run rather than an
-	// upstream failure — an SSE client closing the tab, a shutdown, a parent
-	// timeout. Without this, an ordinary disconnect is indistinguishable from
-	// "every configured model failed": both arrive with OK=false and an empty
-	// Model, which is the series a real provider outage lands on.
-	Cancelled bool
-	Duration  time.Duration
-	Err       error
+	// End records whether the caller's context ended the run, and how. Without
+	// it an ordinary disconnect is indistinguishable from "every configured
+	// model failed": both arrive with OK=false and an empty Model, which is the
+	// series a real provider outage lands on.
+	End      RunEnd
+	Duration time.Duration
+	Err      error
 }
+
+// RunEnd says how the caller's context ended a run, when it did. Cancellation
+// and deadline expiry are separate values because they page different people: a
+// client closing a tab is not actionable, while exhausting our own time budget
+// is a real incident that must stay alertable. A single boolean forced those
+// two into one bucket, and whichever label it carried was wrong for the other.
+type RunEnd string
+
+const (
+	// RunEndNone: the run finished on its own terms — success, a terminal
+	// upstream error, or every model failing. The caller was still waiting.
+	RunEndNone RunEnd = ""
+	// RunEndCancelled: the caller went away (SSE disconnect, shutdown). Not an
+	// upstream fault.
+	RunEndCancelled RunEnd = "cancelled"
+	// RunEndTimedOut: our own deadline expired (AGENT_STEP_TIMEOUT, the refine
+	// budget). Nobody walked away — we ran out of time, usually because
+	// upstream was slow. Alertable.
+	RunEndTimedOut RunEnd = "timeout"
+)
 
 // Observer receives Run's lifecycle events. Implementations MUST be safe for
 // concurrent use (the worker runs Map chunks in parallel) and MUST NOT block —

--- a/internal/llmfallback/observer_test.go
+++ b/internal/llmfallback/observer_test.go
@@ -289,6 +289,23 @@ func TestRun_PreservesSanitizerMatchableText(t *testing.T) {
 		}
 	})
 
+	t.Run("upstream text survives the denied wrapper", func(t *testing.T) {
+		// deniedErr prefixes the caller-visible text; nothing pinned that the
+		// wrapped upstream body still shows through, so sanitizeErrorForUser's
+		// "LLM API error" branch was unguarded for every 403.
+		_, _, err := Run(context.Background(), Config{Models: []string{"a"}, MaxAttempts: 3, Backoff: noBackoff},
+			func(_ context.Context, m string) (string, Outcome, error) {
+				return "", ClassifyStatus(http.StatusForbidden),
+					fmt.Errorf("LLM API error: status=403 body=AccessDenied on %s", m)
+			})
+		if err == nil {
+			t.Fatal("expected an error from a denied model")
+		}
+		if !strings.Contains(err.Error(), "LLM API error") {
+			t.Errorf("upstream text lost through the denied wrapper: %q", err)
+		}
+	})
+
 	t.Run("deadline text survives the budget-starved guard", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
 		defer cancel()
@@ -366,27 +383,85 @@ func TestReasonFor_RealProductionErrorShapes(t *testing.T) {
 	}
 }
 
-// TestRun_CancellationIsFlaggedNotReportedAsExhaustion pins the second half of
-// the same problem: a caller walking away must not look like a total outage.
-func TestRun_CancellationIsFlaggedNotReportedAsExhaustion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+// TestRun_ContextEndIsClassifiedAtEveryExit pins the second half of the same
+// problem: a caller walking away must not look like a total outage, and our own
+// deadline expiring must not look like a caller walking away.
+//
+// The earlier version of this test cancelled BEFORE calling Run, so the attempt
+// function never ran and only the top-of-loop exit was ever exercised — the one
+// exit production almost never takes. Each case below drives a real exit:
+// both clients turn a mid-flight cancel into Terminal (they check the parent
+// ctx), and a cancel during a backoff sleep falls out of the model loop.
+func TestRun_ContextEndIsClassifiedAtEveryExit(t *testing.T) {
+	t.Run("cancelled mid-attempt reaches the Terminal exit", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		r := &recorder{}
+		Run(ctx, Config{Models: []string{"a", "b"}, MaxAttempts: 3, Backoff: noBackoff, Observer: r},
+			func(actx context.Context, _ string) (string, Outcome, error) {
+				cancel() // the client closed the tab while the request was open
+				if actx.Err() != nil {
+					// Exactly what agent attemptChat and service Call do.
+					return "", Terminal, actx.Err()
+				}
+				return "", RetrySameModel, nil
+			})
+		assertEnd(t, r, RunEndCancelled)
+	})
 
-	r := &recorder{}
-	Run(ctx, Config{Models: []string{"a", "b"}, MaxAttempts: 2, Backoff: noBackoff, Observer: r},
-		func(_ context.Context, _ string) (string, Outcome, error) {
-			return "ok", Success, nil
+	t.Run("cancelled during backoff reaches the loop-end exit", func(t *testing.T) {
+		// A single model is the default deployment (LLM_FALLBACK_MODELS empty),
+		// and it is the shape that used to emit the "exhausted every configured
+		// model" ERROR for a plain disconnect.
+		ctx, cancel := context.WithCancel(context.Background())
+		r := &recorder{}
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+		Run(ctx, Config{
+			Models: []string{"only"}, MaxAttempts: 3, Observer: r,
+			Backoff: func(int) time.Duration { return 50 * time.Millisecond },
+		}, func(context.Context, string) (string, Outcome, error) {
+			return "", RetrySameModel, errors.New("upstream 503")
 		})
+		assertEnd(t, r, RunEndCancelled)
+	})
 
+	t.Run("our own deadline expiring is a timeout, not a cancellation", func(t *testing.T) {
+		// Upstream is slow and our budget runs out. Filing this under
+		// "cancelled" would mark a real incident "do not alert on it".
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+		r := &recorder{}
+		Run(ctx, Config{Models: []string{"a", "b"}, MaxAttempts: 1, Backoff: noBackoff, Observer: r},
+			func(context.Context, string) (string, Outcome, error) {
+				time.Sleep(50 * time.Millisecond)
+				return "", ClassifyStatus(http.StatusServiceUnavailable), errors.New("503 slow")
+			})
+		assertEnd(t, r, RunEndTimedOut)
+	})
+
+	t.Run("an ordinary upstream failure is neither", func(t *testing.T) {
+		r := &recorder{}
+		Run(context.Background(), Config{Models: []string{"a"}, MaxAttempts: 1, Backoff: noBackoff, Observer: r},
+			func(context.Context, string) (string, Outcome, error) {
+				return "", ClassifyStatus(http.StatusBadRequest), errors.New("400 bad request")
+			})
+		assertEnd(t, r, RunEndNone)
+	})
+}
+
+func assertEnd(t *testing.T, r *recorder, want RunEnd) {
+	t.Helper()
 	if len(r.results) != 1 {
-		t.Fatalf("expected exactly 1 result event, got %d", len(r.results))
+		t.Fatalf("expected exactly 1 result event, got %d: %+v", len(r.results), r.results)
 	}
 	got := r.results[0]
-	if !got.Cancelled {
-		t.Error("caller cancellation was not flagged; it is indistinguishable from total exhaustion")
+	if got.End != want {
+		t.Errorf("End = %q, want %q (err: %v)", got.End, want, got.Err)
 	}
 	if got.OK {
-		t.Error("a cancelled run must not report OK")
+		t.Error("a failed run must not report OK")
 	}
 }
 

--- a/internal/llmfallback/observer_test.go
+++ b/internal/llmfallback/observer_test.go
@@ -1,0 +1,440 @@
+package llmfallback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// recorder captures every event for assertions.
+type recorder struct {
+	attempts []AttemptEvent
+	switches []SwitchEvent
+	results  []ResultEvent
+}
+
+func (r *recorder) ObserveAttempt(e AttemptEvent) { r.attempts = append(r.attempts, e) }
+func (r *recorder) ObserveSwitch(e SwitchEvent)   { r.switches = append(r.switches, e) }
+func (r *recorder) ObserveResult(e ResultEvent)   { r.results = append(r.results, e) }
+
+// TestObserver_DoesNotAlterRunSemantics is the load-bearing guarantee from the
+// brief: instrumentation must not change which model serves a request, what the
+// caller gets back, or what the error says. internal/worker's
+// sanitizeErrorForUser matches on error TEXT to choose the user-facing message,
+// so an error-string drift would change what users see in their IM DM.
+func TestObserver_DoesNotAlterRunSemantics(t *testing.T) {
+	cases := []struct {
+		name    string
+		models  []string
+		attempt Attempt[string]
+	}{
+		{
+			name:   "primary success",
+			models: []string{"a", "b"},
+			attempt: func(_ context.Context, m string) (string, Outcome, error) {
+				return "ok-" + m, Success, nil
+			},
+		},
+		{
+			name:   "fallback rescues after retries",
+			models: []string{"a", "b"},
+			attempt: func(_ context.Context, m string) (string, Outcome, error) {
+				if m == "a" {
+					return "", RetrySameModel, errors.New("rate limited")
+				}
+				return "ok-" + m, Success, nil
+			},
+		},
+		{
+			name:   "terminal stops immediately and preserves partial",
+			models: []string{"a", "b"},
+			attempt: func(_ context.Context, m string) (string, Outcome, error) {
+				return "partial", Terminal, errors.New("bad request")
+			},
+		},
+		{
+			name:   "every model fails",
+			models: []string{"a", "b"},
+			attempt: func(_ context.Context, m string) (string, Outcome, error) {
+				return "", RetrySameModel, errors.New("boom")
+			},
+		},
+		{
+			name:   "single model preserves the un-wrapped error contract",
+			models: []string{"only"},
+			attempt: func(_ context.Context, m string) (string, Outcome, error) {
+				return "", RetrySameModel, errors.New("solo failure")
+			},
+		},
+		{
+			name:   "403 escalates without same-model retries",
+			models: []string{"a", "b"},
+			attempt: func(_ context.Context, m string) (string, Outcome, error) {
+				if m == "a" {
+					return "", ClassifyStatus(http.StatusForbidden), errors.New("explicit deny")
+				}
+				return "ok-" + m, Success, nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := Config{Models: tc.models, MaxAttempts: 3, Backoff: noBackoff}
+
+			wantVal, wantModel, wantErr := Run(context.Background(), base, tc.attempt)
+
+			instrumented := base
+			instrumented.Observer = &recorder{}
+			gotVal, gotModel, gotErr := Run(context.Background(), instrumented, tc.attempt)
+
+			if gotVal != wantVal {
+				t.Errorf("value drifted with observer: got %q want %q", gotVal, wantVal)
+			}
+			if gotModel != wantModel {
+				t.Errorf("chosen model drifted with observer: got %q want %q", gotModel, wantModel)
+			}
+			switch {
+			case wantErr == nil && gotErr != nil:
+				t.Errorf("observer introduced an error: %v", gotErr)
+			case wantErr != nil && gotErr == nil:
+				t.Errorf("observer swallowed error %v", wantErr)
+			case wantErr != nil && gotErr.Error() != wantErr.Error():
+				// Error TEXT, not just identity: sanitizeErrorForUser greps it.
+				t.Errorf("error text drifted with observer:\n got: %s\nwant: %s", gotErr, wantErr)
+			}
+		})
+	}
+}
+
+// TestObserver_ClassifiesSwitchReasons pins the three reasons apart. Collapsing
+// them into one "fallback happened" counter would page the wrong responder:
+// denied needs billing/IAM, retries_exhausted usually self-heals, and
+// budget_starved is a deadline misconfiguration nobody upstream can fix.
+func TestObserver_ClassifiesSwitchReasons(t *testing.T) {
+	t.Run("retries_exhausted", func(t *testing.T) {
+		r := &recorder{}
+		Run(context.Background(), Config{
+			Models: []string{"a", "b"}, MaxAttempts: 3, Backoff: noBackoff, Observer: r,
+		}, func(_ context.Context, m string) (string, Outcome, error) {
+			if m == "a" {
+				return "", RetrySameModel, errors.New("429")
+			}
+			return "ok", Success, nil
+		})
+		assertSwitch(t, r, ReasonRetriesExhausted, 3)
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		r := &recorder{}
+		Run(context.Background(), Config{
+			Models: []string{"a", "b"}, MaxAttempts: 3, Backoff: noBackoff, Observer: r,
+		}, func(_ context.Context, m string) (string, Outcome, error) {
+			if m == "a" {
+				return "", ClassifyStatus(http.StatusForbidden), errors.New("SCP explicit deny")
+			}
+			return "ok", Success, nil
+		})
+		// A 403 must not burn the retry budget before escalating.
+		assertSwitch(t, r, ReasonDenied, 1)
+	})
+
+	// budget_starved is reproduced with the SHIPPED agent defaults, so this test
+	// fails the day someone retunes them into a sane relationship — which is the
+	// point: the reason should stop firing once the config is fixed.
+	t.Run("budget_starved under shipped 240s/180s defaults", func(t *testing.T) {
+		const stepTimeout = 240 * time.Second // agent/profile.go StepTimeout
+		const perModel = 180 * time.Second    // LLM_TIMEOUT default
+
+		ctx, cancel := context.WithTimeout(context.Background(), stepTimeout)
+		defer cancel()
+
+		r := &recorder{}
+		Run(ctx, Config{
+			Models: []string{"a", "b"}, PerModelTimeout: perModel, MaxAttempts: 3,
+			Backoff: noBackoff, Observer: r,
+		}, func(_ context.Context, m string) (string, Outcome, error) {
+			if m == "a" {
+				return "", RetrySameModel, errors.New("429")
+			}
+			return "ok", Success, nil
+		})
+		// spent=1: the guard fires before the second attempt, which is exactly
+		// the signature that distinguishes starvation from a real exhaustion.
+		assertSwitch(t, r, ReasonBudgetStarved, 1)
+	})
+}
+
+func assertSwitch(t *testing.T, r *recorder, want SwitchReason, wantAttempts int) {
+	t.Helper()
+	if len(r.switches) != 1 {
+		t.Fatalf("expected exactly 1 switch, got %d: %+v", len(r.switches), r.switches)
+	}
+	got := r.switches[0]
+	if got.Reason != want {
+		t.Errorf("reason = %q, want %q (err: %v)", got.Reason, want, got.Err)
+	}
+	if got.Attempts != wantAttempts {
+		t.Errorf("attempts spent on the abandoned model = %d, want %d", got.Attempts, wantAttempts)
+	}
+	if got.FromPos != PositionPrimary {
+		t.Errorf("from_position = %q, want %q", got.FromPos, PositionPrimary)
+	}
+}
+
+// TestObserver_ResultReportsServingPosition covers the headline degradation
+// signal: whether the answer came from the primary or a fallback.
+func TestObserver_ResultReportsServingPosition(t *testing.T) {
+	r := &recorder{}
+	Run(context.Background(), Config{
+		Models: []string{"a", "b"}, MaxAttempts: 1, Backoff: noBackoff, Observer: r,
+		Path: PathAgentChat,
+	}, func(_ context.Context, m string) (string, Outcome, error) {
+		if m == "a" {
+			return "", RetrySameModel, errors.New("down")
+		}
+		return "ok", Success, nil
+	})
+
+	if len(r.results) != 1 {
+		t.Fatalf("expected 1 result event, got %d", len(r.results))
+	}
+	res := r.results[0]
+	if !res.OK || res.Position != PositionFallback || res.Model != "b" {
+		t.Errorf("result = %+v; want OK on fallback model b", res)
+	}
+	if res.Switches != 1 {
+		t.Errorf("switches = %d, want 1", res.Switches)
+	}
+	if res.Path != PathAgentChat {
+		t.Errorf("path = %q, want %q", res.Path, PathAgentChat)
+	}
+}
+
+// TestObserver_PathFromContext covers the generic entry points: LLMClient.Call
+// serves worker Map, worker Reduce and API refine, so the path has to ride the
+// context rather than the Config.
+func TestObserver_PathFromContext(t *testing.T) {
+	r := &recorder{}
+	ctx := WithPath(context.Background(), PathWorkerReduce)
+	Run(ctx, Config{Models: []string{"a"}, MaxAttempts: 1, Observer: r},
+		func(_ context.Context, m string) (string, Outcome, error) { return "ok", Success, nil })
+
+	if len(r.results) != 1 || r.results[0].Path != PathWorkerReduce {
+		t.Fatalf("path did not come from context: %+v", r.results)
+	}
+
+	// Config.Path must win over the context value.
+	r2 := &recorder{}
+	Run(ctx, Config{Models: []string{"a"}, MaxAttempts: 1, Observer: r2, Path: PathAgentChat},
+		func(_ context.Context, m string) (string, Outcome, error) { return "ok", Success, nil })
+	if r2.results[0].Path != PathAgentChat {
+		t.Errorf("Config.Path should override context, got %q", r2.results[0].Path)
+	}
+}
+
+// TestObserver_NilIsSafe guards the default path: no observer installed must not
+// panic and must not cost a nil check at every call site.
+func TestObserver_NilIsSafe(t *testing.T) {
+	SetDefaultObserver(nil)
+	val, model, err := Run(context.Background(), Config{Models: []string{"a"}, MaxAttempts: 1},
+		func(_ context.Context, m string) (string, Outcome, error) { return "ok", Success, nil })
+	if val != "ok" || model != "a" || err != nil {
+		t.Fatalf("got (%q,%q,%v)", val, model, err)
+	}
+}
+
+// TestRun_PreservesSanitizerMatchableText pins the user-facing contract that the
+// error-text-is-user-facing rule describes. worker.sanitizeErrorForUser selects
+// the Chinese message a user receives in their IM DM by substring-matching the
+// internal error, so a wrapped error that loses the matched substring silently
+// downgrades a specific message ("AI 处理超时，请稍后重试") to the generic one.
+//
+// The substrings below are copied from the whitelist in
+// internal/worker/personal_processor.go; this test fails if wrapping in Run ever
+// stops preserving them.
+func TestRun_PreservesSanitizerMatchableText(t *testing.T) {
+	t.Run("deadline text survives multi-model wrapping", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already-dead parent
+
+		_, _, err := Run(ctx, Config{Models: []string{"a", "b"}, MaxAttempts: 3, Backoff: noBackoff},
+			func(_ context.Context, _ string) (string, Outcome, error) {
+				return "", RetrySameModel, errors.New("unused")
+			})
+		if err == nil {
+			t.Fatal("expected an error from a cancelled parent")
+		}
+		if !strings.Contains(err.Error(), context.Canceled.Error()) {
+			t.Errorf("cancellation text lost through Run: %q", err)
+		}
+	})
+
+	t.Run("upstream API error text survives multi-model wrapping", func(t *testing.T) {
+		// "LLM API error" is the substring the whitelist keys on for the
+		// "AI 服务暂时不可用" message.
+		_, _, err := Run(context.Background(), Config{Models: []string{"a", "b"}, MaxAttempts: 2, Backoff: noBackoff},
+			func(_ context.Context, m string) (string, Outcome, error) {
+				return "", RetrySameModel, fmt.Errorf("LLM API error: status=503 model=%s", m)
+			})
+		if err == nil {
+			t.Fatal("expected an error when every model fails")
+		}
+		if !strings.Contains(err.Error(), "LLM API error") {
+			t.Errorf("upstream error text lost through wrapping: %q", err)
+		}
+	})
+
+	t.Run("deadline text survives the budget-starved guard", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+		defer cancel()
+
+		_, _, err := Run(ctx, Config{
+			Models: []string{"a", "b"}, PerModelTimeout: 180 * time.Second,
+			MaxAttempts: 3, Backoff: noBackoff,
+		}, func(_ context.Context, _ string) (string, Outcome, error) {
+			return "", RetrySameModel, context.DeadlineExceeded
+		})
+		if err == nil {
+			t.Fatal("expected an error when every model fails")
+		}
+		if !strings.Contains(err.Error(), "context deadline exceeded") {
+			t.Errorf("deadline text lost through the starvation guard: %q", err)
+		}
+		// The Unwrap chain matters too, not just the text: internal/agent's
+		// tool_error.go:70 classifies with errors.Is(err, context.DeadlineExceeded).
+		// A guard error that stops unwrapping would silently reclassify a timeout.
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("errors.Is chain broken through the starvation guard: %v", err)
+		}
+	})
+}
+
+// TestReasonFor_RealProductionErrorShapes pins the classification against the
+// error shapes production actually produces, rather than the bare sentinels a
+// unit test reaches for first.
+//
+// The regression this exists for: every call site wraps its attempt in its own
+// per-attempt context (agent attemptChat, service CallWithTools). A merely slow
+// upstream trips that INNER deadline while the parent Run context is healthy,
+// so the attempt error wraps context.DeadlineExceeded even though nothing was
+// cancelled. Classifying on the sentinel reported those switches as
+// "cancelled" and left retries_exhausted reading ~0 during exactly the incident
+// the metric exists to surface.
+func TestReasonFor_RealProductionErrorShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want SwitchReason
+	}{
+		{
+			name: "per-attempt timeout on a healthy parent is upstream overload",
+			err:  fmt.Errorf("http do: %w", context.DeadlineExceeded),
+			want: ReasonRetriesExhausted,
+		},
+		{
+			name: "url.Error wrapping the inner deadline, as net/http returns it",
+			err:  fmt.Errorf("model %q failed after 3 attempt(s): %w", "primary", fmt.Errorf("Post \"http://gw\": %w", context.DeadlineExceeded)),
+			want: ReasonRetriesExhausted,
+		},
+		{
+			name: "plain 429",
+			err:  errors.New("LLM API error: status=429"),
+			want: ReasonRetriesExhausted,
+		},
+		{
+			name: "starvation still wins even though it wraps a deadline",
+			err:  &budgetStarvedErr{model: "p", budget: time.Minute, spent: 1, wrapped: context.DeadlineExceeded},
+			want: ReasonBudgetStarved,
+		},
+		{
+			name: "denial still wins over a wrapped deadline",
+			err:  &deniedErr{model: "p", spent: 1, wrapped: fmt.Errorf("403: %w", context.DeadlineExceeded)},
+			want: ReasonDenied,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reasonFor(tc.err); got != tc.want {
+				t.Errorf("reasonFor = %q, want %q (err: %v)", got, tc.want, tc.err)
+			}
+		})
+	}
+}
+
+// TestRun_CancellationIsFlaggedNotReportedAsExhaustion pins the second half of
+// the same problem: a caller walking away must not look like a total outage.
+func TestRun_CancellationIsFlaggedNotReportedAsExhaustion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := &recorder{}
+	Run(ctx, Config{Models: []string{"a", "b"}, MaxAttempts: 2, Backoff: noBackoff, Observer: r},
+		func(_ context.Context, _ string) (string, Outcome, error) {
+			return "ok", Success, nil
+		})
+
+	if len(r.results) != 1 {
+		t.Fatalf("expected exactly 1 result event, got %d", len(r.results))
+	}
+	got := r.results[0]
+	if !got.Cancelled {
+		t.Error("caller cancellation was not flagged; it is indistinguishable from total exhaustion")
+	}
+	if got.OK {
+		t.Error("a cancelled run must not report OK")
+	}
+}
+
+// TestRun_EmptyModelListIsObserved covers the one exit that used to return
+// before any observer call: a deployment configured with no models failed every
+// request while the counters stayed flat.
+func TestRun_EmptyModelListIsObserved(t *testing.T) {
+	r := &recorder{}
+	_, _, err := Run(context.Background(), Config{Models: nil, MaxAttempts: 3, Observer: r},
+		func(_ context.Context, _ string) (string, Outcome, error) {
+			t.Fatal("attempt must not run with no models configured")
+			return "", Terminal, nil
+		})
+	if err == nil {
+		t.Fatal("expected an error for an empty model list")
+	}
+	if len(r.results) != 1 {
+		t.Fatalf("misconfiguration produced %d result events, want 1", len(r.results))
+	}
+	if r.results[0].OK {
+		t.Error("empty model list reported OK")
+	}
+}
+
+// TestRun_AttemptEventCarriesBudget lets a consumer tell "will retry" from
+// "this was the last attempt" — the retry log claimed a retry was coming even
+// on the final attempt before this was plumbed through.
+func TestRun_AttemptEventCarriesBudget(t *testing.T) {
+	r := &recorder{}
+	Run(context.Background(), Config{Models: []string{"solo"}, MaxAttempts: 3, Backoff: noBackoff, Observer: r},
+		func(_ context.Context, _ string) (string, Outcome, error) {
+			return "", RetrySameModel, errors.New("503")
+		})
+
+	if len(r.attempts) != 3 {
+		t.Fatalf("expected 3 attempts, got %d", len(r.attempts))
+	}
+	for i, a := range r.attempts {
+		if a.MaxAttempts != 3 {
+			t.Errorf("attempt %d: MaxAttempts = %d, want 3", i+1, a.MaxAttempts)
+		}
+		if a.Attempt != i+1 {
+			t.Errorf("attempt %d: Attempt = %d, want %d (1-based)", i+1, a.Attempt, i+1)
+		}
+	}
+	// The last one must be identifiable as final: no retry follows it.
+	last := r.attempts[len(r.attempts)-1]
+	if last.Attempt < last.MaxAttempts {
+		t.Errorf("final attempt %d/%d does not read as final", last.Attempt, last.MaxAttempts)
+	}
+}

--- a/internal/llmobs/default.go
+++ b/internal/llmobs/default.go
@@ -1,0 +1,38 @@
+package llmobs
+
+import (
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+)
+
+// defaultMetrics holds the process-wide metric set so the /metrics handler can
+// render it without threading the Observer through the router signature.
+var defaultMetrics atomic.Pointer[Metrics]
+
+// Install builds the production Observer, registers it as llmfallback's
+// process-wide default and returns it. Call once from a composition root
+// (cmd/summary-api, cmd/summary-worker) before serving traffic.
+//
+// After this runs, every llmfallback.Run in the process is instrumented — the
+// worker's Map/Reduce, agent chat, agent tools and API refine alike — with no
+// per-call-site wiring to forget.
+func Install(logger *slog.Logger) *Observer {
+	m := NewMetrics(nil)
+	obs := New(m, logger)
+	defaultMetrics.Store(m)
+	llmfallback.SetDefaultObserver(obs)
+	return obs
+}
+
+// Default returns the installed metric set, or nil when Install has not run.
+func Default() *Metrics { return defaultMetrics.Load() }
+
+// ResetDefaultForTest clears the process-wide metric set. Tests need this
+// because Install publishes a singleton that otherwise leaks across cases —
+// a nil-guard test that cannot restore the un-installed state silently stops
+// asserting once any earlier test has installed.
+func ResetDefaultForTest() {
+	defaultMetrics.Store(nil)
+}

--- a/internal/llmobs/metrics.go
+++ b/internal/llmobs/metrics.go
@@ -55,7 +55,12 @@ func labels(pairs ...string) labelSet {
 // separator so it cannot forge a line, but leaving a bare CR in a value makes
 // log/terminal output overwrite itself, and SafeTextForLog already strips it
 // elsewhere in this codebase.
-var labelEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`)
+// CR is replaced with a space, NOT escaped as \r. The Prometheus text format
+// defines only \\, \" and \n inside a label value; \r is an invalid escape and
+// the reference parser aborts the ENTIRE scrape on it, not just that line. So
+// "hardening" a bare CR into \r traded one ugly character for the loss of every
+// metric in the response. Flattening matches what SafeTextForLog already does.
+var labelEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", " ")
 
 // escapeLabelValue applies the Prometheus text-format escaping rules.
 func escapeLabelValue(v string) string {
@@ -159,9 +164,9 @@ func NewMetrics(nowFn func() time.Time) *Metrics {
 		attempts: newCounterVec("llm_attempts_total",
 			"Upstream LLM attempts by call path, model, list position and classified outcome."),
 		switches: newCounterVec("llm_model_switch_total",
-			"Cross-model fallback switches. reason=denied is a credential/billing problem, retries_exhausted is upstream overload, budget_starved is a deadline misconfiguration."),
+			"Cross-model fallback switches. reason=denied means the provider refused this request for this model (HTTP 403 — credentials, entitlement, a WAF rule or a regional restriction); retries_exhausted means the per-model retry budget ran out, usually upstream overload, though a deterministic contract failure (undecodable response, no choices) also lands here; budget_starved means the deadline guard abandoned the remaining retries, which is a configuration fault."),
 		calls: newCounterVec("llm_calls_total",
-			"Completed LLM calls by call path, the position of the model that served them, and the outcome: ok, failed (no model could serve it), or cancelled (the caller went away — not an upstream fault, do not alert on it)."),
+			"Completed LLM calls by call path, the position of the model that served them, and the outcome: ok; failed (no model could serve it); cancelled (the caller went away — not an upstream fault, do not alert on it); timeout (our own deadline expired before any model answered — nobody walked away, so this one IS alertable)."),
 		callSecs: newCounterVec("llm_call_duration_seconds_total",
 			"Cumulative wall-clock seconds spent in llmfallback.Run, by call path. Labelled by path only, so a mean needs sum by(path)(llm_call_duration_seconds_total) / sum by(path)(llm_calls_total) — dividing the raw series returns an empty vector."),
 		lastOK: newGaugeVec("llm_primary_last_success_timestamp_seconds",
@@ -200,8 +205,10 @@ func (m *Metrics) ObserveResult(e llmfallback.ResultEvent) {
 	switch {
 	case e.OK:
 		result = "ok"
-	case e.Cancelled:
+	case e.End == llmfallback.RunEndCancelled:
 		result = "cancelled"
+	case e.End == llmfallback.RunEndTimedOut:
+		result = "timeout"
 	}
 	position := e.Position
 	if position == "" {

--- a/internal/llmobs/metrics.go
+++ b/internal/llmobs/metrics.go
@@ -1,0 +1,240 @@
+// Package llmobs turns llmfallback's Run events into operational signal:
+// structured logs and scrapeable counters.
+//
+// Why a hand-rolled registry instead of prometheus/client_golang: adding that
+// module to this repo currently drags upgrades to golang.org/x/crypto,
+// golang.org/x/net, golang.org/x/sys, golang.org/x/text and protobuf, which
+// this repo's dependency-review / osv-scanner workflows must then re-clear.
+// The counters below emit the standard Prometheus text exposition format, so a
+// scraper cannot tell the difference. llmfallback.Observer is the seam: swapping
+// in client_golang later is a change to this package only, with no edit to any
+// call site.
+package llmobs
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+)
+
+// labelSet is a bounded, ordered key/value list used as a map key. Every label
+// value fed into it comes from configuration (model ids) or a closed constant
+// set (path, position, outcome, reason) — never from request data — so the
+// series count stays bounded by models * paths.
+type labelSet string
+
+func labels(pairs ...string) labelSet {
+	if len(pairs)%2 != 0 {
+		panic("llmobs: labels requires key/value pairs")
+	}
+	var b strings.Builder
+	for i := 0; i < len(pairs); i += 2 {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(pairs[i])
+		b.WriteString("=\"")
+		b.WriteString(escapeLabelValue(pairs[i+1]))
+		b.WriteString("\"")
+	}
+	return labelSet(b.String())
+}
+
+// labelEscaper is built once at package scope, NOT per call. strings.NewReplacer
+// compiles a trie on construction, so building it inside escapeLabelValue cost
+// ~3.5µs and 6.7KB of garbage per label value (measured) against ~26ns and zero
+// allocations when hoisted — and escapeLabelValue runs on every label of every
+// event on the LLM hot path.
+//
+// \r is escaped alongside the three the text format requires: it is not a
+// separator so it cannot forge a line, but leaving a bare CR in a value makes
+// log/terminal output overwrite itself, and SafeTextForLog already strips it
+// elsewhere in this codebase.
+var labelEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`)
+
+// escapeLabelValue applies the Prometheus text-format escaping rules.
+func escapeLabelValue(v string) string {
+	return labelEscaper.Replace(v)
+}
+
+// counterVec is a labelled monotonic counter.
+type counterVec struct {
+	name string
+	help string
+	mu   sync.Mutex
+	vals map[labelSet]float64
+}
+
+func newCounterVec(name, help string) *counterVec {
+	return &counterVec{name: name, help: help, vals: map[labelSet]float64{}}
+}
+
+func (c *counterVec) inc(l labelSet) { c.add(l, 1) }
+
+func (c *counterVec) add(l labelSet, delta float64) {
+	c.mu.Lock()
+	c.vals[l] += delta
+	c.mu.Unlock()
+}
+
+func (c *counterVec) write(w io.Writer) {
+	c.mu.Lock()
+	keys := make([]labelSet, 0, len(c.vals))
+	for k := range c.vals {
+		keys = append(keys, k)
+	}
+	snapshot := make(map[labelSet]float64, len(c.vals))
+	for k, v := range c.vals {
+		snapshot[k] = v
+	}
+	c.mu.Unlock()
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n", c.name, c.help, c.name)
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s{%s} %g\n", c.name, k, snapshot[k])
+	}
+}
+
+// gaugeVec is a labelled last-write-wins gauge.
+type gaugeVec struct {
+	name string
+	help string
+	mu   sync.Mutex
+	vals map[labelSet]float64
+}
+
+func newGaugeVec(name, help string) *gaugeVec {
+	return &gaugeVec{name: name, help: help, vals: map[labelSet]float64{}}
+}
+
+func (g *gaugeVec) set(l labelSet, v float64) {
+	g.mu.Lock()
+	g.vals[l] = v
+	g.mu.Unlock()
+}
+
+func (g *gaugeVec) write(w io.Writer) {
+	g.mu.Lock()
+	keys := make([]labelSet, 0, len(g.vals))
+	for k := range g.vals {
+		keys = append(keys, k)
+	}
+	snapshot := make(map[labelSet]float64, len(g.vals))
+	for k, v := range g.vals {
+		snapshot[k] = v
+	}
+	g.mu.Unlock()
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", g.name, g.help, g.name)
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s{%s} %g\n", g.name, k, snapshot[k])
+	}
+}
+
+// Metrics is the LLM fallback metric set. The zero value is not usable; call
+// NewMetrics.
+type Metrics struct {
+	attempts *counterVec
+	switches *counterVec
+	calls    *counterVec
+	callSecs *counterVec
+	lastOK   *gaugeVec
+	nowFn    func() time.Time
+}
+
+// NewMetrics builds the metric set. nowFn is injectable for tests; nil uses
+// time.Now.
+func NewMetrics(nowFn func() time.Time) *Metrics {
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	return &Metrics{
+		attempts: newCounterVec("llm_attempts_total",
+			"Upstream LLM attempts by call path, model, list position and classified outcome."),
+		switches: newCounterVec("llm_model_switch_total",
+			"Cross-model fallback switches. reason=denied is a credential/billing problem, retries_exhausted is upstream overload, budget_starved is a deadline misconfiguration."),
+		calls: newCounterVec("llm_calls_total",
+			"Completed LLM calls by call path, the position of the model that served them, and the outcome: ok, failed (no model could serve it), or cancelled (the caller went away — not an upstream fault, do not alert on it)."),
+		callSecs: newCounterVec("llm_call_duration_seconds_total",
+			"Cumulative wall-clock seconds spent in llmfallback.Run, by call path. Labelled by path only, so a mean needs sum by(path)(llm_call_duration_seconds_total) / sum by(path)(llm_calls_total) — dividing the raw series returns an empty vector."),
+		lastOK: newGaugeVec("llm_primary_last_success_timestamp_seconds",
+			"Unix timestamp of the most recent successful call served by the PRIMARY model, per call path. A stale value means sustained silent degradation onto a fallback."),
+		nowFn: nowFn,
+	}
+}
+
+// ObserveAttempt implements llmfallback.Observer.
+func (m *Metrics) ObserveAttempt(e llmfallback.AttemptEvent) {
+	m.attempts.inc(labels(
+		"path", string(e.Path),
+		"model", e.Model,
+		"position", e.Position,
+		"outcome", outcomeLabel(e.Outcome),
+	))
+}
+
+// ObserveSwitch implements llmfallback.Observer.
+func (m *Metrics) ObserveSwitch(e llmfallback.SwitchEvent) {
+	m.switches.inc(labels(
+		"path", string(e.Path),
+		"from", e.From,
+		"to", e.To,
+		"reason", string(e.Reason),
+	))
+}
+
+// ObserveResult implements llmfallback.Observer.
+func (m *Metrics) ObserveResult(e llmfallback.ResultEvent) {
+	// "cancelled" is kept apart from "failed" on purpose. A caller walking away
+	// (an SSE client closing the tab, a shutdown) arrives with OK=false and an
+	// empty Model — byte-identical to a total provider outage. Folding them
+	// together put user-initiated disconnects onto the series operators page on.
+	result := "failed"
+	switch {
+	case e.OK:
+		result = "ok"
+	case e.Cancelled:
+		result = "cancelled"
+	}
+	position := e.Position
+	if position == "" {
+		position = "none"
+	}
+	m.calls.inc(labels("path", string(e.Path), "position", position, "result", result))
+	m.callSecs.add(labels("path", string(e.Path)), e.Duration.Seconds())
+
+	if e.OK && e.Position == llmfallback.PositionPrimary {
+		m.lastOK.set(labels("path", string(e.Path)), float64(m.nowFn().Unix()))
+	}
+}
+
+// WritePrometheus renders the metric set in Prometheus text exposition format.
+func (m *Metrics) WritePrometheus(w io.Writer) {
+	m.attempts.write(w)
+	m.switches.write(w)
+	m.calls.write(w)
+	m.callSecs.write(w)
+	m.lastOK.write(w)
+}
+
+func outcomeLabel(o llmfallback.Outcome) string {
+	switch o {
+	case llmfallback.Success:
+		return "success"
+	case llmfallback.RetrySameModel:
+		return "retry_same_model"
+	case llmfallback.TryNextModel:
+		return "try_next_model"
+	case llmfallback.Terminal:
+		return "terminal"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/llmobs/metrics_test.go
+++ b/internal/llmobs/metrics_test.go
@@ -528,17 +528,36 @@ func TestInstall_ExhaustionAndCancellationAreDistinct(t *testing.T) {
 			return "", llmfallback.ClassifyStatus(http.StatusServiceUnavailable), errors.New("503")
 		})
 
-	// 2. The caller goes away — an SSE client closing the tab.
+	// 2. The caller goes away mid-request — an SSE client closing the tab.
+	// Cancelled from INSIDE the attempt, because that is the exit production
+	// takes: both clients check the parent ctx and return Terminal. Cancelling
+	// before Run only ever exercised the top-of-loop guard.
 	cancelled, cancel := context.WithCancel(context.Background())
-	cancel()
 	llmfallback.Run(
 		llmfallback.WithPath(cancelled, llmfallback.PathAPIRefine),
 		llmfallback.Config{
 			Models: []string{"a-live", "b-live"}, MaxAttempts: 1,
 			Backoff: func(int) time.Duration { return 0 },
 		},
-		func(_ context.Context, _ string) (string, llmfallback.Outcome, error) {
-			return "ok", llmfallback.Success, nil
+		func(actx context.Context, _ string) (string, llmfallback.Outcome, error) {
+			cancel()
+			return "", llmfallback.Terminal, actx.Err()
+		})
+
+	// 3. Our own budget expires while upstream is slow. This must NOT share a
+	// series with either the outage or the disconnect: nobody walked away, and
+	// no model was proven bad — it is its own alertable condition.
+	timedOut, cancelTimeout := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelTimeout()
+	llmfallback.Run(
+		llmfallback.WithPath(timedOut, llmfallback.PathAgentChat),
+		llmfallback.Config{
+			Models: []string{"slow-a", "slow-b"}, MaxAttempts: 1,
+			Backoff: func(int) time.Duration { return 0 },
+		},
+		func(context.Context, string) (string, llmfallback.Outcome, error) {
+			time.Sleep(40 * time.Millisecond)
+			return "", llmfallback.ClassifyStatus(http.StatusServiceUnavailable), errors.New("503 slow")
 		})
 
 	var buf bytes.Buffer
@@ -548,11 +567,19 @@ func TestInstall_ExhaustionAndCancellationAreDistinct(t *testing.T) {
 	if got := mustSample(t, out, `llm_calls_total{path="worker_reduce",position="none",result="failed"}`); got != 1 {
 		t.Errorf("exhausted call = %v, want 1 — Run must emit a result event when every model fails", got)
 	}
-	if got := mustSample(t, out, `llm_calls_total{path="api_refine",position="none",result="cancelled"}`); got != 1 {
+	// The cancelled run reached the Terminal exit, so it carries the position of
+	// the model that was in flight — what matters is the result label.
+	if got := mustSample(t, out, `llm_calls_total{path="api_refine",position="primary",result="cancelled"}`); got != 1 {
 		t.Errorf("cancelled call = %v, want 1", got)
 	}
-	if v, ok := sampleValue(t, out, `llm_calls_total{path="api_refine",position="none",result="failed"}`); ok {
+	if v, ok := sampleValue(t, out, `llm_calls_total{path="api_refine",position="primary",result="failed"}`); ok {
 		t.Errorf("caller cancellation was counted as an upstream failure (%v); it must not land on the series operators alert on", v)
+	}
+	if got := mustSample(t, out, `llm_calls_total{path="agent_chat",position="none",result="timeout"}`); got != 1 {
+		t.Errorf("timed-out call = %v, want 1", got)
+	}
+	if v, ok := sampleValue(t, out, `llm_calls_total{path="agent_chat",position="none",result="cancelled"}`); ok {
+		t.Errorf("our own deadline expiring was labelled cancelled (%v) — that label documents itself as 'do not alert on it', which would bury a real incident", v)
 	}
 }
 
@@ -579,5 +606,36 @@ func TestInstall_TerminalFailureIsNotCountedOK(t *testing.T) {
 	}
 	if v, ok := sampleValue(t, out, `llm_calls_total{path="agent_chat",position="primary",result="ok"}`); ok {
 		t.Errorf("a terminal failure was counted as ok (%v)", v)
+	}
+}
+
+// TestWritePrometheus_CarriageReturnIsFlattenedNotEscaped pins the one escape
+// that must NOT be produced. The Prometheus text format defines only \\, \" and
+// \n inside a label value; \r is an invalid escape sequence and the reference
+// parser aborts the ENTIRE scrape on it — so "hardening" a bare CR into \r
+// trades one ugly character for the loss of every metric in the response.
+// Nothing covered this, which is how it shipped.
+func TestWritePrometheus_CarriageReturnIsFlattenedNotEscaped(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	m.ObserveAttempt(llmfallback.AttemptEvent{
+		Path:     llmfallback.PathAgentChat,
+		Model:    "we\rird-model",
+		Position: llmfallback.PositionPrimary, Attempt: 1, MaxAttempts: 3,
+		Outcome: llmfallback.Success,
+	})
+
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	out := buf.String()
+
+	if strings.Contains(out, `\r`) {
+		t.Errorf("emitted the invalid escape sequence \\r; the reference parser aborts the whole scrape on it:\n%s", out)
+	}
+	if strings.ContainsRune(out, '\r') {
+		t.Errorf("emitted a bare CR inside a label value:\n%q", out)
+	}
+	// And the series is still there, flattened rather than dropped.
+	if !strings.Contains(out, `model="we ird-model"`) {
+		t.Errorf("CR should flatten to a space, keeping the series intact:\n%s", out)
 	}
 }

--- a/internal/llmobs/metrics_test.go
+++ b/internal/llmobs/metrics_test.go
@@ -1,0 +1,583 @@
+package llmobs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+)
+
+func fixedNow() time.Time { return time.Unix(1700000000, 0) }
+
+// advancingClock moves forward one second per read, so a gauge that is refreshed
+// when it should not be produces a DIFFERENT value. A fixed clock cannot
+// distinguish "refreshed wrongly" from "not refreshed" and makes any
+// last-success assertion vacuous.
+func advancingClock() func() time.Time {
+	var n int64
+	return func() time.Time {
+		n++
+		return time.Unix(1700000000+n, 0)
+	}
+}
+
+// parseExposition splits Prometheus text output into metric families and sample
+// lines so the assertions below read against structure rather than substrings.
+type family struct {
+	help    string
+	typ     string
+	samples []string
+}
+
+func parseExposition(t *testing.T, out string) map[string]*family {
+	t.Helper()
+	fams := map[string]*family{}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		switch {
+		case line == "":
+			continue
+		case strings.HasPrefix(line, "# HELP "):
+			rest := strings.TrimPrefix(line, "# HELP ")
+			name, help, ok := strings.Cut(rest, " ")
+			if !ok {
+				t.Errorf("HELP line has no help text: %q", line)
+			}
+			if fams[name] == nil {
+				fams[name] = &family{}
+			}
+			if fams[name].help != "" {
+				t.Errorf("duplicate HELP for %q", name)
+			}
+			fams[name].help = help
+		case strings.HasPrefix(line, "# TYPE "):
+			rest := strings.TrimPrefix(line, "# TYPE ")
+			name, typ, ok := strings.Cut(rest, " ")
+			if !ok {
+				t.Errorf("TYPE line has no type: %q", line)
+			}
+			if fams[name] == nil {
+				fams[name] = &family{}
+			}
+			fams[name].typ = typ
+		case strings.HasPrefix(line, "#"):
+			t.Errorf("unrecognised comment line: %q", line)
+		default:
+			name, _, ok := strings.Cut(line, "{")
+			if !ok {
+				t.Errorf("sample line is not name{labels} value: %q", line)
+				continue
+			}
+			if fams[name] == nil {
+				t.Errorf("sample for %q has no HELP/TYPE header", name)
+				continue
+			}
+			fams[name].samples = append(fams[name].samples, line)
+		}
+	}
+	return fams
+}
+
+func feedOneSwitchedCall(m *Metrics) {
+	m.ObserveAttempt(llmfallback.AttemptEvent{
+		Path: llmfallback.PathWorkerMap, Model: "primary-a", Position: llmfallback.PositionPrimary,
+		Attempt: 1, Outcome: llmfallback.RetrySameModel,
+	})
+	m.ObserveSwitch(llmfallback.SwitchEvent{
+		Path: llmfallback.PathWorkerMap, From: "primary-a", To: "fallback-b",
+		FromPos: llmfallback.PositionPrimary, Reason: llmfallback.ReasonRetriesExhausted, Attempts: 3,
+	})
+	m.ObserveAttempt(llmfallback.AttemptEvent{
+		Path: llmfallback.PathWorkerMap, Model: "fallback-b", Position: llmfallback.PositionFallback,
+		Attempt: 1, Outcome: llmfallback.Success,
+	})
+	m.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathWorkerMap, Model: "fallback-b", Position: llmfallback.PositionFallback,
+		Switches: 1, OK: true, Duration: 250 * time.Millisecond,
+	})
+}
+
+// TestWritePrometheus_ExpositionFormat checks the output a scraper actually
+// parses: every family carries exactly one HELP and one TYPE header before its
+// samples, and every sample is well formed.
+func TestWritePrometheus_ExpositionFormat(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	feedOneSwitchedCall(m)
+
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	fams := parseExposition(t, buf.String())
+
+	// Same vacuity guard as above: assert the set actually carries samples
+	// before checking their shape.
+	if got := len(fams["llm_attempts_total"].samples); got == 0 {
+		t.Fatal("no attempt series emitted; the exposition assertions below would be vacuous")
+	}
+
+	want := map[string]string{
+		"llm_attempts_total":                         "counter",
+		"llm_model_switch_total":                     "counter",
+		"llm_calls_total":                            "counter",
+		"llm_call_duration_seconds_total":            "counter",
+		"llm_primary_last_success_timestamp_seconds": "gauge",
+	}
+	for name, typ := range want {
+		f := fams[name]
+		if f == nil {
+			t.Errorf("missing metric family %q", name)
+			continue
+		}
+		if f.help == "" {
+			t.Errorf("%s: missing HELP text", name)
+		}
+		if f.typ != typ {
+			t.Errorf("%s: TYPE = %q, want %q", name, f.typ, typ)
+		}
+	}
+
+	// The value on every sample line must parse as a float.
+	for name, f := range fams {
+		for _, s := range f.samples {
+			_, val, _ := strings.Cut(s, "} ")
+			if _, err := strconv.ParseFloat(val, 64); err != nil {
+				t.Errorf("%s: sample value %q is not a float: %v", name, val, err)
+			}
+		}
+	}
+}
+
+// TestWritePrometheus_SeriesAreSorted keeps scrape output stable across writes,
+// so a diff of two scrapes shows real changes rather than map iteration order.
+func TestWritePrometheus_SeriesAreSorted(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	for _, model := range []string{"zeta", "alpha", "mu"} {
+		m.ObserveAttempt(llmfallback.AttemptEvent{
+			Path: llmfallback.PathAgentChat, Model: model,
+			Position: llmfallback.PositionPrimary, Attempt: 1, Outcome: llmfallback.Success,
+		})
+	}
+	var a, b bytes.Buffer
+	m.WritePrometheus(&a)
+	m.WritePrometheus(&b)
+	if a.String() != b.String() {
+		t.Fatal("two consecutive scrapes differ; series are not deterministically ordered")
+	}
+
+	fams := parseExposition(t, a.String())
+	got := fams["llm_attempts_total"].samples
+	if !sortedStrings(got) {
+		t.Errorf("samples are not sorted:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+func sortedStrings(s []string) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i-1] > s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestWritePrometheus_EscapesLabelValues guards against a model id containing a
+// quote, backslash or newline breaking the exposition format — an unescaped
+// value would corrupt every following line of the scrape, not just its own.
+func TestWritePrometheus_EscapesLabelValues(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	m.ObserveAttempt(llmfallback.AttemptEvent{
+		Path:     llmfallback.PathAgentChat,
+		Model:    `we"ird\model` + "\nllm_injected_total{a=\"b\"} 99",
+		Position: llmfallback.PositionPrimary, Attempt: 1, Outcome: llmfallback.Success,
+	})
+
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	out := buf.String()
+
+	if strings.Contains(out, "llm_injected_total") && !strings.Contains(out, `\nllm_injected_total`) {
+		t.Error("a newline in a model id injected a forged metric line")
+	}
+	for _, frag := range []string{`we\"ird`, `\\model`, `\n`} {
+		if !strings.Contains(out, frag) {
+			t.Errorf("expected escaped fragment %q in output:\n%s", frag, out)
+		}
+	}
+	// The forged line must not survive as its own parsed sample.
+	fams := parseExposition(t, out)
+	if fams["llm_injected_total"] != nil {
+		t.Error("forged metric family parsed out of an escaped label value")
+	}
+}
+
+// TestMetrics_LabelCardinalityIsBounded is the guard the brief calls for: series
+// count must be a function of (models x paths x closed constant sets) only.
+// Feeding a thousand distinct task-shaped strings through the legitimate fields
+// must not create a thousand series.
+func TestMetrics_LabelCardinalityIsBounded(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	paths := []llmfallback.Path{llmfallback.PathWorkerMap, llmfallback.PathAgentChat}
+	models := []string{"primary-a", "fallback-b"}
+
+	for i := 0; i < 1000; i++ {
+		for _, p := range paths {
+			for j, model := range models {
+				m.ObserveAttempt(llmfallback.AttemptEvent{
+					Path: p, Model: model, Position: llmfallback.PositionOf(j),
+					// Per-call varying data must never reach a label.
+					Attempt:  i % 3,
+					Duration: time.Duration(i) * time.Millisecond,
+					Err:      fmt.Errorf("task-%d chunk-%d user-%d failed", i, j, i),
+					Outcome:  llmfallback.RetrySameModel,
+				})
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	out := buf.String()
+	fams := parseExposition(t, out)
+
+	// 2 paths x 2 (model,position) pairs x 1 outcome = 4 series.
+	if got := len(fams["llm_attempts_total"].samples); got != 4 {
+		t.Errorf("llm_attempts_total has %d series, want 4 — cardinality is not bounded", got)
+	}
+	// Inspect the label sets only: a metric NAME may legitimately contain a word
+	// like "duration", but no LABEL may carry per-call data.
+	allowedKeys := map[string]bool{
+		"path": true, "model": true, "position": true,
+		"outcome": true, "reason": true, "from": true, "to": true, "result": true,
+	}
+	for name, f := range fams {
+		for _, sample := range f.samples {
+			_, rest, _ := strings.Cut(sample, "{")
+			labelPart, _, _ := strings.Cut(rest, "} ")
+			for _, kv := range strings.Split(labelPart, `","`) {
+				key, value, _ := strings.Cut(strings.Trim(kv, `"`), `="`)
+				if !allowedKeys[key] {
+					t.Errorf("%s: unexpected label key %q — only closed-set keys may be labels", name, key)
+				}
+				for _, leak := range []string{"task-", "chunk-", "user-"} {
+					if strings.Contains(value, leak) {
+						t.Errorf("%s: per-call data %q leaked into label %s=%q", name, leak, key, value)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestMetrics_PrimaryLastSuccessTracksSilentDrift covers the signal that answers
+// "how long have we been degraded?": the gauge advances only on a success served
+// by the PRIMARY, so a stale value means sustained fallback dependence even
+// while calls keep succeeding.
+func TestMetrics_PrimaryLastSuccessTracksSilentDrift(t *testing.T) {
+	m := NewMetrics(advancingClock())
+
+	m.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAgentChat, Model: "p", Position: llmfallback.PositionPrimary, OK: true,
+	})
+	first := gaugeValue(t, m, "llm_primary_last_success_timestamp_seconds")
+
+	// A fallback success must NOT refresh it — that is the whole point.
+	m.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAgentChat, Model: "f", Position: llmfallback.PositionFallback, OK: true, Switches: 1,
+	})
+	if got := gaugeValue(t, m, "llm_primary_last_success_timestamp_seconds"); got != first {
+		t.Errorf("a fallback success advanced the primary-health gauge (%v -> %v)", first, got)
+	}
+
+	// A failed primary must not refresh it either.
+	m.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAgentChat, Model: "p", Position: llmfallback.PositionPrimary, OK: false,
+	})
+	if got := gaugeValue(t, m, "llm_primary_last_success_timestamp_seconds"); got != first {
+		t.Errorf("a failed primary advanced the gauge (%v -> %v)", first, got)
+	}
+}
+
+func gaugeValue(t *testing.T, m *Metrics, name string) float64 {
+	t.Helper()
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(line, name+"{") {
+			_, val, _ := strings.Cut(line, "} ")
+			f, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				t.Fatalf("bad gauge value %q: %v", val, err)
+			}
+			return f
+		}
+	}
+	t.Fatalf("gauge %q not found in:\n%s", name, buf.String())
+	return 0
+}
+
+// TestMetrics_ExhaustedCallIsCounted covers total failure: no model served the
+// call, so it must land on position="none" rather than silently vanishing.
+func TestMetrics_ExhaustedCallIsCounted(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	m.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathWorkerReduce, Switches: 2, OK: false, Duration: time.Second,
+	})
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	out := buf.String()
+	if !strings.Contains(out, `position="none"`) || !strings.Contains(out, `result="failed"`) {
+		t.Errorf("exhausted call not counted as none/failed:\n%s", out)
+	}
+}
+
+// TestMetrics_ConcurrentUse matters because the worker runs Map chunks in
+// parallel against one process-wide Metrics. Run with -race.
+func TestMetrics_ConcurrentUse(t *testing.T) {
+	m := NewMetrics(fixedNow)
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				feedOneSwitchedCall(m)
+				if j%10 == 0 {
+					m.WritePrometheus(&bytes.Buffer{}) // concurrent scrape
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	fams := parseExposition(t, buf.String())
+	// 32 goroutines x 50 iterations, one switch each.
+	// Without this the assertion below is vacuous: WritePrometheus emits the
+	// HELP/TYPE header even with no data, so a fully disabled switch counter
+	// still yields a present family with zero samples and the loop body never
+	// runs. Verified by mutation.
+	if got := len(fams["llm_model_switch_total"].samples); got == 0 {
+		t.Fatalf("no switch series emitted; the counter is not recording")
+	}
+	for _, s := range fams["llm_model_switch_total"].samples {
+		_, val, _ := strings.Cut(s, "} ")
+		if val != "1600" {
+			t.Errorf("lost increments under concurrency: switch counter = %s, want 1600", val)
+		}
+	}
+}
+
+// TestInstall_EndToEndFromRealRun closes the gap between the two halves tested
+// above: llmfallback -> Observer is covered in the llmfallback package, and
+// Observer -> exposition is covered here, but neither proves the COMPOSED path
+// works. Without this, SetDefaultObserver could silently fail to install and
+// every test would still pass while production reported nothing.
+func TestInstall_EndToEndFromRealRun(t *testing.T) {
+	obs := Install(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	before := scrape(t, obs.Metrics())
+
+	// A real Run: primary exhausts its budget, fallback succeeds.
+	_, model, err := llmfallback.Run(
+		llmfallback.WithPath(context.Background(), llmfallback.PathWorkerReduce),
+		llmfallback.Config{
+			Models: []string{"primary-e2e", "fallback-e2e"}, MaxAttempts: 2,
+			Backoff: func(int) time.Duration { return 0 },
+		},
+		func(_ context.Context, m string) (string, llmfallback.Outcome, error) {
+			if m == "primary-e2e" {
+				return "", llmfallback.ClassifyStatus(http.StatusTooManyRequests), errors.New("429")
+			}
+			return "ok", llmfallback.Success, nil
+		})
+	if err != nil || model != "fallback-e2e" {
+		t.Fatalf("Run did not fall back as set up: model=%q err=%v", model, err)
+	}
+
+	after := scrape(t, obs.Metrics())
+	if after == before {
+		t.Fatal("a real Run produced no metric change; the default observer is not wired")
+	}
+	for _, want := range []string{
+		`llm_model_switch_total{path="worker_reduce",from="primary-e2e",to="fallback-e2e",reason="retries_exhausted"}`,
+		`llm_calls_total{path="worker_reduce",position="fallback",result="ok"}`,
+		`llm_attempts_total{path="worker_reduce",model="primary-e2e",position="primary",outcome="retry_same_model"}`,
+	} {
+		if !strings.Contains(after, want) {
+			t.Errorf("expected series missing after a real Run:\n  %s\ngot:\n%s", want, after)
+		}
+	}
+}
+
+func scrape(t *testing.T, m *Metrics) string {
+	t.Helper()
+	var buf bytes.Buffer
+	m.WritePrometheus(&buf)
+	return buf.String()
+}
+
+// sampleValue pulls the numeric value of one exact series out of a scrape.
+// Assertions built on strings.Contains of the label set alone cannot see a
+// counter that increments by 2, accumulates into the wrong metric, or records
+// milliseconds into a _seconds_total — every one of those keeps the label set
+// byte-identical. Mutation testing showed that class of defect surviving, so
+// the E2E assertions below read values, not substrings.
+func sampleValue(t *testing.T, scrape, series string) (float64, bool) {
+	t.Helper()
+	for _, line := range strings.Split(scrape, "\n") {
+		labels, val, ok := strings.Cut(line, "} ")
+		if !ok || labels+"}" != series {
+			continue
+		}
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			t.Fatalf("series %s has non-numeric value %q", series, val)
+		}
+		return f, true
+	}
+	return 0, false
+}
+
+func mustSample(t *testing.T, scrape, series string) float64 {
+	t.Helper()
+	v, ok := sampleValue(t, scrape, series)
+	if !ok {
+		t.Fatalf("series not present in scrape:\n  %s\n--- scrape ---\n%s", series, scrape)
+	}
+	return v
+}
+
+// TestInstall_EndToEndValuesAreExact drives a real Run and asserts the exact
+// counter values it must produce, not merely that some series bearing the right
+// labels exists.
+func TestInstall_EndToEndValuesAreExact(t *testing.T) {
+	obs := Install(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { llmfallback.SetDefaultObserver(nil) })
+
+	const primary, fallback = "p-exact", "f-exact"
+	var primaryTries int
+	_, model, err := llmfallback.Run(
+		llmfallback.WithPath(context.Background(), llmfallback.PathWorkerMap),
+		llmfallback.Config{
+			Models: []string{primary, fallback}, MaxAttempts: 2,
+			Backoff: func(int) time.Duration { return 0 },
+		},
+		func(_ context.Context, m string) (string, llmfallback.Outcome, error) {
+			if m == primary {
+				primaryTries++
+				return "", llmfallback.ClassifyStatus(http.StatusTooManyRequests), errors.New("429")
+			}
+			return "ok", llmfallback.Success, nil
+		})
+	if err != nil || model != fallback {
+		t.Fatalf("setup: model=%q err=%v", model, err)
+	}
+
+	var buf bytes.Buffer
+	obs.Metrics().WritePrometheus(&buf)
+	out := buf.String()
+
+	// The primary burned its full 2-attempt budget; the fallback answered first try.
+	if got := mustSample(t, out, `llm_attempts_total{path="worker_map",model="p-exact",position="primary",outcome="retry_same_model"}`); got != 2 {
+		t.Errorf("primary retry attempts = %v, want 2 (attempt fn ran %d times)", got, primaryTries)
+	}
+	if got := mustSample(t, out, `llm_attempts_total{path="worker_map",model="f-exact",position="fallback",outcome="success"}`); got != 1 {
+		t.Errorf("fallback success attempts = %v, want 1", got)
+	}
+	if got := mustSample(t, out, `llm_model_switch_total{path="worker_map",from="p-exact",to="f-exact",reason="retries_exhausted"}`); got != 1 {
+		t.Errorf("switches = %v, want 1", got)
+	}
+	if got := mustSample(t, out, `llm_calls_total{path="worker_map",position="fallback",result="ok"}`); got != 1 {
+		t.Errorf("calls = %v, want exactly 1 per Run", got)
+	}
+
+	// A unit slip (ms or ns accumulated into a _seconds_total) leaves the label
+	// set untouched but moves the value by 3-9 orders of magnitude. This Run is
+	// sub-second, so anything at or above 1 is a unit bug rather than slowness.
+	secs := mustSample(t, out, `llm_call_duration_seconds_total{path="worker_map"}`)
+	if secs <= 0 || secs >= 1 {
+		t.Errorf("duration = %v seconds; expected a sub-second value — a value >= 1 means ms or ns were accumulated as seconds", secs)
+	}
+}
+
+// TestInstall_ExhaustionAndCancellationAreDistinct pins the two failure shapes
+// apart at the series level, driven through a real Run. Before this, the only
+// exhaustion coverage hand-fed a ResultEvent, so it could not prove Run emits
+// one at all — and a caller who merely walked away was counted as a total
+// provider outage.
+func TestInstall_ExhaustionAndCancellationAreDistinct(t *testing.T) {
+	obs := Install(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { llmfallback.SetDefaultObserver(nil) })
+
+	// 1. Everything down: no model can serve the call.
+	llmfallback.Run(
+		llmfallback.WithPath(context.Background(), llmfallback.PathWorkerReduce),
+		llmfallback.Config{
+			Models: []string{"a-down", "b-down"}, MaxAttempts: 1,
+			Backoff: func(int) time.Duration { return 0 },
+		},
+		func(_ context.Context, _ string) (string, llmfallback.Outcome, error) {
+			return "", llmfallback.ClassifyStatus(http.StatusServiceUnavailable), errors.New("503")
+		})
+
+	// 2. The caller goes away — an SSE client closing the tab.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	llmfallback.Run(
+		llmfallback.WithPath(cancelled, llmfallback.PathAPIRefine),
+		llmfallback.Config{
+			Models: []string{"a-live", "b-live"}, MaxAttempts: 1,
+			Backoff: func(int) time.Duration { return 0 },
+		},
+		func(_ context.Context, _ string) (string, llmfallback.Outcome, error) {
+			return "ok", llmfallback.Success, nil
+		})
+
+	var buf bytes.Buffer
+	obs.Metrics().WritePrometheus(&buf)
+	out := buf.String()
+
+	if got := mustSample(t, out, `llm_calls_total{path="worker_reduce",position="none",result="failed"}`); got != 1 {
+		t.Errorf("exhausted call = %v, want 1 — Run must emit a result event when every model fails", got)
+	}
+	if got := mustSample(t, out, `llm_calls_total{path="api_refine",position="none",result="cancelled"}`); got != 1 {
+		t.Errorf("cancelled call = %v, want 1", got)
+	}
+	if v, ok := sampleValue(t, out, `llm_calls_total{path="api_refine",position="none",result="failed"}`); ok {
+		t.Errorf("caller cancellation was counted as an upstream failure (%v); it must not land on the series operators alert on", v)
+	}
+}
+
+// TestInstall_TerminalFailureIsNotCountedOK covers the shape a 400 produces:
+// a model DID serve the call, and it failed. Recording that as ok would hide
+// contract errors entirely.
+func TestInstall_TerminalFailureIsNotCountedOK(t *testing.T) {
+	obs := Install(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { llmfallback.SetDefaultObserver(nil) })
+
+	llmfallback.Run(
+		llmfallback.WithPath(context.Background(), llmfallback.PathAgentChat),
+		llmfallback.Config{Models: []string{"only-m"}, MaxAttempts: 2, Backoff: func(int) time.Duration { return 0 }},
+		func(_ context.Context, _ string) (string, llmfallback.Outcome, error) {
+			return "", llmfallback.ClassifyStatus(http.StatusBadRequest), errors.New("400 malformed")
+		})
+
+	var buf bytes.Buffer
+	obs.Metrics().WritePrometheus(&buf)
+	out := buf.String()
+
+	if got := mustSample(t, out, `llm_calls_total{path="agent_chat",position="primary",result="failed"}`); got != 1 {
+		t.Errorf("terminal failure = %v, want 1 on result=failed", got)
+	}
+	if v, ok := sampleValue(t, out, `llm_calls_total{path="agent_chat",position="primary",result="ok"}`); ok {
+		t.Errorf("a terminal failure was counted as ok (%v)", v)
+	}
+}

--- a/internal/llmobs/observer.go
+++ b/internal/llmobs/observer.go
@@ -1,0 +1,110 @@
+package llmobs
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+)
+
+// Observer is the production llmfallback.Observer: it feeds the metric set and
+// emits one structured log record per model switch and per fully-exhausted
+// call.
+//
+// Deliberately quiet on the success path. The per-attempt counter already
+// carries retry volume, and logging every attempt would bury the two records
+// that actually need a human.
+type Observer struct {
+	m   *Metrics
+	log *slog.Logger
+}
+
+// New builds an Observer. A nil logger uses slog.Default().
+func New(m *Metrics, logger *slog.Logger) *Observer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Observer{m: m, log: logger}
+}
+
+// Metrics exposes the underlying metric set for the /metrics handler.
+func (o *Observer) Metrics() *Metrics { return o.m }
+
+// ObserveAttempt implements llmfallback.Observer.
+func (o *Observer) ObserveAttempt(e llmfallback.AttemptEvent) {
+	o.m.ObserveAttempt(e)
+
+	// A retry that is about to be spent is the only attempt-level event worth a
+	// record: it is the leading indicator of a degrading primary, and without it
+	// a same-model retry storm is completely invisible (the switch log only
+	// fires once the model is abandoned).
+	// Only when a retry actually follows. The final attempt of a budget also
+	// classifies RetrySameModel — the model is abandoned right after it — so
+	// logging unconditionally announced a retry that never happened.
+	if e.Outcome == llmfallback.RetrySameModel && e.Attempt < e.MaxAttempts {
+		o.log.Warn("llm attempt failed, retrying same model",
+			slog.String("event", "llm.attempt.retry"),
+			slog.String("path", string(e.Path)),
+			slog.String("model", e.Model),
+			slog.String("position", e.Position),
+			slog.Int("attempt", e.Attempt),
+			slog.Int64("duration_ms", e.Duration.Milliseconds()),
+			slog.String("error", llmfallback.SafeErrorForLog(e.Err, 200)),
+		)
+	}
+}
+
+// ObserveSwitch implements llmfallback.Observer. This is THE record that makes
+// silent quality drift visible: from here on, output comes from a different
+// model than the one the deployment nominated.
+func (o *Observer) ObserveSwitch(e llmfallback.SwitchEvent) {
+	o.m.ObserveSwitch(e)
+
+	// budget_starved is a configuration fault, not an upstream one, so it is
+	// logged at Error: nobody upstream will fix it and it silently costs the
+	// primary its retry budget on every single blip.
+	level := slog.LevelWarn
+	if e.Reason == llmfallback.ReasonBudgetStarved || e.Reason == llmfallback.ReasonDenied {
+		level = slog.LevelError
+	}
+	o.log.Log(context.Background(), level, "llm falling back to next model",
+		slog.String("event", "llm.model.switch"),
+		slog.String("path", string(e.Path)),
+		slog.String("from", e.From),
+		slog.String("to", e.To),
+		slog.String("from_position", e.FromPos),
+		slog.String("reason", string(e.Reason)),
+		slog.Int("attempts_spent", e.Attempts),
+		slog.String("error", llmfallback.SafeErrorForLog(e.Err, 200)),
+	)
+}
+
+// ObserveResult implements llmfallback.Observer. Only total exhaustion is
+// logged — a call served by a fallback already produced a switch record.
+func (o *Observer) ObserveResult(e llmfallback.ResultEvent) {
+	o.m.ObserveResult(e)
+
+	if !e.OK && e.Model == "" {
+		// A caller walking away is not an outage. Logging a disconnect at Error
+		// with "exhausted every configured model" put user-closed SSE streams
+		// into the same record operators page on; switches=0 with one attempt
+		// was the only tell.
+		if e.Cancelled {
+			o.log.Info("llm call ended by caller cancellation",
+				slog.String("event", "llm.call.cancelled"),
+				slog.String("path", string(e.Path)),
+				slog.Int("switches", e.Switches),
+				slog.Int64("duration_ms", e.Duration.Milliseconds()),
+				slog.String("error", llmfallback.SafeErrorForLog(e.Err, 200)),
+			)
+			return
+		}
+		o.log.Error("llm call exhausted every configured model",
+			slog.String("event", "llm.call.exhausted"),
+			slog.String("path", string(e.Path)),
+			slog.Int("switches", e.Switches),
+			slog.Int64("duration_ms", e.Duration.Milliseconds()),
+			slog.String("error", llmfallback.SafeErrorForLog(e.Err, 200)),
+		)
+	}
+}

--- a/internal/llmobs/observer.go
+++ b/internal/llmobs/observer.go
@@ -89,9 +89,22 @@ func (o *Observer) ObserveResult(e llmfallback.ResultEvent) {
 		// with "exhausted every configured model" put user-closed SSE streams
 		// into the same record operators page on; switches=0 with one attempt
 		// was the only tell.
-		if e.Cancelled {
+		switch e.End {
+		case llmfallback.RunEndCancelled:
 			o.log.Info("llm call ended by caller cancellation",
 				slog.String("event", "llm.call.cancelled"),
+				slog.String("path", string(e.Path)),
+				slog.Int("switches", e.Switches),
+				slog.Int64("duration_ms", e.Duration.Milliseconds()),
+				slog.String("error", llmfallback.SafeErrorForLog(e.Err, 200)),
+			)
+			return
+		case llmfallback.RunEndTimedOut:
+			// Warn, not Info: nobody walked away — we ran out of our own budget,
+			// which is what an operator needs to see. Not Error either: no model
+			// was proven bad, so it must not read as a provider outage.
+			o.log.Warn("llm call ran out of its time budget",
+				slog.String("event", "llm.call.timeout"),
 				slog.String("path", string(e.Path)),
 				slog.Int("switches", e.Switches),
 				slog.Int64("duration_ms", e.Duration.Milliseconds()),

--- a/internal/llmobs/observer_log_test.go
+++ b/internal/llmobs/observer_log_test.go
@@ -122,7 +122,7 @@ func TestObserverLog_SuccessAndTerminalAreQuiet(t *testing.T) {
 func TestObserverLog_CancellationIsNotAnOutage(t *testing.T) {
 	o, buf := captureLogs(t)
 	o.ObserveResult(llmfallback.ResultEvent{
-		Path: llmfallback.PathAPIRefine, Cancelled: true,
+		Path: llmfallback.PathAPIRefine, End: llmfallback.RunEndCancelled,
 		Duration: 10 * time.Millisecond, Err: context.Canceled,
 	})
 	recs := records(t, buf)
@@ -154,4 +154,26 @@ func TestObserverLog_NilLoggerIsSafe(t *testing.T) {
 	o.ObserveAttempt(llmfallback.AttemptEvent{Attempt: 1, MaxAttempts: 3, Outcome: llmfallback.RetrySameModel})
 	o.ObserveSwitch(llmfallback.SwitchEvent{Reason: llmfallback.ReasonDenied})
 	o.ObserveResult(llmfallback.ResultEvent{})
+}
+
+// TestObserverLog_TimeoutIsAlertableButNotAnOutage pins the third state apart
+// from the other two. Our own deadline expiring is not a caller walking away
+// (Info would bury a real incident) and not a proven provider outage (Error
+// would page someone about a model that was never shown to be bad).
+func TestObserverLog_TimeoutIsAlertableButNotAnOutage(t *testing.T) {
+	o, buf := captureLogs(t)
+	o.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAgentChat, End: llmfallback.RunEndTimedOut,
+		Duration: 240 * time.Second, Err: context.DeadlineExceeded,
+	})
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	if got := recs[0]["level"]; got != "WARN" {
+		t.Errorf("level = %v, want WARN (Info buries it, Error reads as a provider outage)", got)
+	}
+	if got := recs[0]["event"]; got != "llm.call.timeout" {
+		t.Errorf("event = %v, want llm.call.timeout", got)
+	}
 }

--- a/internal/llmobs/observer_log_test.go
+++ b/internal/llmobs/observer_log_test.go
@@ -1,0 +1,157 @@
+package llmobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+)
+
+// captureLogs returns an Observer writing JSON records into buf, so the log
+// half of this package can be asserted. Before this, every log mutation
+// survived: level policy, event names and the retry-record condition were all
+// unasserted, and that half carries the "who gets paged" semantics.
+func captureLogs(t *testing.T) (*Observer, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return New(NewMetrics(fixedNow), slog.New(h)), &buf
+}
+
+func records(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("log line is not JSON: %q (%v)", line, err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// TestObserverLog_SwitchLevelsMatchWhoCanFixIt pins the level policy: a
+// configuration or credential fault nobody upstream will fix is ERROR; ordinary
+// upstream overload is WARN. Collapsing them makes a transient blip page the
+// same as a broken deployment.
+func TestObserverLog_SwitchLevelsMatchWhoCanFixIt(t *testing.T) {
+	cases := []struct {
+		reason    llmfallback.SwitchReason
+		wantLevel string
+	}{
+		{llmfallback.ReasonBudgetStarved, "ERROR"},
+		{llmfallback.ReasonDenied, "ERROR"},
+		{llmfallback.ReasonRetriesExhausted, "WARN"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.reason), func(t *testing.T) {
+			o, buf := captureLogs(t)
+			o.ObserveSwitch(llmfallback.SwitchEvent{
+				Path: llmfallback.PathAgentChat, From: "p", To: "f",
+				FromPos: llmfallback.PositionPrimary, Reason: tc.reason,
+				Attempts: 1, Err: errors.New("boom"),
+			})
+			recs := records(t, buf)
+			if len(recs) != 1 {
+				t.Fatalf("want exactly 1 record, got %d", len(recs))
+			}
+			if got := recs[0]["level"]; got != tc.wantLevel {
+				t.Errorf("level = %v, want %v", got, tc.wantLevel)
+			}
+			if got := recs[0]["event"]; got != "llm.model.switch" {
+				t.Errorf("event = %v, want llm.model.switch (alert rules match on it)", got)
+			}
+			if got := recs[0]["reason"]; got != string(tc.reason) {
+				t.Errorf("reason = %v, want %v", got, tc.reason)
+			}
+		})
+	}
+}
+
+// TestObserverLog_RetryRecordOnlyWhenARetryFollows covers the record that used
+// to announce a retry on the final attempt, when the next step is abandoning
+// the model entirely.
+func TestObserverLog_RetryRecordOnlyWhenARetryFollows(t *testing.T) {
+	o, buf := captureLogs(t)
+	for attempt := 1; attempt <= 3; attempt++ {
+		o.ObserveAttempt(llmfallback.AttemptEvent{
+			Path: llmfallback.PathWorkerMap, Model: "m", Position: llmfallback.PositionPrimary,
+			Attempt: attempt, MaxAttempts: 3, Outcome: llmfallback.RetrySameModel,
+			Duration: time.Millisecond, Err: errors.New("503"),
+		})
+	}
+	recs := records(t, buf)
+	if len(recs) != 2 {
+		t.Fatalf("want 2 retry records for a 3-attempt budget (the last attempt is not retried), got %d", len(recs))
+	}
+	for _, r := range recs {
+		if r["event"] != "llm.attempt.retry" {
+			t.Errorf("unexpected event %v", r["event"])
+		}
+	}
+}
+
+// TestObserverLog_SuccessAndTerminalAreQuiet keeps the retry record from
+// becoming a log flood: only RetrySameModel is worth a line.
+func TestObserverLog_SuccessAndTerminalAreQuiet(t *testing.T) {
+	for _, oc := range []llmfallback.Outcome{llmfallback.Success, llmfallback.Terminal, llmfallback.TryNextModel} {
+		o, buf := captureLogs(t)
+		o.ObserveAttempt(llmfallback.AttemptEvent{
+			Path: llmfallback.PathWorkerMap, Model: "m", Position: llmfallback.PositionPrimary,
+			Attempt: 1, MaxAttempts: 3, Outcome: oc,
+		})
+		if recs := records(t, buf); len(recs) != 0 {
+			t.Errorf("outcome %v produced %d log records, want 0", oc, len(recs))
+		}
+	}
+}
+
+// TestObserverLog_CancellationIsNotAnOutage is the log-side half of the
+// exhaustion/cancellation split: a user closing a tab must not emit the ERROR
+// record that means "no model could serve this".
+func TestObserverLog_CancellationIsNotAnOutage(t *testing.T) {
+	o, buf := captureLogs(t)
+	o.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAPIRefine, Cancelled: true,
+		Duration: 10 * time.Millisecond, Err: context.Canceled,
+	})
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("want 1 record, got %d", len(recs))
+	}
+	if got := recs[0]["level"]; got == "ERROR" {
+		t.Errorf("caller cancellation logged at ERROR; it is not an outage")
+	}
+	if got := recs[0]["event"]; got != "llm.call.cancelled" {
+		t.Errorf("event = %v, want llm.call.cancelled", got)
+	}
+
+	// The genuine outage still is one.
+	o2, buf2 := captureLogs(t)
+	o2.ObserveResult(llmfallback.ResultEvent{
+		Path: llmfallback.PathAPIRefine, Duration: time.Second, Err: errors.New("all failed"),
+	})
+	recs2 := records(t, buf2)
+	if len(recs2) != 1 || recs2[0]["level"] != "ERROR" || recs2[0]["event"] != "llm.call.exhausted" {
+		t.Errorf("total exhaustion must stay an ERROR llm.call.exhausted record, got %+v", recs2)
+	}
+}
+
+// TestObserverLog_NilLoggerIsSafe covers Install(nil): the guard is only
+// exercised if an event actually flows afterwards.
+func TestObserverLog_NilLoggerIsSafe(t *testing.T) {
+	o := New(NewMetrics(fixedNow), nil)
+	o.ObserveAttempt(llmfallback.AttemptEvent{Attempt: 1, MaxAttempts: 3, Outcome: llmfallback.RetrySameModel})
+	o.ObserveSwitch(llmfallback.SwitchEvent{Reason: llmfallback.ReasonDenied})
+	o.ObserveResult(llmfallback.ResultEvent{})
+}

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -546,6 +546,7 @@ func (c *LLMClient) CallWithTools(ctx context.Context, messages []ChatMessage, t
 		Models:          c.models(),
 		PerModelTimeout: c.toolCallTimeout,
 		MaxAttempts:     3,
+		Path:            llmfallback.PathToolCall,
 	}, func(ctx context.Context, model string) (result, llmfallback.Outcome, error) {
 		temp := temperature
 		if config.IsKimiModel(model) {
@@ -754,6 +755,7 @@ func (c *LLMClient) CallMap(ctx context.Context, formattedMessages string, sourc
 
 // CallMapWithModel is CallMap with the actual producing model included.
 func (c *LLMClient) CallMapWithModel(ctx context.Context, formattedMessages string, sourceName string, chunkIndex int, msgCount int, timeStart, timeEnd string, topic string, userName string) (string, int, string, error) {
+	ctx = llmfallback.WithPath(ctx, llmfallback.PathWorkerMap)
 	if strings.TrimSpace(formattedMessages) == "" {
 		return "(该时段无文本消息)", 0, c.model, nil
 	}
@@ -788,6 +790,7 @@ func (c *LLMClient) CallReduce(ctx context.Context, chunkSummaries []string, sou
 
 // CallReduceWithModel is CallReduce with the actual producing model included.
 func (c *LLMClient) CallReduceWithModel(ctx context.Context, chunkSummaries []string, sourceNames string, startTime, endTime string, totalMsgCount int, topic string) (string, int, string, error) {
+	ctx = llmfallback.WithPath(ctx, llmfallback.PathWorkerReduce)
 	if len(chunkSummaries) == 1 {
 		return chunkSummaries[0], 0, c.model, nil
 	}
@@ -828,6 +831,7 @@ func (c *LLMClient) CallMapStream(ctx context.Context, formattedMessages string,
 
 // CallMapStreamWithModel is CallMapStream with the actual producing model included.
 func (c *LLMClient) CallMapStreamWithModel(ctx context.Context, formattedMessages string, sourceName string, chunkIndex int, msgCount int, timeStart, timeEnd string, topic string, userName string, onDelta func(string) error) (string, int, string, error) {
+	ctx = llmfallback.WithPath(ctx, llmfallback.PathWorkerMap)
 	if strings.TrimSpace(formattedMessages) == "" {
 		return "(该时段无文本消息)", 0, c.model, nil
 	}
@@ -872,6 +876,7 @@ func (c *LLMClient) CallReduceStream(ctx context.Context, chunkSummaries []strin
 
 // CallReduceStreamWithModel is CallReduceStream with the actual producing model included.
 func (c *LLMClient) CallReduceStreamWithModel(ctx context.Context, chunkSummaries []string, sourceNames string, startTime, endTime string, totalMsgCount int, topic string, onDelta func(string) error) (string, int, string, error) {
+	ctx = llmfallback.WithPath(ctx, llmfallback.PathWorkerReduce)
 	if len(chunkSummaries) == 1 {
 		if onDelta != nil && chunkSummaries[0] != "" {
 			_ = onDelta(chunkSummaries[0])
@@ -939,5 +944,6 @@ func (c *LLMClient) CallReduceByPersonStream(ctx context.Context, participantSum
 
 // CallReduceByPersonStreamWithModel is CallReduceByPersonStream with the actual producing model included.
 func (c *LLMClient) CallReduceByPersonStreamWithModel(ctx context.Context, participantSummaries []struct{ Name, Summary string }, startTime, endTime string, topic string, onDelta func(string) error) (string, int, string, error) {
+	ctx = llmfallback.WithPath(ctx, llmfallback.PathWorkerReduce)
 	return c.callStreamWithModel(ctx, buildReduceByPersonMessages(participantSummaries, startTime, endTime, topic), 0.1, onDelta, true)
 }


### PR DESCRIPTION
## Summary

`LLM_FALLBACK_MODELS` silently swaps the model serving a request when the primary fails. Until now that swap left almost no trace: one unstructured `log.Printf` line, no counter, and no way to answer *"how often are we running on the fallback?"* or *"how long have we been degraded?"*.

This adds an `Observer` seam to `llmfallback.Run` and a concrete backend:

- **`llmfallback`** — `Config` gains `Path` and `Observer`; `Run`/`runModel` report every attempt, every model switch and the final result. Control flow is untouched.
- **Classified switch reasons**, not one "a fallback happened" counter, because each needs a different responder:

  | reason | meaning | who fixes it |
  |---|---|---|
  | `denied` | the provider refused this request for this model (HTTP 403 — credentials, entitlement, a WAF rule or a regional restriction) | billing / IAM — will not self-heal |
  | `retries_exhausted` | the per-model retry budget ran out, usually upstream overload (also where a merely slow upstream lands — a per-attempt timeout is overload, not caller cancellation) | usually transient |
  | `budget_starved` | the deadline guard abandoned the primary's remaining retries | the config owner — nothing upstream to fix |

  Two unexported error types carry the classification, so it never depends on parsing error prose.
- **How a run ended** is classified separately from why a model was abandoned. `RunEnd` distinguishes caller cancellation (`result="cancelled"`, logged at Info — an SSE client closing a tab is not an outage) from our own deadline expiring (`result="timeout"`, logged at Warn — nobody walked away, so it stays alertable) from a genuine all-models failure (`result="failed"`, Error).
- **`internal/llmobs`** — turns those events into structured `log/slog` records plus counters, rendered in Prometheus text exposition format.
- **`/internal/metrics`** — registered in `router.SetupInternal`, so *both* the API and the worker expose it on their own internal listeners, never on the public one. Both listeners are unauthenticated (as the pre-existing `/internal/*` endpoints already are); `CONFIGURATION.md` now states they must not be published beyond the cluster network, and notes that the API listener — unlike the worker — has no bind-address knob, so the network layer is the only control there.
- The path rides the **context** for generic entry points, since `LLMClient.Call` serves worker Map, worker Reduce and API refine alike; the three agent tool call sites tag `PathAgentTool` explicitly.

**No Prometheus client dependency.** `client_golang` currently drags upgrades to `x/crypto`, `x/net`, `x/sys`, `x/text` and protobuf, which this repo's `dependency-review` and `osv-scanner` workflows would have to re-clear — a large blast radius for a monitoring change. The counters emit the same text format a scraper parses, and the `Observer` interface is the seam: swapping in the real client later touches `internal/llmobs` alone, with no call site edited.

## How verified

- `go vet ./...` clean; `gofmt` clean on all changed files.
- Full suite green across `llmfallback` / `llmobs` / `api-router` / `service` / `agent` / `worker` under `CGO_ENABLED=1 CGO_LDFLAGS="-L/usr/local/lib" go test -race -shuffle=on -count=1`, matching the CI race gate. No data races.
- **Signal classification** — `TestReasonFor_RealProductionErrorShapes` pins the production error shapes: a per-attempt timeout wrapping `context.DeadlineExceeded` classifies as `retries_exhausted` (not cancellation); starvation and denial still win even when they wrap a deadline. `TestObserver_ClassifiesSwitchReasons` pins each reason with the attempt-count signature that distinguishes starvation (1 attempt) from genuine exhaustion (full budget).
- **Every exit classified** — `TestRun_ContextEndIsClassifiedAtEveryExit` drives all three failure exits with a *live* context cancelled from inside the attempt (the shape production takes), plus the deadline case and an ordinary-failure control.
- **Metric values, not just labels** — `TestInstall_EndToEndFromRealRun` drives a real `Run` and asserts exact counter values via a `sampleValue` helper, so a `+1`-vs-`+2` or wrong-unit bug is caught. Every exposition/concurrency test asserts `len(samples)` before ranging, so a disabled counter cannot pass vacuously.
- Label cardinality: 1000 iterations feeding task/chunk/user-shaped strings through the event fields still yield 4 series, and every label key is checked against a closed set. Escaping: a model id containing `"`, `\` or `\n` cannot forge a metric line, and a CR is flattened rather than emitted as the invalid `\r` escape (which aborts the whole scrape in the reference parser).

### On "mutation-tested"

An earlier 15-mutation pass caught two vacuous tests (a fixed-clock gauge assertion; a sanitizer test that checked text but not the `errors.Is` chain). A subsequent wider adversarial sweep found more misses — the end-to-end test asserted label-string presence but never counter values, `ConcurrentUse` passed with the switch counter fully disabled, the log half of `Observer` had no assertions at all, and `TestMetricsBeforeInstallDoesNotPanic` skipped its body under `-shuffle` whenever another test had already installed the process default. Those are the gaps the value assertions, `len(samples)` guards, `observer_log_test.go`, and the `ResetDefaultForTest` reset now close. Each fix was re-checked by mutating the code it guards and confirming the test goes red.

## COMPREHENSION

**1. What does this change actually do to the load-bearing path?**

`llmfallback.Run` is the single choke point every LLM call in both processes flows through — agent chat, agent tools, worker Map/Reduce, API refine. Before: it decided retry/switch/stop and emitted one `log.Printf` on a switch. After: it makes the same decisions and additionally calls three observer hooks. The retry/switch/stop logic, the model chosen, and the value returned are unchanged.

Two error paths changed shape internally: the deadline-guard exit and the attempt-classified `TryNextModel` exit now return typed errors (`budgetStarvedErr`, `deniedErr`) instead of an `fmt.Errorf` string. Both preserve the wrapped cause via `Unwrap`, and both keep the upstream text via `%v` so every substring `worker.sanitizeErrorForUser` keys on survives.

Observationally: a `budget_starved` or `denied` switch logs at **Error**; a same-model retry logs at Warn *only below the final attempt* (the last attempt is never retried); a cancelled run logs at Info and a timed-out one at Warn; and a scrape endpoint appears on the internal listener.

**2. What could break because of it (dependents + failure mode)?**

- **`worker.sanitizeErrorForUser`** picks the Chinese message a user receives by *substring-matching* the internal error text. If a string drifted, the whitelist would silently fall through to the generic message. `TestRun_PreservesSanitizerMatchableText` pins the matched substrings and the `errors.Is` chain through the new wrappers, including the 403/denied case.
- **Log records.** The slog switch/attempt/exhaustion records were *added alongside* the existing `log.Printf("[llmfallback] falling back…")` line, which is kept on purpose — it is the only switch log when no observer is installed. Anything deriving a metric from that line should read `llm_model_switch_total` instead.
- **Metric cardinality.** A label fed from request data would blow up the series count. Mitigated by restricting labels to config-derived model ids plus closed constant sets, and asserted by a test.
- **The process-wide default observer** is global mutable state, set once from each composition root before any LLM client is constructed; `SetDefaultObserver(nil)` / `ResetDefaultForTest` restore the no-op for tests.
- **Scrape before install** returns a benign empty 200, not a 500 — asserted unconditionally.

**3. How do you know it works (specific test/repro/trace)?**

The pre-change baseline is held by `TestRun_PreservesSanitizerMatchableText` (matched substrings + `errors.Is` chain survive the new wrappers) — the equivalence test `TestObserver_DoesNotAlterRunSemantics` only proves the observer itself perturbs nothing, and is documented as such rather than credited with more. Classification is pinned against the shapes production actually produces. Metrics are parsed structurally and asserted by value, so a malformed header, an unescaped label, or a wrong count is caught rather than passing by accident.

## Pre-existing issue this PR makes measurable (not fixed here)

`budget_starved` is not a hypothetical, and it is **not introduced by this PR** — the guard (`remaining < delay + 2*PerModelTimeout`) already exists on `main` at `internal/llmfallback/fallback.go:172`, from #212. What this PR adds is the ability to *see* it: the reason is classified, counted and alertable, and `TestObserver_ClassifiesSwitchReasons` reproduces it under the shipped defaults on purpose — so that test starts failing the day the defaults are retuned, which is the correct signal.

The guard reserves 361s while `AGENT_STEP_TIMEOUT` defaults to 240s — a reserve that can never be satisfied, so the primary gets **1** attempt instead of the 3 its doc comment and `CONFIGURATION.md` promise:

```
before → primary_attempts=3, elapsed 3.005s
after  → primary_attempts=1, elapsed 2ms
```

Changing the reserve to `1x` restores the budget but breaks `TestRun_DeadlineCheckHappensBeforeBackoff`, whose comment records that `2x` was a deliberate anti-starvation change — so the resolution is a config decision, left to its own task.

## Unrelated finding, recorded here only because it surfaced during the same review

While reviewing #212 I also found that the worker's retry budget (up to ~18 min across two models under `context.Background()`) can exceed the 10-minute lease at `internal/worker/scheduler.go:465`, so `scanStuckPersonalTasks` may re-dispatch a participant that is still being processed.

To be explicit about scope: **this PR does not touch it and does not make it observable.** The diff contains no changes under `internal/worker/`, and no metric here measures lease expiry or duplicate dispatch. It also originates in #212, not here. It is noted only so it is not lost; it deserves its own issue rather than being carried in this description.

## History

Rebased onto `main` as a self-contained change. It previously stacked on an octospec-onboarding branch (#218); that branch was closed rather than merged, because two security defects in its vendored onboarding tooling (a symlink-following temp write, and unbounded block append on an unclosed code fence) belong upstream in `octo-spec` — and this observability change has no runtime dependency on it.

Refs #211.