### PR TITLE
feat(summary): let a pending submission raise attention (red dot + count)

### DIFF
--- a/internal/api/handler/attention_pending_submit_mysql_test.go
+++ b/internal/api/handler/attention_pending_submit_mysql_test.go
@@ -1,0 +1,149 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// MySQL placeholder-ordering coverage for the pending-submission argument.
+//
+// The SQLite harness cannot exercise schedulePendingInvitationExpr: it needs
+// JSON_TABLE, so on SQLite the predicate collapses to the constant "0" and
+// contributes no placeholder. On MySQL it contributes one `?` that sits
+// immediately BEFORE the new PersonalStatusCompleted argument in every
+// hand-assembled statement. A mutation that swapped those two would pass the
+// whole SQLite suite and only break in production.
+//
+// schedule_attention_mysql_test.go already pins the list query's ordering. This
+// covers the two statements it does not touch: the attention-count query (whose
+// new has_submit term is a third placeholder position) and MarkSummaryRead's
+// stateSQL (which had no MySQL coverage at all).
+//
+// Opt-in like its sibling: point SUMMARY_MYSQL_TEST_DSN at an isolated,
+// migrated database.
+func TestPendingSubmission_MySQL_PlaceholderOrderingAndMarkRead(t *testing.T) {
+	dsn := os.Getenv("SUMMARY_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("SUMMARY_MYSQL_TEST_DSN is not set")
+	}
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	for _, table := range []string{
+		"summary_task", "summary_source", "summary_participant", "summary_result",
+		"summary_personal_result", "summary_personal_result_version", "summary_user_read", "summary_schedule",
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Fatalf("mysql integration database is not migrated: missing %s", table)
+		}
+	}
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin transaction: %v", tx.Error)
+	}
+	defer tx.Rollback()
+
+	const spaceID = "pending-submit-mysql-space"
+	const me = "submit-owner"
+	now := timezone.Now()
+
+	// A schedule whose roster still has an unconfirmed member makes
+	// schedulePendingInvitationExpr live (confirm_policy=1), so its placeholder
+	// really is bound during this test rather than short-circuiting.
+	schedule := model.SummarySchedule{
+		SpaceID: spaceID, CreatorID: me, Title: "scheduled", SummaryMode: model.ModeByPerson,
+		CronExpr: "0 0 * * *", TimeRangeType: 1,
+		ParticipantConfig: model.JSON(`{"participants":[{"user_id":"other-invitee","confirmed":false}],"confirm_gate_passed":false}`),
+		ConfirmPolicy:     model.SchedConfirmRequire, IsActive: 1,
+	}
+	if err := tx.Create(&schedule).Error; err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+
+	task := model.SummaryTask{
+		TaskNo: "MYSQL-PENDING-SUBMIT", SpaceID: spaceID, CreatorID: me,
+		SummaryMode: model.ModeByPerson, Status: model.StatusProcessing,
+		TriggerType: model.TriggerScheduled, ScheduleID: &schedule.ID,
+		TimeRangeStart: time.Now().Add(-time.Hour), TimeRangeEnd: time.Now(),
+	}
+	if err := tx.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	for _, uid := range []string{me, "teammate"} {
+		if err := tx.Create(&model.SummaryParticipant{
+			TaskID: task.ID, UserID: uid, UserName: uid, Status: model.ParticipantAccepted,
+		}).Error; err != nil {
+			t.Fatalf("create participant %s: %v", uid, err)
+		}
+	}
+	version := model.PersonalResultVersion{
+		TaskID: task.ID, UserID: me, Content: "personal", Version: 1,
+		GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := tx.Create(&version).Error; err != nil {
+		t.Fatalf("create personal version: %v", err)
+	}
+	if err := tx.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: me, Content: "personal draft",
+		WorkerStatus: model.PersonalStatusCompleted, SubmittedAt: nil,
+		CurrentVersionID: &version.ID, CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("create personal result: %v", err)
+	}
+
+	// --- list projection + attention-count query ---
+	r := setupListRouter(NewTaskHandler(tx, nil, ""))
+	w := doRequestWithSpace(r, http.MethodGet, "/api/v1/summaries", me, spaceID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != task.ID {
+		t.Fatalf("expected the seeded task: %+v", resp.Data)
+	}
+	if !resp.Data.Items[0].HasPendingSubmission || !resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("MySQL list projection lost the pending submission: %+v", resp.Data.Items[0])
+	}
+	// A wrong argument position would not necessarily error — it would silently
+	// compare worker_status against a uid, yielding 0. Assert the value.
+	if resp.Data.PendingSubmissionCount != 1 || resp.Data.AttentionCount != 1 {
+		t.Fatalf("MySQL attention-count placeholders are misaligned: attention=%d submission=%d",
+			resp.Data.AttentionCount, resp.Data.PendingSubmissionCount)
+	}
+
+	// --- MarkSummaryRead stateSQL ---
+	rr := setupReadRouter(NewTaskHandler(tx, nil, ""))
+	rw := markReadRequestWithSpace(rr, task.ID, me, spaceID, fmt.Sprintf(`{"personal_version_id":%d}`, version.ID))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200 from mark-read, got %d: %s", rw.Code, rw.Body.String())
+	}
+	var readResp struct {
+		Data struct {
+			IsUnread             bool `json:"is_unread"`
+			HasPendingSubmission bool `json:"has_pending_submission"`
+			NeedsAttention       bool `json:"needs_attention"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &readResp); err != nil {
+		t.Fatalf("unmarshal mark-read response: %v; body=%s", err, rw.Body.String())
+	}
+	if readResp.Data.IsUnread {
+		t.Fatalf("the rendered version was recorded: %+v", readResp.Data)
+	}
+	if !readResp.Data.HasPendingSubmission || !readResp.Data.NeedsAttention {
+		t.Fatalf("MySQL stateSQL lost the pending submission on read: %+v", readResp.Data)
+	}
+}

--- a/internal/api/handler/attention_pending_submit_test.go
+++ b/internal/api/handler/attention_pending_submit_test.go
@@ -176,6 +176,122 @@ func TestListSummaries_SinglePersonTaskNeverPendsSubmission(t *testing.T) {
 	}
 }
 
+// A dead task must not keep nagging. The stuck-task reaper flips Processing ->
+// Failed once retries are exhausted (worker/scheduler.go) and CancelSummary
+// writes Cancelled; neither touches summary_personal_result, so without the
+// status guard the member who DID generate their summary keeps a red dot and a
+// non-zero space-level attention_count for a task nobody can revive
+// (Regenerate and Delete are creator-gated). A badge that cannot return to zero
+// is worse than no badge.
+func TestListSummaries_TerminalTaskDropsPendingSubmission(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		taskNo string
+		status int
+	}{
+		{"reaper marked it failed", "SUBMIT-FAILED", model.StatusFailed},
+		{"creator cancelled it", "SUBMIT-CANCELLED", model.StatusCancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, imDB := setupListTestDBs(t)
+			taskID := seedPendingSubmitTask(t, db, tc.taskNo, "participant1", []string{"participant2"})
+			if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
+				Update("status", tc.status).Error; err != nil {
+				t.Fatalf("set terminal status: %v", err)
+			}
+
+			r := setupListRouter(NewTaskHandler(db, imDB, ""))
+			w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+			resp := parseAttentionList(t, w)
+			if len(resp.Data.Items) != 1 {
+				t.Fatalf("expected the seeded task, got %+v", resp.Data)
+			}
+			if resp.Data.Items[0].HasPendingSubmission || resp.Data.Items[0].NeedsAttention {
+				t.Fatalf("a terminal task must not pend submission: %+v", resp.Data.Items[0])
+			}
+			if resp.Data.AttentionCount != 0 || resp.Data.PendingSubmissionCount != 0 {
+				t.Fatalf("terminal task must not hold the badge above zero: %+v", resp.Data)
+			}
+
+			// MarkSummaryRead must agree — it is the other needs_attention producer.
+			rr := setupReadRouter(NewTaskHandler(db, imDB, ""))
+			now := timezone.Now()
+			version := model.PersonalResultVersion{
+				TaskID: taskID, UserID: "participant1", Content: "personal", Version: 1,
+				GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+			}
+			if err := db.Create(&version).Error; err != nil {
+				t.Fatalf("create personal version: %v", err)
+			}
+			if err := db.Model(&model.PersonalResult{}).
+				Where("task_id = ? AND user_id = ?", taskID, "participant1").
+				Update("current_version_id", version.ID).Error; err != nil {
+				t.Fatalf("attach current version: %v", err)
+			}
+			rw := markReadRequest(rr, taskID, "participant1", fmt.Sprintf(`{"personal_version_id":%d}`, version.ID))
+			var readResp struct {
+				Data struct {
+					HasPendingSubmission bool `json:"has_pending_submission"`
+					NeedsAttention       bool `json:"needs_attention"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(rw.Body.Bytes(), &readResp); err != nil {
+				t.Fatalf("unmarshal mark-read response: %v; body=%s", err, rw.Body.String())
+			}
+			if readResp.Data.HasPendingSubmission || readResp.Data.NeedsAttention {
+				t.Fatalf("mark-read must agree that a terminal task pends nothing: %+v", readResp.Data)
+			}
+		})
+	}
+}
+
+// Completed is deliberately NOT guarded. A personal-only regenerate on a
+// finished task leaves submitted_at NULL on purpose and waits for an explicit
+// submit (worker/personal_processor.go), so the dot is correct there. Pinning
+// this stops a future "just exclude every terminal status" simplification from
+// silently dropping the signal on the one terminal status that still needs it.
+func TestListSummaries_CompletedTaskStillPendsSubmission(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-REGEN", "participant1", []string{"participant2"})
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
+		Update("status", model.StatusCompleted).Error; err != nil {
+		t.Fatalf("set completed status: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected the seeded task, got %+v", resp.Data)
+	}
+	if !resp.Data.Items[0].HasPendingSubmission || !resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("a regenerated personal result on a completed task still owes a submit: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 1 || resp.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("completed task must still hold the counts: %+v", resp.Data)
+	}
+}
+
+// The status=waiting list filter carries the same predicate as the badge. If
+// the two disagree, a card can be counted by the badge but hidden by the
+// filter the user clicks to find it (or vice versa).
+func TestListSummaries_WaitingFilterAgreesWithTerminalGuard(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	liveID := seedPendingSubmitTask(t, db, "SUBMIT-WAIT-LIVE", "participant1", []string{"participant2"})
+	deadID := seedPendingSubmitTask(t, db, "SUBMIT-WAIT-DEAD", "participant1", []string{"participant2"})
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", deadID).
+		Update("status", model.StatusFailed).Error; err != nil {
+		t.Fatalf("set terminal status: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, fmt.Sprintf("/api/v1/summaries?status=%d", model.StatusPending), "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != liveID {
+		t.Fatalf("waiting filter must keep the live task and drop the terminal one: %+v", resp.Data)
+	}
+}
+
 // Owner decision 2026-08-26: reading is not submitting. Opening the detail page
 // records the read cursor, but the participant still owes the team a /submit,
 // so the dot must survive MarkSummaryRead.

--- a/internal/api/handler/attention_pending_submit_test.go
+++ b/internal/api/handler/attention_pending_submit_test.go
@@ -1,0 +1,236 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/gorm"
+)
+
+// Pending-submission attention (multi-person "your turn to submit" red dot).
+//
+// has_pending_submission was already computed by ListSummaries but never fed
+// needs_attention / attention_count, so the dot never rendered. These tests pin
+// the three rules that make it a usable signal:
+//
+//  1. it only fires for MULTI-person tasks (single-person owners have nobody to
+//     submit to),
+//  2. it clears on submitted_at, not on read — MarkSummaryRead must leave it
+//     standing (owner decision 2026-08-26),
+//  3. it participates in the space-level attention_count that drives the
+//     sidebar badge, with its own pending_submission_count breakdown.
+
+type attentionListResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		Total                  int `json:"total"`
+		AttentionCount         int `json:"attention_count"`
+		UnreadCount            int `json:"unread_count"`
+		PendingInvitationCount int `json:"pending_invitation_count"`
+		PendingSubmissionCount int `json:"pending_submission_count"`
+		Items                  []struct {
+			TaskID               int64 `json:"task_id"`
+			IsUnread             bool  `json:"is_unread"`
+			HasPendingInvitation bool  `json:"has_pending_invitation"`
+			HasPendingSubmission bool  `json:"has_pending_submission"`
+			NeedsAttention       bool  `json:"needs_attention"`
+		} `json:"items"`
+	} `json:"data"`
+}
+
+func parseAttentionList(t *testing.T, w *httptest.ResponseRecorder) attentionListResponse {
+	t.Helper()
+	var resp attentionListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal list response: %v; body=%s", err, w.Body.String())
+	}
+	return resp
+}
+
+// seedPendingSubmitTask builds a task whose personal result for userID has
+// finished generating but has not been submitted. extraParticipants controls
+// whether the task is multi-person (the gate for the submission signal).
+func seedPendingSubmitTask(t *testing.T, db *gorm.DB, taskNo, userID string, extraParticipants []string) int64 {
+	t.Helper()
+	now := timezone.Now()
+
+	task := model.SummaryTask{
+		TaskNo:      taskNo,
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusProcessing,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	if err := db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: userID, UserName: userID, Status: model.ParticipantAccepted,
+	}).Error; err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	for _, uid := range extraParticipants {
+		if err := db.Create(&model.SummaryParticipant{
+			TaskID: task.ID, UserID: uid, UserName: uid, Status: model.ParticipantAccepted,
+		}).Error; err != nil {
+			t.Fatalf("create participant %s: %v", uid, err)
+		}
+	}
+
+	// Personal summary generated (worker_status=Completed) but not submitted.
+	// No current_version_id / current_result_id is set, so is_unread stays false
+	// and the assertions below isolate the submission signal.
+	if err := db.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: userID, Content: "personal draft",
+		WorkerStatus: model.PersonalStatusCompleted, SubmittedAt: nil,
+		CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("create personal result: %v", err)
+	}
+
+	return task.ID
+}
+
+func TestListSummaries_PendingSubmissionDrivesAttention(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-MULTI", "participant1", []string{"participant2"})
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != taskID {
+		t.Fatalf("expected the seeded task in the list, got %+v", resp.Data)
+	}
+	item := resp.Data.Items[0]
+	if !item.HasPendingSubmission {
+		t.Fatalf("generated-but-unsubmitted personal result must flag pending submission: %+v", item)
+	}
+	if item.IsUnread || item.HasPendingInvitation {
+		t.Fatalf("test isolates the submission signal; unread/invitation must be off: %+v", item)
+	}
+	if !item.NeedsAttention {
+		t.Fatalf("pending submission must raise needs_attention (the card red dot): %+v", item)
+	}
+	if resp.Data.AttentionCount != 1 || resp.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("pending submission must feed the sidebar counts: attention=%d submission=%d",
+			resp.Data.AttentionCount, resp.Data.PendingSubmissionCount)
+	}
+	if resp.Data.UnreadCount != 0 || resp.Data.PendingInvitationCount != 0 {
+		t.Fatalf("submission must not leak into the unread/invitation breakdown: %+v", resp.Data)
+	}
+}
+
+func TestListSummaries_SubmittedPersonalResultClearsAttention(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-DONE", "participant1", []string{"participant2"})
+	now := timezone.Now()
+	if err := db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", taskID, "participant1").
+		Updates(map[string]interface{}{"submitted_at": now, "submit_source": model.SubmitSourceManual}).Error; err != nil {
+		t.Fatalf("mark submitted: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected the seeded task, got %+v", resp.Data)
+	}
+	if resp.Data.Items[0].HasPendingSubmission || resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("submitting must clear the dot: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 0 || resp.Data.PendingSubmissionCount != 0 {
+		t.Fatalf("counts must drop after submit: attention=%d submission=%d",
+			resp.Data.AttentionCount, resp.Data.PendingSubmissionCount)
+	}
+}
+
+func TestListSummaries_SinglePersonTaskNeverPendsSubmission(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	// Sole participant: there is no team to submit into, so an unsubmitted
+	// personal result is just the owner's own summary.
+	seedPendingSubmitTask(t, db, "SUBMIT-SOLO", "participant1", nil)
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected the seeded task, got %+v", resp.Data)
+	}
+	if resp.Data.Items[0].HasPendingSubmission || resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("single-person task must not pend submission: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 0 || resp.Data.PendingSubmissionCount != 0 {
+		t.Fatalf("single-person task must not raise counts: %+v", resp.Data)
+	}
+}
+
+// Owner decision 2026-08-26: reading is not submitting. Opening the detail page
+// records the read cursor, but the participant still owes the team a /submit,
+// so the dot must survive MarkSummaryRead.
+func TestMarkSummaryRead_KeepsPendingSubmissionAttention(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-READ", "participant1", []string{"participant2"})
+
+	now := timezone.Now()
+	version := model.PersonalResultVersion{
+		TaskID: taskID, UserID: "participant1", Content: "personal", Version: 1,
+		GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&version).Error; err != nil {
+		t.Fatalf("create personal version: %v", err)
+	}
+	if err := db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", taskID, "participant1").
+		Update("current_version_id", version.ID).Error; err != nil {
+		t.Fatalf("attach current version: %v", err)
+	}
+
+	r := setupReadRouter(NewTaskHandler(db, imDB, ""))
+	w := markReadRequest(r, taskID, "participant1", fmt.Sprintf(`{"personal_version_id":%d}`, version.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			IsUnread             bool `json:"is_unread"`
+			HasPendingInvitation bool `json:"has_pending_invitation"`
+			HasPendingSubmission bool `json:"has_pending_submission"`
+			NeedsAttention       bool `json:"needs_attention"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal mark-read response: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.IsUnread {
+		t.Fatalf("the rendered version was recorded, so content is read: %+v", resp.Data)
+	}
+	if !resp.Data.HasPendingSubmission || !resp.Data.NeedsAttention {
+		t.Fatalf("reading must not clear the pending-submission dot: %+v", resp.Data)
+	}
+
+	// The list projection must agree with the read response — a client that
+	// refreshes instead of trusting the optimistic update sees the same dot.
+	lr := setupListRouter(NewTaskHandler(db, imDB, ""))
+	lw := doRequest(lr, http.MethodGet, "/api/v1/summaries", "participant1")
+	list := parseAttentionList(t, lw)
+	if len(list.Data.Items) != 1 || !list.Data.Items[0].NeedsAttention || !list.Data.Items[0].HasPendingSubmission {
+		t.Fatalf("list must keep the dot after read: %+v", list.Data)
+	}
+	if list.Data.AttentionCount != 1 || list.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("counts must survive read: attention=%d submission=%d",
+			list.Data.AttentionCount, list.Data.PendingSubmissionCount)
+	}
+}

--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -401,11 +401,17 @@ func setupReadRouter(h *TaskHandler) *gin.Engine {
 }
 
 func markReadRequest(r *gin.Engine, taskID int64, userID string, body string) *httptest.ResponseRecorder {
+	return markReadRequestWithSpace(r, taskID, userID, "space1", body)
+}
+
+// markReadRequestWithSpace is the Space-explicit form. The MySQL integration
+// tests seed into their own space, so they cannot use the "space1" default.
+func markReadRequestWithSpace(r *gin.Engine, taskID int64, userID, spaceID, body string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/summaries/%d/read", taskID), bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Token", userID)
-	req.Header.Set("X-Space-Id", "space1")
+	req.Header.Set("X-Space-Id", spaceID)
 	r.ServeHTTP(w, req)
 	return w
 }

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -658,9 +658,15 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	}
 
 	// Attention is caller-specific. Compute it only after schedule folding, then
-	// sort before pagination. A pending invitation outranks unread content; team
-	// and personal cursors are compared independently because their ids belong to
-	// different tables.
+	// sort before pagination. A pending invitation outranks a pending submission,
+	// which outranks unread content; team and personal cursors are compared
+	// independently because their ids belong to different tables.
+	//
+	// All three signals feed needs_attention (the per-card red dot) and
+	// attention_count (the sidebar badge). has_pending_submission is deliberately
+	// NOT cleared by MarkSummaryRead: opening the detail page marks the content
+	// read, but the participant still owes the team an explicit /submit, so the
+	// dot survives until submitted_at is set.
 	attentionJoins := `
  LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
  LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
@@ -683,7 +689,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	      THEN CASE WHEN cr.generated_at >= pv.generated_at THEN cr.generated_at ELSE pv.generated_at END
 	      ELSE COALESCE(cr.generated_at, pv.generated_at, sub.created_at) END AS activity_at`
 	pageSQL := "SELECT sub.*" + attentionSelect + " FROM (" + innerSQL + ") sub" + attentionJoins +
-		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
+		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, has_pending_submission DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
 	pageArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		pageArgs = append(pageArgs, userID)
@@ -909,7 +915,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"is_unread":                    attention.IsUnread,
 			"has_pending_invitation":       attention.HasPendingInvitation,
 			"has_pending_submission":       attention.HasPendingSubmission,
-			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation,
+			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation || attention.HasPendingSubmission,
 			"current_result_id":            attention.ListCurrentResultID,
 			"current_personal_version_id":  attention.CurrentPersonalVersionID,
 			"activity_at":                  attention.ActivityAt,
@@ -922,16 +928,25 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	// Counts deliberately ignore the current list filters: the navigation badge
 	// represents all cards that require this user's attention in the space.
 	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
-	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
+	//
+	// ⚠️ The placeholders below are positional and hand-assembled; countArgs must
+	// be appended in exactly the textual order the `?`s appear:
+	//   1. has_invite      -> ParticipantPending [+ userID when schedulePendingExpr is live (MySQL only)]
+	//   2. has_submit      -> PersonalStatusCompleted
+	//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
+	//   4. attentionJoins  -> userID x4
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1 THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
 	var counts struct {
 		AttentionCount         int64 `gorm:"column:attention_count"`
 		UnreadCount            int64 `gorm:"column:unread_count"`
 		PendingInvitationCount int64 `gorm:"column:pending_invitation_count"`
+		PendingSubmissionCount int64 `gorm:"column:pending_submission_count"`
 	}
 	countArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		countArgs = append(countArgs, userID)
 	}
+	countArgs = append(countArgs, model.PersonalStatusCompleted)
 	countArgs = append(countArgs, spaceID, userID, userID)
 	if h.db.Dialector.Name() == "mysql" {
 		countArgs = append(countArgs, userID)
@@ -942,7 +957,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
 		return
 	}
-	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount})
+	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount, "pending_submission_count": counts.PendingSubmissionCount})
 }
 
 type markSummaryReadRequest struct {
@@ -1002,13 +1017,19 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 		ReadTeamID        *int64 `gorm:"column:read_team_id"`
 		ReadPersonalID    *int64 `gorm:"column:read_personal_id"`
 		PendingInvitation bool   `gorm:"column:pending_invitation"`
+		PendingSubmission bool   `gorm:"column:pending_submission"`
 	}
 	schedulePendingExpr := h.schedulePendingInvitationExpr("t")
+	// pending_submission mirrors the list projection. Marking content read must
+	// NOT clear it: the participant has seen their personal summary but still
+	// owes the team an explicit /submit. Returning it here keeps the client's
+	// optimistic needs_attention recompute from dropping the dot on read.
 	stateSQL := `SELECT t.current_result_id AS current_team_id,
  pr.current_version_id AS current_personal_id,
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
- CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation
+ CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1 THEN 1 ELSE 0 END AS pending_submission
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?
@@ -1018,6 +1039,7 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	if h.db.Dialector.Name() == "mysql" {
 		stateArgs = append(stateArgs, userID)
 	}
+	stateArgs = append(stateArgs, model.PersonalStatusCompleted)
 	stateArgs = append(stateArgs, userID, userID, userID, taskID)
 	if err := h.db.Raw(stateSQL, stateArgs...).Scan(&state).Error; err != nil {
 		log.Printf("mark summary read state query failed: %v", err)
@@ -1030,7 +1052,8 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	ok(c, gin.H{
 		"task_id": taskID, "team_result_id": req.TeamResultID, "personal_version_id": req.PersonalVersionID,
 		"is_unread": isUnread, "has_pending_invitation": state.PendingInvitation,
-		"needs_attention": isUnread || state.PendingInvitation,
+		"has_pending_submission": state.PendingSubmission,
+		"needs_attention":        isUnread || state.PendingInvitation || state.PendingSubmission,
 	})
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -77,6 +77,38 @@ func (h *TaskHandler) schedulePendingInvitationExpr(taskAlias string) string {
  AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
 }
 
+// pendingSubmitStatusGuard excludes terminally-dead tasks from the
+// pending-submission signal, for the given summary_task alias.
+//
+// The raw predicate (personal worker_status=Completed AND submitted_at IS NULL
+// AND roster > 1) has no notion of the task's own lifecycle, and two ordinary
+// paths strand a task while a participant's personal result still matches it:
+//
+//  1. the stuck-task reaper flips Processing -> Failed once retry_count is
+//     exhausted (worker/scheduler.go), which is exactly the outcome of the
+//     situation this signal exists to prevent — metaCompletionReady blocks
+//     aggregation until every accepted participant is terminal, so one member
+//     who never submits stalls the task until the reaper kills it;
+//  2. CancelSummary writes status=Cancelled and nothing else.
+//
+// Neither touches summary_personal_result, so the member who *did* generate
+// their summary would keep a red dot — and a non-zero space-level
+// attention_count — for a task nobody can revive (Regenerate and Delete are
+// both creator-gated). A badge that cannot return to zero destroys the
+// credibility of the whole signal, so gate it server-side.
+//
+// Completed is deliberately NOT excluded: a personal-only regenerate on a
+// finished task intentionally leaves submitted_at NULL and waits for an
+// explicit submit (worker/personal_processor.go), so the dot is correct there.
+//
+// The constants are inlined rather than bound as parameters on purpose. Every
+// call site lives in hand-assembled SQL whose arguments are positional; adding
+// two placeholders in four statements is precisely the hazard the ordering
+// comment in ListSummaries warns about.
+func pendingSubmitStatusGuard(taskAlias string) string {
+	return fmt.Sprintf(" AND %s.status NOT IN (%d,%d)", taskAlias, model.StatusFailed, model.StatusCancelled)
+}
+
 // R11 Q2 (owner decision 2026-08-14, option 1): a task whose origin was
 // inherited from a DERIVED (worker-backfilled) source row carries
 // OriginFromDerived=true. List/detail projections mask such an origin to
@@ -585,7 +617,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 				// yet started, pending task invitations, and pending schedule invitations.
 				// Apply it before pagination to keep totals and pages accurate.
 				statusPendingExpr := h.schedulePendingInvitationExpr("summary_task")
-				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1) OR " + statusPendingExpr + ")"
+				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1" + pendingSubmitStatusGuard("summary_task") + ") OR " + statusPendingExpr + ")"
 				args = append(args, v, userID, model.ParticipantPending, userID, model.PersonalStatusCompleted)
 				if h.db.Dialector.Name() == "mysql" {
 					args = append(args, userID)
@@ -679,7 +711,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
 	attentionSelect := `,
  CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1 THEN 1 ELSE 0 END AS has_pending_submission,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1` + pendingSubmitStatusGuard("sub") + ` THEN 1 ELSE 0 END AS has_pending_submission,
  CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
         OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id <> pr.current_version_id))
       THEN 1 ELSE 0 END AS is_unread,
@@ -935,7 +967,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	//   2. has_submit      -> PersonalStatusCompleted
 	//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
 	//   4. attentionJoins  -> userID x4
-	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1 THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1" + pendingSubmitStatusGuard("sub") + " THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
 	var counts struct {
 		AttentionCount         int64 `gorm:"column:attention_count"`
 		UnreadCount            int64 `gorm:"column:unread_count"`
@@ -1029,7 +1061,7 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
  CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1 THEN 1 ELSE 0 END AS pending_submission
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1` + pendingSubmitStatusGuard("t") + ` THEN 1 ELSE 0 END AS pending_submission
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?


### PR DESCRIPTION
## Summary

`ListSummaries` has computed `has_pending_submission` since #167, but the flag never reached `needs_attention` or `attention_count`. The frontend only used it to relabel a card's status badge as "waiting", so a participant whose personal summary had finished generating had **no indicator anywhere** that the team was blocked on their `/submit`.

This wires the existing signal into the two projections that actually drive UI.

## Related Issue

Closes #230

Follow-up to #159 (per-user unread + attention model) and #167 (`has_pending_submission`). Pairs with octo-web `feat/summary-attention-badge`, which switches the sidebar badge to `attention_count`.

## Changes

- `needs_attention` (per-card red dot) now ORs `has_pending_submission`.
- `attention_count` (sidebar badge) gains the same term, plus a new `pending_submission_count` breakdown alongside `unread_count` / `pending_invitation_count`.
- List ordering places pending submissions between invitations and unread content.
- `MarkSummaryRead` returns `has_pending_submission` and includes it in its own `needs_attention` recompute.

### Terminal tasks are excluded (added in review round 2)

`pendingSubmitStatusGuard` excludes `Failed` and `Cancelled` at all four sites that carry the predicate (list projection, attention-count query, `MarkSummaryRead`, and the pre-existing `status=waiting` filter). Without it, the stuck-task reaper or a manual cancel leaves a participant holding a red dot — and a permanently non-zero `attention_count` — for a task nobody can revive, since `Regenerate` and `Delete` are creator-gated. `Completed` stays eligible: a personal-only regenerate intentionally waits for an explicit submit.

### Reading is deliberately not submitting

Owner decision 2026-08-26: opening the detail page records the read cursor, but the participant still owes the team an explicit `/submit`. The dot therefore **survives `MarkSummaryRead`** and clears only when `submitted_at` is set. `MarkSummaryRead` returning the flag is what lets a client recompute `needs_attention` without dropping it.

### Placeholder ordering (the risky part)

`attentionCountSQL` is hand-assembled with positional placeholders. The new `has_submit` term sits between the invitation term and `countInner`, so `model.PersonalStatusCompleted` must be appended to `countArgs` at exactly that position. Both dialect branches (the MySQL-only `JSON_TABLE` roster predicates in `schedulePendingInvitationExpr` / `scheduleVisibilityExpr`) are unaffected — they still contribute their `userID` conditionally, before and after the new argument respectively.

A comment now documents the full placeholder order so a future edit does not shift the arguments silently:

```
//   1. has_invite      -> ParticipantPending [+ userID when schedulePendingExpr is live (MySQL only)]
//   2. has_submit      -> PersonalStatusCompleted
//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
//   4. attentionJoins  -> userID x4
```

The same insertion applies to `MarkSummaryRead`'s `stateArgs`.

## Testing

New `internal/api/handler/attention_pending_submit_test.go`:

- a generated-but-unsubmitted personal result raises the dot and both counts, without leaking into the unread/invitation breakdown
- submitting clears the dot and the counts
- single-person tasks never pend submission (nobody to submit to — the existing `COUNT(*) > 1` gate)
- `MarkSummaryRead` keeps the dot, and the list projection agrees with the read response
- a reaper-failed or creator-cancelled task drops the dot in both producers
- a `Completed` task with a regenerated personal result still holds it
- the `status=waiting` filter agrees with the badge

`attention_pending_submit_mysql_test.go` (opt-in, `SUMMARY_MYSQL_TEST_DSN`) covers the MySQL placeholder ordering for the attention-count query and `MarkSummaryRead` — the two statements the existing MySQL test does not touch. It seeds a live `confirm_policy=1` roster so `schedulePendingInvitationExpr` actually binds its placeholder, and asserts count values rather than booleans (a misaligned argument yields 0 silently instead of erroring).

Commands:

```
CGO_LDFLAGS="-L/usr/local/lib" go test ./internal/api/handler/ -count=1   # full package, 29.9s, pass
CGO_ENABLED=0 go vet ./...                                               # clean
```

- [x] Unit tests added/updated
- [x] Manually verified (SQLite handler tests; the MySQL-only schedule predicate path is unchanged and still covered by the opt-in `SUMMARY_MYSQL_TEST_DSN` test)

## Rollout note

List ordering gains a `has_pending_submission DESC` term between the invitation and unread terms. Any client asserting on list order will see a shift when this deploys, independent of the frontend change.

## Compatibility

- No schema change. `summary_user_read`, `summary_personal_result.submitted_at` and `worker_status` all already exist.
- `pending_submission_count` is additive; existing clients ignore it.
- Deploying this **before** the octo-web change is harmless: the card dot appears immediately, the sidebar badge simply keeps its old narrower meaning until the frontend lands.

## Checklist

- [x] PR description is in English
- [x] Added tests for my changes
- [x] Followed commit message conventions (Conventional Commits)
