### PR TITLE
feat(summary): 可轮询的 attention 计数接口（复用列表自身的 SQL）

### DIFF
--- a/internal/api/handler/attention.go
+++ b/internal/api/handler/attention.go
@@ -1,0 +1,254 @@
+package handler
+
+import (
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+)
+
+// attentionJoinsSQL is the caller-specific join block shared by the ListSummaries
+// page query and the attention-count query. It is a single constant on purpose:
+// the count and the per-card dots must be derived from exactly the same rows, or
+// the sidebar badge and the list disagree and neither can be trusted.
+//
+// It contributes FOUR positional placeholders, all userID, in textual order.
+const attentionJoinsSQL = `
+ LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
+ LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
+ LEFT JOIN summary_personal_result pr ON pr.task_id = sub.id AND pr.user_id = ?
+ LEFT JOIN summary_personal_result_version pv ON pv.id = pr.current_version_id AND pv.task_id = sub.id AND pv.user_id = ?
+ LEFT JOIN summary_participant me ON me.task_id = sub.id AND me.user_id = ?`
+
+// attentionCounts is the space-level, caller-specific attention breakdown that
+// drives the navigation badge.
+type attentionCounts struct {
+	AttentionCount         int64 `gorm:"column:attention_count" json:"attention_count"`
+	UnreadCount            int64 `gorm:"column:unread_count" json:"unread_count"`
+	PendingInvitationCount int64 `gorm:"column:pending_invitation_count" json:"pending_invitation_count"`
+	PendingSubmissionCount int64 `gorm:"column:pending_submission_count" json:"pending_submission_count"`
+}
+
+// attentionCounts computes the attention breakdown for one (space, user) pair.
+//
+// This is the ONLY place the attention statistics SQL exists. Both the list
+// endpoint (which returns the counts alongside its page) and the dedicated
+// polling endpoint call it, so the badge shown by a poll can never drift from
+// the badge shown by a list refresh — a second hand-maintained copy of this
+// query would drift the first time either signal's definition changed.
+//
+// Counts deliberately ignore the list filters: the navigation badge represents
+// all cards that require this user's attention in the space.
+func (h *TaskHandler) attentionCounts(spaceID, userID string) (attentionCounts, error) {
+	var counts attentionCounts
+
+	scheduleVisibilityExpr := h.schedulePendingInvitationExpr("summary_task")
+	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
+
+	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
+	//
+	// ⚠️ The placeholders below are positional and hand-assembled; countArgs must
+	// be appended in exactly the textual order the `?`s appear:
+	//   1. has_invite      -> ParticipantPending [+ userID when schedulePendingExpr is live (MySQL only)]
+	//   2. has_submit      -> PersonalStatusCompleted
+	//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
+	//   4. attentionJoins  -> userID x4
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1" + pendingSubmitStatusGuard("sub") + " THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoinsSQL + " WHERE sub.rn=1) attention"
+
+	countArgs := []interface{}{model.ParticipantPending}
+	if h.db.Dialector.Name() == "mysql" {
+		countArgs = append(countArgs, userID)
+	}
+	countArgs = append(countArgs, model.PersonalStatusCompleted)
+	countArgs = append(countArgs, spaceID, userID, userID)
+	if h.db.Dialector.Name() == "mysql" {
+		countArgs = append(countArgs, userID)
+	}
+	countArgs = append(countArgs, userID, userID, userID, userID)
+
+	if err := h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts).Error; err != nil {
+		return attentionCounts{}, err
+	}
+	return counts, nil
+}
+
+// ---------------------------------------------------------------------------
+// Polling cache
+// ---------------------------------------------------------------------------
+
+// attentionCacheTTL bounds how stale a polled badge may be. Five seconds is
+// short enough that a user who never triggers an explicit refresh still
+// converges quickly, and long enough to collapse the fan-out of a browser tab
+// polling every second (plus every duplicated tab of the same user).
+const attentionCacheTTL = 5 * time.Second
+
+// maxAttentionCacheEntries caps memory for the whole process. The key space is
+// (user, space), which grows with the active population and is unbounded over a
+// long uptime, so the map MUST NOT be allowed to grow forever. Overflow is
+// handled by dropping entries, never by refusing to answer: a dropped entry only
+// costs one extra query.
+const maxAttentionCacheEntries = 4096
+
+type attentionCacheKey struct {
+	userID  string
+	spaceID string
+}
+
+type attentionCacheEntry struct {
+	counts    attentionCounts
+	expiresAt time.Time
+}
+
+// attentionCache is a plain in-process TTL cache.
+//
+// Why in-process and not a shared cache: the API deployment runs a single
+// replica by default, and the value being cached is a cheap, self-healing
+// derived number with a 5s lifetime. A shared cache would add an infrastructure
+// dependency and a new failure mode to protect a query the database can already
+// answer; if the process count ever grows, each replica simply keeps its own
+// copy, which is still correct because every entry expires on its own.
+//
+// Why there is NO write-path invalidation:
+//
+//	Correctness here comes from bounded staleness plus an explicit refresh
+//	(`?fresh=1`) on the reads that follow a user action, NOT from remembering to
+//	poke this cache from every code path that can change an attention signal.
+//	Invalidation hooks would have to be added to read-marking, invite accept and
+//	decline, member add and remove, submit, personal edit, regenerate, delete,
+//	cancel, the scheduler, and the worker — and every future path that touches
+//	those tables. A single missed hook produces a badge that is stuck FOREVER
+//	(until an unrelated request happens to evict the entry): the user clears
+//	their tasks and the red dot never goes away, with nothing they can do about
+//	it. That failure is silent, user-visible, and unbounded in time. Five seconds
+//	of staleness is bounded, self-correcting, and invisible in practice. Trading
+//	a bounded, self-healing error for an unbounded, silent one is never worth it,
+//	so this cache intentionally has no invalidation surface at all.
+type attentionCache struct {
+	mu      sync.Mutex
+	entries map[attentionCacheKey]attentionCacheEntry
+	ttl     time.Duration
+	// now is injectable so TTL behaviour can be tested deterministically
+	// instead of with real sleeps.
+	now func() time.Time
+}
+
+func newAttentionCache() *attentionCache {
+	return &attentionCache{
+		entries: make(map[attentionCacheKey]attentionCacheEntry),
+		ttl:     attentionCacheTTL,
+		now:     time.Now,
+	}
+}
+
+// get returns the cached counts when the entry exists and has not expired.
+func (c *attentionCache) get(key attentionCacheKey) (attentionCounts, bool) {
+	if c == nil {
+		return attentionCounts{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, found := c.entries[key]
+	if !found {
+		return attentionCounts{}, false
+	}
+	if !c.now().Before(entry.expiresAt) {
+		// Expired entries are dropped on sight so a key that stops being
+		// polled cannot pin memory until the next overflow sweep.
+		delete(c.entries, key)
+		return attentionCounts{}, false
+	}
+	return entry.counts, true
+}
+
+// put stores freshly computed counts, evicting as needed to stay under the cap.
+func (c *attentionCache) put(key attentionCacheKey, counts attentionCounts) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now()
+	if len(c.entries) >= maxAttentionCacheEntries {
+		for k, e := range c.entries {
+			if !now.Before(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		// Still full: every entry is live, so there is no "least valuable"
+		// one to pick without tracking extra metadata. Reset wholesale. The
+		// only cost is that the next poll of each dropped key re-queries,
+		// and the cap is high enough that this is a pathological case.
+		if len(c.entries) >= maxAttentionCacheEntries {
+			c.entries = make(map[attentionCacheKey]attentionCacheEntry)
+		}
+	}
+	c.entries[key] = attentionCacheEntry{counts: counts, expiresAt: now.Add(c.ttl)}
+}
+
+// GetAttention handles GET /api/v1/summaries/attention.
+//
+// It is the poll-friendly sibling of ListSummaries: same numbers, none of the
+// page rendering (participants, sources, per-task result lookups). Clients that
+// only need the badge should poll this instead of re-listing.
+//
+// `?fresh=1` bypasses and refreshes the cache. Callers must use it on the read
+// that immediately follows a user action which can change a signal (marking a
+// summary read, accepting or declining an invitation, submitting) so the badge
+// reacts instantly; plain polls take the cached path.
+func (h *TaskHandler) GetAttention(c *gin.Context) {
+	spaceID := middleware.GetSpaceID(c)
+	// Same fail-closed hard gate as ListSummaries: SummaryTask.SpaceID is
+	// `not null default ''`, so querying `space_id=''` would MATCH rows with an
+	// empty space and leak them across spaces. Reject before any query.
+	if spaceID == "" {
+		c.JSON(http.StatusNotFound, apiResponse{Code: 40008, Message: "任务不存在"})
+		return
+	}
+	userID := middleware.GetUserID(c)
+
+	// The key is (user, space) because the counts are caller-specific AND
+	// space-specific: the same user has a different badge per space, and two
+	// users in one space must never see each other's numbers.
+	key := attentionCacheKey{userID: userID, spaceID: spaceID}
+	fresh := c.Query("fresh") == "1"
+	if !fresh {
+		if counts, hit := h.attentionCacheGet(key); hit {
+			writeAttentionCounts(c, counts)
+			return
+		}
+	}
+
+	counts, err := h.attentionCounts(spaceID, userID)
+	if err != nil {
+		log.Printf("attention count query failed: %v", err)
+		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to load attention counts"})
+		return
+	}
+	h.attentionCachePut(key, counts)
+	writeAttentionCounts(c, counts)
+}
+
+func writeAttentionCounts(c *gin.Context, counts attentionCounts) {
+	ok(c, gin.H{
+		"attention_count":          counts.AttentionCount,
+		"unread_count":             counts.UnreadCount,
+		"pending_invitation_count": counts.PendingInvitationCount,
+		"pending_submission_count": counts.PendingSubmissionCount,
+	})
+}
+
+// attentionCacheGet / attentionCachePut are the handler-level accessors. They
+// tolerate a nil cache so a TaskHandler built by any other construction path
+// still works (uncached, always fresh) instead of panicking.
+func (h *TaskHandler) attentionCacheGet(key attentionCacheKey) (attentionCounts, bool) {
+	return h.attentionCache.get(key)
+}
+
+func (h *TaskHandler) attentionCachePut(key attentionCacheKey, counts attentionCounts) {
+	h.attentionCache.put(key, counts)
+}

--- a/internal/api/handler/attention.go
+++ b/internal/api/handler/attention.go
@@ -173,18 +173,32 @@ func (c *attentionCache) put(key attentionCacheKey, counts attentionCounts) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	now := c.now()
+	// Refreshing an existing key must never wipe the entire cache. Without
+	// this short-circuit a put at capacity flushes all live entries.
+	if _, exists := c.entries[key]; exists {
+		c.entries[key] = attentionCacheEntry{counts: counts, expiresAt: now.Add(c.ttl)}
+		return
+	}
 	if len(c.entries) >= maxAttentionCacheEntries {
 		for k, e := range c.entries {
 			if !now.Before(e.expiresAt) {
 				delete(c.entries, k)
 			}
 		}
-		// Still full: every entry is live, so there is no "least valuable"
-		// one to pick without tracking extra metadata. Reset wholesale. The
-		// only cost is that the next poll of each dropped key re-queries,
-		// and the cap is high enough that this is a pathological case.
+		// Still full: every entry is live, so evict the one closest to
+		// expiry rather than resetting wholesale.
 		if len(c.entries) >= maxAttentionCacheEntries {
-			c.entries = make(map[attentionCacheKey]attentionCacheEntry)
+			var oldestK attentionCacheKey
+			var oldestT time.Time
+			first := true
+			for k, e := range c.entries {
+				if first || e.expiresAt.Before(oldestT) {
+					oldestK = k
+					oldestT = e.expiresAt
+					first = false
+				}
+			}
+			delete(c.entries, oldestK)
 		}
 	}
 	c.entries[key] = attentionCacheEntry{counts: counts, expiresAt: now.Add(c.ttl)}

--- a/internal/api/handler/attention_endpoint_test.go
+++ b/internal/api/handler/attention_endpoint_test.go
@@ -1,0 +1,400 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/middleware"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+)
+
+// GET /api/v1/summaries/attention is the poll-friendly badge endpoint. These
+// tests pin the two properties that make it safe to add:
+//
+//  1. it can never disagree with the list endpoint (both must go through the
+//     one attentionCounts helper), and
+//  2. its 5s cache is scoped per (user, space), bypassable with ?fresh=1, and
+//     genuinely expires — a badge that gets stuck is worse than no badge.
+
+type attentionCountsResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		AttentionCount         int `json:"attention_count"`
+		UnreadCount            int `json:"unread_count"`
+		PendingInvitationCount int `json:"pending_invitation_count"`
+		PendingSubmissionCount int `json:"pending_submission_count"`
+	} `json:"data"`
+}
+
+func parseAttentionCounts(t *testing.T, w *httptest.ResponseRecorder) attentionCountsResponse {
+	t.Helper()
+	var resp attentionCountsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal attention response: %v; body=%s", err, w.Body.String())
+	}
+	return resp
+}
+
+// setupAttentionRouter mounts the attention endpoint next to the list endpoint
+// AND next to the /summaries/:id wildcard. Registering the static sibling here
+// is itself an assertion: gin panics at registration time on a route tree it
+// cannot represent, so a regression in the route shape fails every test in this
+// file rather than only at server start.
+func setupAttentionRouter(h *TaskHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.AuthMiddleware(&mockTokenResolver{}), middleware.SpaceMiddleware())
+	r.GET("/api/v1/summaries", h.ListSummaries)
+	r.GET("/api/v1/summaries/attention", h.GetAttention)
+	r.GET("/api/v1/summaries/:id", h.GetSummary)
+	return r
+}
+
+// seedAttentionFixture builds one task per attention signal for userID in
+// spaceID: a pending invitation, a pending submission, and unread team content.
+func seedAttentionFixture(t *testing.T, db *gorm.DB, prefix, spaceID, userID string) {
+	t.Helper()
+	now := timezone.Now()
+
+	// 1. Pending invitation.
+	invite := model.SummaryTask{
+		TaskNo: prefix + "-INVITE", SpaceID: spaceID, CreatorID: "creator1",
+		SummaryMode: model.ModeByPerson, Status: model.StatusProcessing,
+	}
+	if err := db.Create(&invite).Error; err != nil {
+		t.Fatalf("create invite task: %v", err)
+	}
+	if err := db.Create(&model.SummaryParticipant{
+		TaskID: invite.ID, UserID: userID, UserName: userID, Status: model.ParticipantPending,
+	}).Error; err != nil {
+		t.Fatalf("create pending participant: %v", err)
+	}
+
+	// 2. Pending submission (needs a second participant to be a team task).
+	seedPendingSubmitTaskInSpace(t, db, prefix+"-SUBMIT", spaceID, userID, []string{"participant2"})
+
+	// 3. Unread team result.
+	unread := model.SummaryTask{
+		TaskNo: prefix + "-UNREAD", SpaceID: spaceID, CreatorID: userID,
+		SummaryMode: model.ModeByPerson, Status: model.StatusCompleted,
+	}
+	if err := db.Create(&unread).Error; err != nil {
+		t.Fatalf("create unread task: %v", err)
+	}
+	result := model.SummaryResult{
+		TaskID: unread.ID, Content: "team result", Version: 1,
+		GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&result).Error; err != nil {
+		t.Fatalf("create team result: %v", err)
+	}
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", unread.ID).
+		Update("current_result_id", result.ID).Error; err != nil {
+		t.Fatalf("attach current result: %v", err)
+	}
+}
+
+// seedPendingSubmitTaskInSpace is the space-explicit form of
+// seedPendingSubmitTask; the per-space isolation test needs a space other than
+// the "space1" default.
+func seedPendingSubmitTaskInSpace(t *testing.T, db *gorm.DB, taskNo, spaceID, userID string, extraParticipants []string) int64 {
+	t.Helper()
+	now := timezone.Now()
+
+	task := model.SummaryTask{
+		TaskNo: taskNo, SpaceID: spaceID, CreatorID: "creator1",
+		SummaryMode: model.ModeByPerson, Status: model.StatusProcessing,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: userID, UserName: userID, Status: model.ParticipantAccepted,
+	}).Error; err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	for _, uid := range extraParticipants {
+		if err := db.Create(&model.SummaryParticipant{
+			TaskID: task.ID, UserID: uid, UserName: uid, Status: model.ParticipantAccepted,
+		}).Error; err != nil {
+			t.Fatalf("create participant %s: %v", uid, err)
+		}
+	}
+	if err := db.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: userID, Content: "personal draft",
+		WorkerStatus: model.PersonalStatusCompleted, SubmittedAt: nil,
+		CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("create personal result: %v", err)
+	}
+	return task.ID
+}
+
+// The drift guard. The whole reason attentionCounts exists as a shared helper
+// is that a second copy of this SQL would eventually disagree with the first,
+// and the user would see a badge that contradicts the cards below it. Compare
+// the two endpoints on the same fixture, on every breakdown field.
+func TestGetAttention_MatchesListSummaries(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedAttentionFixture(t, db, "DRIFT", "space1", "participant1")
+
+	r := setupAttentionRouter(NewTaskHandler(db, imDB, ""))
+
+	lw := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	if lw.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", lw.Code, lw.Body.String())
+	}
+	list := parseAttentionList(t, lw)
+
+	aw := doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1")
+	if aw.Code != http.StatusOK {
+		t.Fatalf("attention: expected 200, got %d: %s", aw.Code, aw.Body.String())
+	}
+	att := parseAttentionCounts(t, aw)
+
+	// Sanity: the fixture must actually exercise all three signals, otherwise
+	// an all-zero match would pass vacuously.
+	if list.Data.AttentionCount != 3 || list.Data.UnreadCount != 1 ||
+		list.Data.PendingInvitationCount != 1 || list.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("fixture must raise all three signals, list said %+v", list.Data)
+	}
+
+	if att.Data.AttentionCount != list.Data.AttentionCount ||
+		att.Data.UnreadCount != list.Data.UnreadCount ||
+		att.Data.PendingInvitationCount != list.Data.PendingInvitationCount ||
+		att.Data.PendingSubmissionCount != list.Data.PendingSubmissionCount {
+		t.Fatalf("attention endpoint drifted from the list endpoint: attention=%+v list=%+v",
+			att.Data, list.Data)
+	}
+}
+
+// Same fail-closed gate as ListSummaries: SummaryTask.SpaceID defaults to '',
+// so an empty X-Space-Id would MATCH those rows and leak them across spaces.
+func TestGetAttention_RejectsEmptySpaceID(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedAttentionFixture(t, db, "NOSPACE", "space1", "participant1")
+
+	r := setupAttentionRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequestWithSpace(r, http.MethodGet, "/api/v1/summaries/attention", "participant1", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("empty X-Space-Id must be rejected with 404, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp apiResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal error body: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Code != 40008 {
+		t.Fatalf("expected code 40008, got %d: %s", resp.Code, w.Body.String())
+	}
+}
+
+// Within the TTL the endpoint answers from cache. This is the point of the
+// cache: a tab polling once a second must not become one full attention query
+// per second per tab.
+func TestGetAttention_CacheServesStaleValueWithinTTL(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedAttentionFixture(t, db, "CACHE", "space1", "participant1")
+
+	h := NewTaskHandler(db, imDB, "")
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	h.attentionCache.now = clock.Now
+	r := setupAttentionRouter(h)
+
+	first := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if first.Data.AttentionCount != 3 {
+		t.Fatalf("expected 3 attention items, got %+v", first.Data)
+	}
+
+	// Remove every signal behind the cache's back. No invalidation hook exists
+	// by design, so the cached answer must survive unchanged until it expires.
+	if err := db.Where("1 = 1").Delete(&model.SummaryTask{}).Error; err != nil {
+		t.Fatalf("delete tasks: %v", err)
+	}
+
+	clock.advance(attentionCacheTTL - time.Millisecond)
+	second := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if second.Data != first.Data {
+		t.Fatalf("within the TTL the cached value must be served: got %+v want %+v", second.Data, first.Data)
+	}
+}
+
+// ?fresh=1 is the escape hatch that makes the no-invalidation design work: the
+// read that follows a user action asks for a recomputation, so the badge reacts
+// immediately instead of lagging by up to a TTL.
+func TestGetAttention_FreshBypassesAndRefreshesCache(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedAttentionFixture(t, db, "FRESH", "space1", "participant1")
+
+	h := NewTaskHandler(db, imDB, "")
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	h.attentionCache.now = clock.Now
+	r := setupAttentionRouter(h)
+
+	first := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if first.Data.AttentionCount != 3 {
+		t.Fatalf("expected 3 attention items, got %+v", first.Data)
+	}
+
+	if err := db.Where("1 = 1").Delete(&model.SummaryTask{}).Error; err != nil {
+		t.Fatalf("delete tasks: %v", err)
+	}
+
+	fresh := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention?fresh=1", "participant1"))
+	if fresh.Data.AttentionCount != 0 || fresh.Data.UnreadCount != 0 ||
+		fresh.Data.PendingInvitationCount != 0 || fresh.Data.PendingSubmissionCount != 0 {
+		t.Fatalf("fresh=1 must bypass the cache: %+v", fresh.Data)
+	}
+
+	// It must also REFRESH the cache, not merely skip it — otherwise the next
+	// plain poll would resurrect the stale value the user just watched clear.
+	cached := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if cached.Data != fresh.Data {
+		t.Fatalf("fresh=1 must overwrite the cached entry: cached=%+v fresh=%+v", cached.Data, fresh.Data)
+	}
+}
+
+// Staleness must be bounded. If an entry could outlive its TTL the badge would
+// be stuck for a user who never triggers a fresh read.
+func TestGetAttention_CacheExpiresAfterTTL(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedAttentionFixture(t, db, "EXPIRE", "space1", "participant1")
+
+	h := NewTaskHandler(db, imDB, "")
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	h.attentionCache.now = clock.Now
+	r := setupAttentionRouter(h)
+
+	first := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if first.Data.AttentionCount != 3 {
+		t.Fatalf("expected 3 attention items, got %+v", first.Data)
+	}
+
+	if err := db.Where("1 = 1").Delete(&model.SummaryTask{}).Error; err != nil {
+		t.Fatalf("delete tasks: %v", err)
+	}
+
+	clock.advance(attentionCacheTTL)
+	after := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if after.Data.AttentionCount != 0 {
+		t.Fatalf("the entry must expire at the TTL boundary, got %+v", after.Data)
+	}
+}
+
+// The counts are caller-specific AND space-specific, so the key must be both.
+// A key missing either dimension would show one user another user's badge.
+func TestGetAttention_CacheIsKeyedPerUserAndSpace(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	// Only participant1 in space1 has anything pending.
+	seedAttentionFixture(t, db, "KEYED", "space1", "participant1")
+	// participant1 also belongs to space2, with nothing pending there.
+	otherSpaceTask := model.SummaryTask{
+		TaskNo: "KEYED-OTHER-SPACE", SpaceID: "space2", CreatorID: "participant1",
+		SummaryMode: model.ModeByPerson, Status: model.StatusCompleted,
+	}
+	if err := db.Create(&otherSpaceTask).Error; err != nil {
+		t.Fatalf("create space2 task: %v", err)
+	}
+
+	h := NewTaskHandler(db, imDB, "")
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	h.attentionCache.now = clock.Now
+	r := setupAttentionRouter(h)
+
+	// Warm the cache for (participant1, space1).
+	warm := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if warm.Data.AttentionCount != 3 {
+		t.Fatalf("expected 3 for participant1/space1, got %+v", warm.Data)
+	}
+
+	// Same space, different user: must not inherit participant1's number.
+	other := parseAttentionCounts(t, doRequestWithSpace(r, http.MethodGet, "/api/v1/summaries/attention", "participant2", "space1"))
+	if other.Data.AttentionCount != 0 {
+		t.Fatalf("user A's cached badge leaked to user B: %+v", other.Data)
+	}
+
+	// Same user, different space: must not inherit space1's number either.
+	otherSpace := parseAttentionCounts(t, doRequestWithSpace(r, http.MethodGet, "/api/v1/summaries/attention", "participant1", "space2"))
+	if otherSpace.Data.AttentionCount != 0 {
+		t.Fatalf("space X's cached badge leaked to space Y: %+v", otherSpace.Data)
+	}
+
+	// And the original entry is still intact (the other lookups were misses,
+	// not overwrites).
+	again := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if again.Data != warm.Data {
+		t.Fatalf("the (participant1, space1) entry was clobbered: got %+v want %+v", again.Data, warm.Data)
+	}
+}
+
+// ListSummaries must not READ the cache — its page rows and its badge are
+// computed in the same request, and serving a cached badge next to freshly
+// queried cards is exactly the inconsistency this endpoint set out to avoid.
+func TestListSummaries_IgnoresAttentionCacheOnRead(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	seedAttentionFixture(t, db, "LISTFRESH", "space1", "participant1")
+
+	h := NewTaskHandler(db, imDB, "")
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	h.attentionCache.now = clock.Now
+	r := setupAttentionRouter(h)
+
+	// Warm the cache with the three-signal state.
+	warm := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if warm.Data.AttentionCount != 3 {
+		t.Fatalf("expected 3 attention items, got %+v", warm.Data)
+	}
+
+	if err := db.Where("1 = 1").Delete(&model.SummaryTask{}).Error; err != nil {
+		t.Fatalf("delete tasks: %v", err)
+	}
+
+	list := parseAttentionList(t, doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1"))
+	if list.Data.AttentionCount != 0 {
+		t.Fatalf("the list must recompute its own badge, got %+v", list.Data)
+	}
+
+	// It DOES populate the cache, so the poll that follows a list load is cheap
+	// and agrees with what the list just rendered.
+	after := parseAttentionCounts(t, doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1"))
+	if after.Data.AttentionCount != 0 {
+		t.Fatalf("the list must refresh the cached entry it computed, got %+v", after.Data)
+	}
+}
+
+// The cache is keyed by (user, space), which is unbounded over a long uptime.
+// Pin the cap so a future change cannot turn it into a slow memory leak.
+func TestAttentionCache_BoundedSize(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	cache := newAttentionCache()
+	cache.now = clock.Now
+
+	for i := 0; i < maxAttentionCacheEntries*2; i++ {
+		cache.put(attentionCacheKey{userID: "u" + strconv.Itoa(i), spaceID: "space1"}, attentionCounts{AttentionCount: int64(i)})
+	}
+	cache.mu.Lock()
+	size := len(cache.entries)
+	cache.mu.Unlock()
+	if size > maxAttentionCacheEntries {
+		t.Fatalf("cache grew past its cap: %d > %d", size, maxAttentionCacheEntries)
+	}
+}
+
+// fakeClock drives the TTL deterministically; the TTL tests must not depend on
+// wall-clock sleeps.
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }

--- a/internal/api/handler/attention_endpoint_test.go
+++ b/internal/api/handler/attention_endpoint_test.go
@@ -46,10 +46,9 @@ func parseAttentionCounts(t *testing.T, w *httptest.ResponseRecorder) attentionC
 }
 
 // setupAttentionRouter mounts the attention endpoint next to the list endpoint
-// AND next to the /summaries/:id wildcard. Registering the static sibling here
-// is itself an assertion: gin panics at registration time on a route tree it
-// cannot represent, so a regression in the route shape fails every test in this
-// file rather than only at server start.
+// AND next to the /summaries/:id wildcard. gin's radix tree gives static
+// segments priority over wildcards at the same position regardless of
+// registration order, so both routes resolve correctly.
 func setupAttentionRouter(h *TaskHandler) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -156,7 +155,7 @@ func TestGetAttention_MatchesListSummaries(t *testing.T) {
 	}
 	list := parseAttentionList(t, lw)
 
-	aw := doRequest(r, http.MethodGet, "/api/v1/summaries/attention", "participant1")
+	aw := doRequest(r, http.MethodGet, "/api/v1/summaries/attention?fresh=1", "participant1")
 	if aw.Code != http.StatusOK {
 		t.Fatalf("attention: expected 200, got %d: %s", aw.Code, aw.Body.String())
 	}

--- a/internal/api/handler/attention_pending_submit_mysql_test.go
+++ b/internal/api/handler/attention_pending_submit_mysql_test.go
@@ -1,0 +1,149 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// MySQL placeholder-ordering coverage for the pending-submission argument.
+//
+// The SQLite harness cannot exercise schedulePendingInvitationExpr: it needs
+// JSON_TABLE, so on SQLite the predicate collapses to the constant "0" and
+// contributes no placeholder. On MySQL it contributes one `?` that sits
+// immediately BEFORE the new PersonalStatusCompleted argument in every
+// hand-assembled statement. A mutation that swapped those two would pass the
+// whole SQLite suite and only break in production.
+//
+// schedule_attention_mysql_test.go already pins the list query's ordering. This
+// covers the two statements it does not touch: the attention-count query (whose
+// new has_submit term is a third placeholder position) and MarkSummaryRead's
+// stateSQL (which had no MySQL coverage at all).
+//
+// Opt-in like its sibling: point SUMMARY_MYSQL_TEST_DSN at an isolated,
+// migrated database.
+func TestPendingSubmission_MySQL_PlaceholderOrderingAndMarkRead(t *testing.T) {
+	dsn := os.Getenv("SUMMARY_MYSQL_TEST_DSN")
+	if dsn == "" {
+		t.Skip("SUMMARY_MYSQL_TEST_DSN is not set")
+	}
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
+	if err != nil {
+		t.Fatalf("open mysql: %v", err)
+	}
+	for _, table := range []string{
+		"summary_task", "summary_source", "summary_participant", "summary_result",
+		"summary_personal_result", "summary_personal_result_version", "summary_user_read", "summary_schedule",
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Fatalf("mysql integration database is not migrated: missing %s", table)
+		}
+	}
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin transaction: %v", tx.Error)
+	}
+	defer tx.Rollback()
+
+	const spaceID = "pending-submit-mysql-space"
+	const me = "submit-owner"
+	now := timezone.Now()
+
+	// A schedule whose roster still has an unconfirmed member makes
+	// schedulePendingInvitationExpr live (confirm_policy=1), so its placeholder
+	// really is bound during this test rather than short-circuiting.
+	schedule := model.SummarySchedule{
+		SpaceID: spaceID, CreatorID: me, Title: "scheduled", SummaryMode: model.ModeByPerson,
+		CronExpr: "0 0 * * *", TimeRangeType: 1,
+		ParticipantConfig: model.JSON(`{"participants":[{"user_id":"other-invitee","confirmed":false}],"confirm_gate_passed":false}`),
+		ConfirmPolicy:     model.SchedConfirmRequire, IsActive: 1,
+	}
+	if err := tx.Create(&schedule).Error; err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+
+	task := model.SummaryTask{
+		TaskNo: "MYSQL-PENDING-SUBMIT", SpaceID: spaceID, CreatorID: me,
+		SummaryMode: model.ModeByPerson, Status: model.StatusProcessing,
+		TriggerType: model.TriggerScheduled, ScheduleID: &schedule.ID,
+		TimeRangeStart: time.Now().Add(-time.Hour), TimeRangeEnd: time.Now(),
+	}
+	if err := tx.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	for _, uid := range []string{me, "teammate"} {
+		if err := tx.Create(&model.SummaryParticipant{
+			TaskID: task.ID, UserID: uid, UserName: uid, Status: model.ParticipantAccepted,
+		}).Error; err != nil {
+			t.Fatalf("create participant %s: %v", uid, err)
+		}
+	}
+	version := model.PersonalResultVersion{
+		TaskID: task.ID, UserID: me, Content: "personal", Version: 1,
+		GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := tx.Create(&version).Error; err != nil {
+		t.Fatalf("create personal version: %v", err)
+	}
+	if err := tx.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: me, Content: "personal draft",
+		WorkerStatus: model.PersonalStatusCompleted, SubmittedAt: nil,
+		CurrentVersionID: &version.ID, CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("create personal result: %v", err)
+	}
+
+	// --- list projection + attention-count query ---
+	r := setupListRouter(NewTaskHandler(tx, nil, ""))
+	w := doRequestWithSpace(r, http.MethodGet, "/api/v1/summaries", me, spaceID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != task.ID {
+		t.Fatalf("expected the seeded task: %+v", resp.Data)
+	}
+	if !resp.Data.Items[0].HasPendingSubmission || !resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("MySQL list projection lost the pending submission: %+v", resp.Data.Items[0])
+	}
+	// A wrong argument position would not necessarily error — it would silently
+	// compare worker_status against a uid, yielding 0. Assert the value.
+	if resp.Data.PendingSubmissionCount != 1 || resp.Data.AttentionCount != 1 {
+		t.Fatalf("MySQL attention-count placeholders are misaligned: attention=%d submission=%d",
+			resp.Data.AttentionCount, resp.Data.PendingSubmissionCount)
+	}
+
+	// --- MarkSummaryRead stateSQL ---
+	rr := setupReadRouter(NewTaskHandler(tx, nil, ""))
+	rw := markReadRequestWithSpace(rr, task.ID, me, spaceID, fmt.Sprintf(`{"personal_version_id":%d}`, version.ID))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200 from mark-read, got %d: %s", rw.Code, rw.Body.String())
+	}
+	var readResp struct {
+		Data struct {
+			IsUnread             bool `json:"is_unread"`
+			HasPendingSubmission bool `json:"has_pending_submission"`
+			NeedsAttention       bool `json:"needs_attention"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rw.Body.Bytes(), &readResp); err != nil {
+		t.Fatalf("unmarshal mark-read response: %v; body=%s", err, rw.Body.String())
+	}
+	if readResp.Data.IsUnread {
+		t.Fatalf("the rendered version was recorded: %+v", readResp.Data)
+	}
+	if !readResp.Data.HasPendingSubmission || !readResp.Data.NeedsAttention {
+		t.Fatalf("MySQL stateSQL lost the pending submission on read: %+v", readResp.Data)
+	}
+}

--- a/internal/api/handler/attention_pending_submit_test.go
+++ b/internal/api/handler/attention_pending_submit_test.go
@@ -176,6 +176,122 @@ func TestListSummaries_SinglePersonTaskNeverPendsSubmission(t *testing.T) {
 	}
 }
 
+// A dead task must not keep nagging. The stuck-task reaper flips Processing ->
+// Failed once retries are exhausted (worker/scheduler.go) and CancelSummary
+// writes Cancelled; neither touches summary_personal_result, so without the
+// status guard the member who DID generate their summary keeps a red dot and a
+// non-zero space-level attention_count for a task nobody can revive
+// (Regenerate and Delete are creator-gated). A badge that cannot return to zero
+// is worse than no badge.
+func TestListSummaries_TerminalTaskDropsPendingSubmission(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		taskNo string
+		status int
+	}{
+		{"reaper marked it failed", "SUBMIT-FAILED", model.StatusFailed},
+		{"creator cancelled it", "SUBMIT-CANCELLED", model.StatusCancelled},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, imDB := setupListTestDBs(t)
+			taskID := seedPendingSubmitTask(t, db, tc.taskNo, "participant1", []string{"participant2"})
+			if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
+				Update("status", tc.status).Error; err != nil {
+				t.Fatalf("set terminal status: %v", err)
+			}
+
+			r := setupListRouter(NewTaskHandler(db, imDB, ""))
+			w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+			resp := parseAttentionList(t, w)
+			if len(resp.Data.Items) != 1 {
+				t.Fatalf("expected the seeded task, got %+v", resp.Data)
+			}
+			if resp.Data.Items[0].HasPendingSubmission || resp.Data.Items[0].NeedsAttention {
+				t.Fatalf("a terminal task must not pend submission: %+v", resp.Data.Items[0])
+			}
+			if resp.Data.AttentionCount != 0 || resp.Data.PendingSubmissionCount != 0 {
+				t.Fatalf("terminal task must not hold the badge above zero: %+v", resp.Data)
+			}
+
+			// MarkSummaryRead must agree — it is the other needs_attention producer.
+			rr := setupReadRouter(NewTaskHandler(db, imDB, ""))
+			now := timezone.Now()
+			version := model.PersonalResultVersion{
+				TaskID: taskID, UserID: "participant1", Content: "personal", Version: 1,
+				GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+			}
+			if err := db.Create(&version).Error; err != nil {
+				t.Fatalf("create personal version: %v", err)
+			}
+			if err := db.Model(&model.PersonalResult{}).
+				Where("task_id = ? AND user_id = ?", taskID, "participant1").
+				Update("current_version_id", version.ID).Error; err != nil {
+				t.Fatalf("attach current version: %v", err)
+			}
+			rw := markReadRequest(rr, taskID, "participant1", fmt.Sprintf(`{"personal_version_id":%d}`, version.ID))
+			var readResp struct {
+				Data struct {
+					HasPendingSubmission bool `json:"has_pending_submission"`
+					NeedsAttention       bool `json:"needs_attention"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(rw.Body.Bytes(), &readResp); err != nil {
+				t.Fatalf("unmarshal mark-read response: %v; body=%s", err, rw.Body.String())
+			}
+			if readResp.Data.HasPendingSubmission || readResp.Data.NeedsAttention {
+				t.Fatalf("mark-read must agree that a terminal task pends nothing: %+v", readResp.Data)
+			}
+		})
+	}
+}
+
+// Completed is deliberately NOT guarded. A personal-only regenerate on a
+// finished task leaves submitted_at NULL on purpose and waits for an explicit
+// submit (worker/personal_processor.go), so the dot is correct there. Pinning
+// this stops a future "just exclude every terminal status" simplification from
+// silently dropping the signal on the one terminal status that still needs it.
+func TestListSummaries_CompletedTaskStillPendsSubmission(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-REGEN", "participant1", []string{"participant2"})
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", taskID).
+		Update("status", model.StatusCompleted).Error; err != nil {
+		t.Fatalf("set completed status: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected the seeded task, got %+v", resp.Data)
+	}
+	if !resp.Data.Items[0].HasPendingSubmission || !resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("a regenerated personal result on a completed task still owes a submit: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 1 || resp.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("completed task must still hold the counts: %+v", resp.Data)
+	}
+}
+
+// The status=waiting list filter carries the same predicate as the badge. If
+// the two disagree, a card can be counted by the badge but hidden by the
+// filter the user clicks to find it (or vice versa).
+func TestListSummaries_WaitingFilterAgreesWithTerminalGuard(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	liveID := seedPendingSubmitTask(t, db, "SUBMIT-WAIT-LIVE", "participant1", []string{"participant2"})
+	deadID := seedPendingSubmitTask(t, db, "SUBMIT-WAIT-DEAD", "participant1", []string{"participant2"})
+	if err := db.Model(&model.SummaryTask{}).Where("id = ?", deadID).
+		Update("status", model.StatusFailed).Error; err != nil {
+		t.Fatalf("set terminal status: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, fmt.Sprintf("/api/v1/summaries?status=%d", model.StatusPending), "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != liveID {
+		t.Fatalf("waiting filter must keep the live task and drop the terminal one: %+v", resp.Data)
+	}
+}
+
 // Owner decision 2026-08-26: reading is not submitting. Opening the detail page
 // records the read cursor, but the participant still owes the team a /submit,
 // so the dot must survive MarkSummaryRead.

--- a/internal/api/handler/attention_pending_submit_test.go
+++ b/internal/api/handler/attention_pending_submit_test.go
@@ -1,0 +1,236 @@
+//go:build cgo
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
+	"gorm.io/gorm"
+)
+
+// Pending-submission attention (multi-person "your turn to submit" red dot).
+//
+// has_pending_submission was already computed by ListSummaries but never fed
+// needs_attention / attention_count, so the dot never rendered. These tests pin
+// the three rules that make it a usable signal:
+//
+//  1. it only fires for MULTI-person tasks (single-person owners have nobody to
+//     submit to),
+//  2. it clears on submitted_at, not on read — MarkSummaryRead must leave it
+//     standing (owner decision 2026-08-26),
+//  3. it participates in the space-level attention_count that drives the
+//     sidebar badge, with its own pending_submission_count breakdown.
+
+type attentionListResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		Total                  int `json:"total"`
+		AttentionCount         int `json:"attention_count"`
+		UnreadCount            int `json:"unread_count"`
+		PendingInvitationCount int `json:"pending_invitation_count"`
+		PendingSubmissionCount int `json:"pending_submission_count"`
+		Items                  []struct {
+			TaskID               int64 `json:"task_id"`
+			IsUnread             bool  `json:"is_unread"`
+			HasPendingInvitation bool  `json:"has_pending_invitation"`
+			HasPendingSubmission bool  `json:"has_pending_submission"`
+			NeedsAttention       bool  `json:"needs_attention"`
+		} `json:"items"`
+	} `json:"data"`
+}
+
+func parseAttentionList(t *testing.T, w *httptest.ResponseRecorder) attentionListResponse {
+	t.Helper()
+	var resp attentionListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal list response: %v; body=%s", err, w.Body.String())
+	}
+	return resp
+}
+
+// seedPendingSubmitTask builds a task whose personal result for userID has
+// finished generating but has not been submitted. extraParticipants controls
+// whether the task is multi-person (the gate for the submission signal).
+func seedPendingSubmitTask(t *testing.T, db *gorm.DB, taskNo, userID string, extraParticipants []string) int64 {
+	t.Helper()
+	now := timezone.Now()
+
+	task := model.SummaryTask{
+		TaskNo:      taskNo,
+		SpaceID:     "space1",
+		CreatorID:   "creator1",
+		SummaryMode: model.ModeByPerson,
+		Status:      model.StatusProcessing,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	if err := db.Create(&model.SummaryParticipant{
+		TaskID: task.ID, UserID: userID, UserName: userID, Status: model.ParticipantAccepted,
+	}).Error; err != nil {
+		t.Fatalf("create participant: %v", err)
+	}
+	for _, uid := range extraParticipants {
+		if err := db.Create(&model.SummaryParticipant{
+			TaskID: task.ID, UserID: uid, UserName: uid, Status: model.ParticipantAccepted,
+		}).Error; err != nil {
+			t.Fatalf("create participant %s: %v", uid, err)
+		}
+	}
+
+	// Personal summary generated (worker_status=Completed) but not submitted.
+	// No current_version_id / current_result_id is set, so is_unread stays false
+	// and the assertions below isolate the submission signal.
+	if err := db.Create(&model.PersonalResult{
+		TaskID: task.ID, UserID: userID, Content: "personal draft",
+		WorkerStatus: model.PersonalStatusCompleted, SubmittedAt: nil,
+		CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("create personal result: %v", err)
+	}
+
+	return task.ID
+}
+
+func TestListSummaries_PendingSubmissionDrivesAttention(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-MULTI", "participant1", []string{"participant2"})
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 || resp.Data.Items[0].TaskID != taskID {
+		t.Fatalf("expected the seeded task in the list, got %+v", resp.Data)
+	}
+	item := resp.Data.Items[0]
+	if !item.HasPendingSubmission {
+		t.Fatalf("generated-but-unsubmitted personal result must flag pending submission: %+v", item)
+	}
+	if item.IsUnread || item.HasPendingInvitation {
+		t.Fatalf("test isolates the submission signal; unread/invitation must be off: %+v", item)
+	}
+	if !item.NeedsAttention {
+		t.Fatalf("pending submission must raise needs_attention (the card red dot): %+v", item)
+	}
+	if resp.Data.AttentionCount != 1 || resp.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("pending submission must feed the sidebar counts: attention=%d submission=%d",
+			resp.Data.AttentionCount, resp.Data.PendingSubmissionCount)
+	}
+	if resp.Data.UnreadCount != 0 || resp.Data.PendingInvitationCount != 0 {
+		t.Fatalf("submission must not leak into the unread/invitation breakdown: %+v", resp.Data)
+	}
+}
+
+func TestListSummaries_SubmittedPersonalResultClearsAttention(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-DONE", "participant1", []string{"participant2"})
+	now := timezone.Now()
+	if err := db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", taskID, "participant1").
+		Updates(map[string]interface{}{"submitted_at": now, "submit_source": model.SubmitSourceManual}).Error; err != nil {
+		t.Fatalf("mark submitted: %v", err)
+	}
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected the seeded task, got %+v", resp.Data)
+	}
+	if resp.Data.Items[0].HasPendingSubmission || resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("submitting must clear the dot: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 0 || resp.Data.PendingSubmissionCount != 0 {
+		t.Fatalf("counts must drop after submit: attention=%d submission=%d",
+			resp.Data.AttentionCount, resp.Data.PendingSubmissionCount)
+	}
+}
+
+func TestListSummaries_SinglePersonTaskNeverPendsSubmission(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	// Sole participant: there is no team to submit into, so an unsubmitted
+	// personal result is just the owner's own summary.
+	seedPendingSubmitTask(t, db, "SUBMIT-SOLO", "participant1", nil)
+
+	r := setupListRouter(NewTaskHandler(db, imDB, ""))
+	w := doRequest(r, http.MethodGet, "/api/v1/summaries", "participant1")
+	resp := parseAttentionList(t, w)
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected the seeded task, got %+v", resp.Data)
+	}
+	if resp.Data.Items[0].HasPendingSubmission || resp.Data.Items[0].NeedsAttention {
+		t.Fatalf("single-person task must not pend submission: %+v", resp.Data.Items[0])
+	}
+	if resp.Data.AttentionCount != 0 || resp.Data.PendingSubmissionCount != 0 {
+		t.Fatalf("single-person task must not raise counts: %+v", resp.Data)
+	}
+}
+
+// Owner decision 2026-08-26: reading is not submitting. Opening the detail page
+// records the read cursor, but the participant still owes the team a /submit,
+// so the dot must survive MarkSummaryRead.
+func TestMarkSummaryRead_KeepsPendingSubmissionAttention(t *testing.T) {
+	db, imDB := setupListTestDBs(t)
+	taskID := seedPendingSubmitTask(t, db, "SUBMIT-READ", "participant1", []string{"participant2"})
+
+	now := timezone.Now()
+	version := model.PersonalResultVersion{
+		TaskID: taskID, UserID: "participant1", Content: "personal", Version: 1,
+		GeneratedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&version).Error; err != nil {
+		t.Fatalf("create personal version: %v", err)
+	}
+	if err := db.Model(&model.PersonalResult{}).
+		Where("task_id = ? AND user_id = ?", taskID, "participant1").
+		Update("current_version_id", version.ID).Error; err != nil {
+		t.Fatalf("attach current version: %v", err)
+	}
+
+	r := setupReadRouter(NewTaskHandler(db, imDB, ""))
+	w := markReadRequest(r, taskID, "participant1", fmt.Sprintf(`{"personal_version_id":%d}`, version.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Code int `json:"code"`
+		Data struct {
+			IsUnread             bool `json:"is_unread"`
+			HasPendingInvitation bool `json:"has_pending_invitation"`
+			HasPendingSubmission bool `json:"has_pending_submission"`
+			NeedsAttention       bool `json:"needs_attention"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal mark-read response: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Data.IsUnread {
+		t.Fatalf("the rendered version was recorded, so content is read: %+v", resp.Data)
+	}
+	if !resp.Data.HasPendingSubmission || !resp.Data.NeedsAttention {
+		t.Fatalf("reading must not clear the pending-submission dot: %+v", resp.Data)
+	}
+
+	// The list projection must agree with the read response — a client that
+	// refreshes instead of trusting the optimistic update sees the same dot.
+	lr := setupListRouter(NewTaskHandler(db, imDB, ""))
+	lw := doRequest(lr, http.MethodGet, "/api/v1/summaries", "participant1")
+	list := parseAttentionList(t, lw)
+	if len(list.Data.Items) != 1 || !list.Data.Items[0].NeedsAttention || !list.Data.Items[0].HasPendingSubmission {
+		t.Fatalf("list must keep the dot after read: %+v", list.Data)
+	}
+	if list.Data.AttentionCount != 1 || list.Data.PendingSubmissionCount != 1 {
+		t.Fatalf("counts must survive read: attention=%d submission=%d",
+			list.Data.AttentionCount, list.Data.PendingSubmissionCount)
+	}
+}

--- a/internal/api/handler/auth_test.go
+++ b/internal/api/handler/auth_test.go
@@ -401,11 +401,17 @@ func setupReadRouter(h *TaskHandler) *gin.Engine {
 }
 
 func markReadRequest(r *gin.Engine, taskID int64, userID string, body string) *httptest.ResponseRecorder {
+	return markReadRequestWithSpace(r, taskID, userID, "space1", body)
+}
+
+// markReadRequestWithSpace is the Space-explicit form. The MySQL integration
+// tests seed into their own space, so they cannot use the "space1" default.
+func markReadRequestWithSpace(r *gin.Engine, taskID int64, userID, spaceID, body string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/summaries/%d/read", taskID), bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Token", userID)
-	req.Header.Set("X-Space-Id", "space1")
+	req.Header.Set("X-Space-Id", spaceID)
 	r.ServeHTTP(w, req)
 	return w
 }

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -42,11 +42,14 @@ type TaskHandler struct {
 	imDB                *gorm.DB
 	workerTriggerURL    string
 	customTemplateLimit int
+	// attentionCache serves the polling endpoint only. See attention.go for
+	// the TTL and the no-invalidation rationale.
+	attentionCache *attentionCache
 }
 
 // NewTaskHandler creates a new TaskHandler.
 func NewTaskHandler(db, imDB *gorm.DB, workerTriggerURL string) *TaskHandler {
-	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit}
+	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit, attentionCache: newAttentionCache()}
 }
 
 func (h *TaskHandler) SetCustomTemplateLimit(limit int) {
@@ -75,6 +78,38 @@ func (h *TaskHandler) schedulePendingInvitationExpr(taskAlias string) string {
  COLUMNS(user_id VARCHAR(64) PATH '$.user_id', confirmed BOOL PATH '$.confirmed' DEFAULT 'false' ON EMPTY)) sc
  WHERE ss.id=` + taskAlias + `.schedule_id AND ss.deleted_at IS NULL AND ss.is_active=1
  AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
+}
+
+// pendingSubmitStatusGuard excludes terminally-dead tasks from the
+// pending-submission signal, for the given summary_task alias.
+//
+// The raw predicate (personal worker_status=Completed AND submitted_at IS NULL
+// AND roster > 1) has no notion of the task's own lifecycle, and two ordinary
+// paths strand a task while a participant's personal result still matches it:
+//
+//  1. the stuck-task reaper flips Processing -> Failed once retry_count is
+//     exhausted (worker/scheduler.go), which is exactly the outcome of the
+//     situation this signal exists to prevent — metaCompletionReady blocks
+//     aggregation until every accepted participant is terminal, so one member
+//     who never submits stalls the task until the reaper kills it;
+//  2. CancelSummary writes status=Cancelled and nothing else.
+//
+// Neither touches summary_personal_result, so the member who *did* generate
+// their summary would keep a red dot — and a non-zero space-level
+// attention_count — for a task nobody can revive (Regenerate and Delete are
+// both creator-gated). A badge that cannot return to zero destroys the
+// credibility of the whole signal, so gate it server-side.
+//
+// Completed is deliberately NOT excluded: a personal-only regenerate on a
+// finished task intentionally leaves submitted_at NULL and waits for an
+// explicit submit (worker/personal_processor.go), so the dot is correct there.
+//
+// The constants are inlined rather than bound as parameters on purpose. Every
+// call site lives in hand-assembled SQL whose arguments are positional; adding
+// two placeholders in four statements is precisely the hazard the ordering
+// comment in ListSummaries warns about.
+func pendingSubmitStatusGuard(taskAlias string) string {
+	return fmt.Sprintf(" AND %s.status NOT IN (%d,%d)", taskAlias, model.StatusFailed, model.StatusCancelled)
 }
 
 // R11 Q2 (owner decision 2026-08-14, option 1): a task whose origin was
@@ -585,7 +620,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 				// yet started, pending task invitations, and pending schedule invitations.
 				// Apply it before pagination to keep totals and pages accurate.
 				statusPendingExpr := h.schedulePendingInvitationExpr("summary_task")
-				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1) OR " + statusPendingExpr + ")"
+				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1" + pendingSubmitStatusGuard("summary_task") + ") OR " + statusPendingExpr + ")"
 				args = append(args, v, userID, model.ParticipantPending, userID, model.PersonalStatusCompleted)
 				if h.db.Dialector.Name() == "mysql" {
 					args = append(args, userID)
@@ -658,22 +693,25 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	}
 
 	// Attention is caller-specific. Compute it only after schedule folding, then
-	// sort before pagination. A pending invitation outranks unread content; team
-	// and personal cursors are compared independently because their ids belong to
-	// different tables.
-	attentionJoins := `
- LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
- LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
- LEFT JOIN summary_personal_result pr ON pr.task_id = sub.id AND pr.user_id = ?
- LEFT JOIN summary_personal_result_version pv ON pv.id = pr.current_version_id AND pv.task_id = sub.id AND pv.user_id = ?
- LEFT JOIN summary_participant me ON me.task_id = sub.id AND me.user_id = ?`
+	// sort before pagination. A pending invitation outranks a pending submission,
+	// which outranks unread content; team and personal cursors are compared
+	// independently because their ids belong to different tables.
+	//
+	// All three signals feed needs_attention (the per-card red dot) and
+	// attention_count (the sidebar badge). has_pending_submission is deliberately
+	// NOT cleared by MarkSummaryRead: opening the detail page marks the content
+	// read, but the participant still owes the team an explicit /submit, so the
+	// dot survives until submitted_at is set.
+	// Shared with the attention-count query (attention.go) so the per-card dots
+	// and the badge are computed over identical rows.
+	attentionJoins := attentionJoinsSQL
 	// Schedule-level confirmation lives in participant_config rather than
 	// summary_participant. Expand the V5 roster so these invitations share the
 	// same attention/red-dot semantics as ordinary task invitations.
 	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
 	attentionSelect := `,
  CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1 THEN 1 ELSE 0 END AS has_pending_submission,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1` + pendingSubmitStatusGuard("sub") + ` THEN 1 ELSE 0 END AS has_pending_submission,
  CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
         OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id <> pr.current_version_id))
       THEN 1 ELSE 0 END AS is_unread,
@@ -683,7 +721,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	      THEN CASE WHEN cr.generated_at >= pv.generated_at THEN cr.generated_at ELSE pv.generated_at END
 	      ELSE COALESCE(cr.generated_at, pv.generated_at, sub.created_at) END AS activity_at`
 	pageSQL := "SELECT sub.*" + attentionSelect + " FROM (" + innerSQL + ") sub" + attentionJoins +
-		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
+		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, has_pending_submission DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
 	pageArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		pageArgs = append(pageArgs, userID)
@@ -909,7 +947,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"is_unread":                    attention.IsUnread,
 			"has_pending_invitation":       attention.HasPendingInvitation,
 			"has_pending_submission":       attention.HasPendingSubmission,
-			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation,
+			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation || attention.HasPendingSubmission,
 			"current_result_id":            attention.ListCurrentResultID,
 			"current_personal_version_id":  attention.CurrentPersonalVersionID,
 			"activity_at":                  attention.ActivityAt,
@@ -919,30 +957,31 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		})
 	}
 
-	// Counts deliberately ignore the current list filters: the navigation badge
-	// represents all cards that require this user's attention in the space.
-	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
-	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
-	var counts struct {
-		AttentionCount         int64 `gorm:"column:attention_count"`
-		UnreadCount            int64 `gorm:"column:unread_count"`
-		PendingInvitationCount int64 `gorm:"column:pending_invitation_count"`
-	}
-	countArgs := []interface{}{model.ParticipantPending}
-	if h.db.Dialector.Name() == "mysql" {
-		countArgs = append(countArgs, userID)
-	}
-	countArgs = append(countArgs, spaceID, userID, userID)
-	if h.db.Dialector.Name() == "mysql" {
-		countArgs = append(countArgs, userID)
-	}
-	countArgs = append(countArgs, userID, userID, userID, userID)
-	if err := h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts).Error; err != nil {
+	// The badge numbers come from the shared helper (attention.go), which owns
+	// the only copy of the attention statistics SQL. Keeping a second copy here
+	// would let the list badge and the polled badge drift apart.
+	//
+	// This path deliberately does NOT read the cache — it has just executed the
+	// full page query anyway, so a cache read could only serve a staler answer
+	// than the rows being rendered right next to it, which is exactly the
+	// inconsistency (dots say one thing, badge another) worth avoiding. It DOES
+	// populate the cache: the value was computed by the same SQL, so it is no
+	// staler than any other write, and it makes the polls that follow a list
+	// load cheap.
+	counts, err := h.attentionCounts(spaceID, userID)
+	if err != nil {
 		log.Printf("list summaries attention count query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
 		return
 	}
-	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount})
+	// Only the human surface writes the badge cache. A bot ListSummaries
+	// computes the same value (same owner UID, same server-resolved space),
+	// but letting it overwrite the human entry makes it an extra trigger for
+	// stale-set races and couples two independently-authenticated surfaces.
+	if !c.GetBool("bot_request") {
+		h.attentionCachePut(attentionCacheKey{userID: userID, spaceID: spaceID}, counts)
+	}
+	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount, "pending_submission_count": counts.PendingSubmissionCount})
 }
 
 type markSummaryReadRequest struct {
@@ -1002,13 +1041,19 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 		ReadTeamID        *int64 `gorm:"column:read_team_id"`
 		ReadPersonalID    *int64 `gorm:"column:read_personal_id"`
 		PendingInvitation bool   `gorm:"column:pending_invitation"`
+		PendingSubmission bool   `gorm:"column:pending_submission"`
 	}
 	schedulePendingExpr := h.schedulePendingInvitationExpr("t")
+	// pending_submission mirrors the list projection. Marking content read must
+	// NOT clear it: the participant has seen their personal summary but still
+	// owes the team an explicit /submit. Returning it here keeps the client's
+	// optimistic needs_attention recompute from dropping the dot on read.
 	stateSQL := `SELECT t.current_result_id AS current_team_id,
  pr.current_version_id AS current_personal_id,
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
- CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation
+ CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1` + pendingSubmitStatusGuard("t") + ` THEN 1 ELSE 0 END AS pending_submission
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?
@@ -1018,6 +1063,7 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	if h.db.Dialector.Name() == "mysql" {
 		stateArgs = append(stateArgs, userID)
 	}
+	stateArgs = append(stateArgs, model.PersonalStatusCompleted)
 	stateArgs = append(stateArgs, userID, userID, userID, taskID)
 	if err := h.db.Raw(stateSQL, stateArgs...).Scan(&state).Error; err != nil {
 		log.Printf("mark summary read state query failed: %v", err)
@@ -1030,7 +1076,8 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	ok(c, gin.H{
 		"task_id": taskID, "team_result_id": req.TeamResultID, "personal_version_id": req.PersonalVersionID,
 		"is_unread": isUnread, "has_pending_invitation": state.PendingInvitation,
-		"needs_attention": isUnread || state.PendingInvitation,
+		"has_pending_submission": state.PendingSubmission,
+		"needs_attention":        isUnread || state.PendingInvitation || state.PendingSubmission,
 	})
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -42,11 +42,14 @@ type TaskHandler struct {
 	imDB                *gorm.DB
 	workerTriggerURL    string
 	customTemplateLimit int
+	// attentionCache serves the polling endpoint only. See attention.go for
+	// the TTL and the no-invalidation rationale.
+	attentionCache *attentionCache
 }
 
 // NewTaskHandler creates a new TaskHandler.
 func NewTaskHandler(db, imDB *gorm.DB, workerTriggerURL string) *TaskHandler {
-	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit}
+	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit, attentionCache: newAttentionCache()}
 }
 
 func (h *TaskHandler) SetCustomTemplateLimit(limit int) {
@@ -699,12 +702,9 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	// NOT cleared by MarkSummaryRead: opening the detail page marks the content
 	// read, but the participant still owes the team an explicit /submit, so the
 	// dot survives until submitted_at is set.
-	attentionJoins := `
- LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
- LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
- LEFT JOIN summary_personal_result pr ON pr.task_id = sub.id AND pr.user_id = ?
- LEFT JOIN summary_personal_result_version pv ON pv.id = pr.current_version_id AND pv.task_id = sub.id AND pv.user_id = ?
- LEFT JOIN summary_participant me ON me.task_id = sub.id AND me.user_id = ?`
+	// Shared with the attention-count query (attention.go) so the per-card dots
+	// and the badge are computed over identical rows.
+	attentionJoins := attentionJoinsSQL
 	// Schedule-level confirmation lives in participant_config rather than
 	// summary_participant. Expand the V5 roster so these invitations share the
 	// same attention/red-dot semantics as ordinary task invitations.
@@ -957,38 +957,24 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		})
 	}
 
-	// Counts deliberately ignore the current list filters: the navigation badge
-	// represents all cards that require this user's attention in the space.
-	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
+	// The badge numbers come from the shared helper (attention.go), which owns
+	// the only copy of the attention statistics SQL. Keeping a second copy here
+	// would let the list badge and the polled badge drift apart.
 	//
-	// ⚠️ The placeholders below are positional and hand-assembled; countArgs must
-	// be appended in exactly the textual order the `?`s appear:
-	//   1. has_invite      -> ParticipantPending [+ userID when schedulePendingExpr is live (MySQL only)]
-	//   2. has_submit      -> PersonalStatusCompleted
-	//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
-	//   4. attentionJoins  -> userID x4
-	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1" + pendingSubmitStatusGuard("sub") + " THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
-	var counts struct {
-		AttentionCount         int64 `gorm:"column:attention_count"`
-		UnreadCount            int64 `gorm:"column:unread_count"`
-		PendingInvitationCount int64 `gorm:"column:pending_invitation_count"`
-		PendingSubmissionCount int64 `gorm:"column:pending_submission_count"`
-	}
-	countArgs := []interface{}{model.ParticipantPending}
-	if h.db.Dialector.Name() == "mysql" {
-		countArgs = append(countArgs, userID)
-	}
-	countArgs = append(countArgs, model.PersonalStatusCompleted)
-	countArgs = append(countArgs, spaceID, userID, userID)
-	if h.db.Dialector.Name() == "mysql" {
-		countArgs = append(countArgs, userID)
-	}
-	countArgs = append(countArgs, userID, userID, userID, userID)
-	if err := h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts).Error; err != nil {
+	// This path deliberately does NOT read the cache — it has just executed the
+	// full page query anyway, so a cache read could only serve a staler answer
+	// than the rows being rendered right next to it, which is exactly the
+	// inconsistency (dots say one thing, badge another) worth avoiding. It DOES
+	// populate the cache: the value was computed by the same SQL, so it is no
+	// staler than any other write, and it makes the polls that follow a list
+	// load cheap.
+	counts, err := h.attentionCounts(spaceID, userID)
+	if err != nil {
 		log.Printf("list summaries attention count query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
 		return
 	}
+	h.attentionCachePut(attentionCacheKey{userID: userID, spaceID: spaceID}, counts)
 	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount, "pending_submission_count": counts.PendingSubmissionCount})
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -658,9 +658,15 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	}
 
 	// Attention is caller-specific. Compute it only after schedule folding, then
-	// sort before pagination. A pending invitation outranks unread content; team
-	// and personal cursors are compared independently because their ids belong to
-	// different tables.
+	// sort before pagination. A pending invitation outranks a pending submission,
+	// which outranks unread content; team and personal cursors are compared
+	// independently because their ids belong to different tables.
+	//
+	// All three signals feed needs_attention (the per-card red dot) and
+	// attention_count (the sidebar badge). has_pending_submission is deliberately
+	// NOT cleared by MarkSummaryRead: opening the detail page marks the content
+	// read, but the participant still owes the team an explicit /submit, so the
+	// dot survives until submitted_at is set.
 	attentionJoins := `
  LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
  LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
@@ -683,7 +689,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	      THEN CASE WHEN cr.generated_at >= pv.generated_at THEN cr.generated_at ELSE pv.generated_at END
 	      ELSE COALESCE(cr.generated_at, pv.generated_at, sub.created_at) END AS activity_at`
 	pageSQL := "SELECT sub.*" + attentionSelect + " FROM (" + innerSQL + ") sub" + attentionJoins +
-		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
+		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, has_pending_submission DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
 	pageArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		pageArgs = append(pageArgs, userID)
@@ -909,7 +915,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"is_unread":                    attention.IsUnread,
 			"has_pending_invitation":       attention.HasPendingInvitation,
 			"has_pending_submission":       attention.HasPendingSubmission,
-			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation,
+			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation || attention.HasPendingSubmission,
 			"current_result_id":            attention.ListCurrentResultID,
 			"current_personal_version_id":  attention.CurrentPersonalVersionID,
 			"activity_at":                  attention.ActivityAt,
@@ -922,16 +928,25 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	// Counts deliberately ignore the current list filters: the navigation badge
 	// represents all cards that require this user's attention in the space.
 	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
-	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
+	//
+	// ⚠️ The placeholders below are positional and hand-assembled; countArgs must
+	// be appended in exactly the textual order the `?`s appear:
+	//   1. has_invite      -> ParticipantPending [+ userID when schedulePendingExpr is live (MySQL only)]
+	//   2. has_submit      -> PersonalStatusCompleted
+	//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
+	//   4. attentionJoins  -> userID x4
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1 THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
 	var counts struct {
 		AttentionCount         int64 `gorm:"column:attention_count"`
 		UnreadCount            int64 `gorm:"column:unread_count"`
 		PendingInvitationCount int64 `gorm:"column:pending_invitation_count"`
+		PendingSubmissionCount int64 `gorm:"column:pending_submission_count"`
 	}
 	countArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		countArgs = append(countArgs, userID)
 	}
+	countArgs = append(countArgs, model.PersonalStatusCompleted)
 	countArgs = append(countArgs, spaceID, userID, userID)
 	if h.db.Dialector.Name() == "mysql" {
 		countArgs = append(countArgs, userID)
@@ -942,7 +957,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
 		return
 	}
-	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount})
+	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount, "pending_submission_count": counts.PendingSubmissionCount})
 }
 
 type markSummaryReadRequest struct {
@@ -1002,13 +1017,19 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 		ReadTeamID        *int64 `gorm:"column:read_team_id"`
 		ReadPersonalID    *int64 `gorm:"column:read_personal_id"`
 		PendingInvitation bool   `gorm:"column:pending_invitation"`
+		PendingSubmission bool   `gorm:"column:pending_submission"`
 	}
 	schedulePendingExpr := h.schedulePendingInvitationExpr("t")
+	// pending_submission mirrors the list projection. Marking content read must
+	// NOT clear it: the participant has seen their personal summary but still
+	// owes the team an explicit /submit. Returning it here keeps the client's
+	// optimistic needs_attention recompute from dropping the dot on read.
 	stateSQL := `SELECT t.current_result_id AS current_team_id,
  pr.current_version_id AS current_personal_id,
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
- CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation
+ CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1 THEN 1 ELSE 0 END AS pending_submission
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?
@@ -1018,6 +1039,7 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	if h.db.Dialector.Name() == "mysql" {
 		stateArgs = append(stateArgs, userID)
 	}
+	stateArgs = append(stateArgs, model.PersonalStatusCompleted)
 	stateArgs = append(stateArgs, userID, userID, userID, taskID)
 	if err := h.db.Raw(stateSQL, stateArgs...).Scan(&state).Error; err != nil {
 		log.Printf("mark summary read state query failed: %v", err)
@@ -1030,7 +1052,8 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	ok(c, gin.H{
 		"task_id": taskID, "team_result_id": req.TeamResultID, "personal_version_id": req.PersonalVersionID,
 		"is_unread": isUnread, "has_pending_invitation": state.PendingInvitation,
-		"needs_attention": isUnread || state.PendingInvitation,
+		"has_pending_submission": state.PendingSubmission,
+		"needs_attention":        isUnread || state.PendingInvitation || state.PendingSubmission,
 	})
 }
 

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -77,6 +77,38 @@ func (h *TaskHandler) schedulePendingInvitationExpr(taskAlias string) string {
  AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
 }
 
+// pendingSubmitStatusGuard excludes terminally-dead tasks from the
+// pending-submission signal, for the given summary_task alias.
+//
+// The raw predicate (personal worker_status=Completed AND submitted_at IS NULL
+// AND roster > 1) has no notion of the task's own lifecycle, and two ordinary
+// paths strand a task while a participant's personal result still matches it:
+//
+//  1. the stuck-task reaper flips Processing -> Failed once retry_count is
+//     exhausted (worker/scheduler.go), which is exactly the outcome of the
+//     situation this signal exists to prevent — metaCompletionReady blocks
+//     aggregation until every accepted participant is terminal, so one member
+//     who never submits stalls the task until the reaper kills it;
+//  2. CancelSummary writes status=Cancelled and nothing else.
+//
+// Neither touches summary_personal_result, so the member who *did* generate
+// their summary would keep a red dot — and a non-zero space-level
+// attention_count — for a task nobody can revive (Regenerate and Delete are
+// both creator-gated). A badge that cannot return to zero destroys the
+// credibility of the whole signal, so gate it server-side.
+//
+// Completed is deliberately NOT excluded: a personal-only regenerate on a
+// finished task intentionally leaves submitted_at NULL and waits for an
+// explicit submit (worker/personal_processor.go), so the dot is correct there.
+//
+// The constants are inlined rather than bound as parameters on purpose. Every
+// call site lives in hand-assembled SQL whose arguments are positional; adding
+// two placeholders in four statements is precisely the hazard the ordering
+// comment in ListSummaries warns about.
+func pendingSubmitStatusGuard(taskAlias string) string {
+	return fmt.Sprintf(" AND %s.status NOT IN (%d,%d)", taskAlias, model.StatusFailed, model.StatusCancelled)
+}
+
 // R11 Q2 (owner decision 2026-08-14, option 1): a task whose origin was
 // inherited from a DERIVED (worker-backfilled) source row carries
 // OriginFromDerived=true. List/detail projections mask such an origin to
@@ -585,7 +617,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 				// yet started, pending task invitations, and pending schedule invitations.
 				// Apply it before pagination to keep totals and pages accurate.
 				statusPendingExpr := h.schedulePendingInvitationExpr("summary_task")
-				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1) OR " + statusPendingExpr + ")"
+				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1" + pendingSubmitStatusGuard("summary_task") + ") OR " + statusPendingExpr + ")"
 				args = append(args, v, userID, model.ParticipantPending, userID, model.PersonalStatusCompleted)
 				if h.db.Dialector.Name() == "mysql" {
 					args = append(args, userID)
@@ -679,7 +711,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
 	attentionSelect := `,
  CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1 THEN 1 ELSE 0 END AS has_pending_submission,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1` + pendingSubmitStatusGuard("sub") + ` THEN 1 ELSE 0 END AS has_pending_submission,
  CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
         OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id <> pr.current_version_id))
       THEN 1 ELSE 0 END AS is_unread,
@@ -935,7 +967,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	//   2. has_submit      -> PersonalStatusCompleted
 	//   3. countInner      -> spaceID, userID, userID [+ userID when scheduleVisibilityExpr is live]
 	//   4. attentionJoins  -> userID x4
-	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1 THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(has_submit),0) pending_submission_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 OR has_submit=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN pr.worker_status=? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id=sub.id) > 1" + pendingSubmitStatusGuard("sub") + " THEN 1 ELSE 0 END has_submit, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
 	var counts struct {
 		AttentionCount         int64 `gorm:"column:attention_count"`
 		UnreadCount            int64 `gorm:"column:unread_count"`
@@ -1029,7 +1061,7 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
  CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1 THEN 1 ELSE 0 END AS pending_submission
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1` + pendingSubmitStatusGuard("t") + ` THEN 1 ELSE 0 END AS pending_submission
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?

--- a/internal/api/handler/task.go
+++ b/internal/api/handler/task.go
@@ -42,14 +42,11 @@ type TaskHandler struct {
 	imDB                *gorm.DB
 	workerTriggerURL    string
 	customTemplateLimit int
-	// attentionCache serves the polling endpoint only. See attention.go for
-	// the TTL and the no-invalidation rationale.
-	attentionCache *attentionCache
 }
 
 // NewTaskHandler creates a new TaskHandler.
 func NewTaskHandler(db, imDB *gorm.DB, workerTriggerURL string) *TaskHandler {
-	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit, attentionCache: newAttentionCache()}
+	return &TaskHandler{db: db, imDB: imDB, workerTriggerURL: workerTriggerURL, customTemplateLimit: defaultCustomTemplateLimit}
 }
 
 func (h *TaskHandler) SetCustomTemplateLimit(limit int) {
@@ -78,38 +75,6 @@ func (h *TaskHandler) schedulePendingInvitationExpr(taskAlias string) string {
  COLUMNS(user_id VARCHAR(64) PATH '$.user_id', confirmed BOOL PATH '$.confirmed' DEFAULT 'false' ON EMPTY)) sc
  WHERE ss.id=` + taskAlias + `.schedule_id AND ss.deleted_at IS NULL AND ss.is_active=1
  AND ss.confirm_policy=1 AND sc.user_id=? AND sc.confirmed=false)`
-}
-
-// pendingSubmitStatusGuard excludes terminally-dead tasks from the
-// pending-submission signal, for the given summary_task alias.
-//
-// The raw predicate (personal worker_status=Completed AND submitted_at IS NULL
-// AND roster > 1) has no notion of the task's own lifecycle, and two ordinary
-// paths strand a task while a participant's personal result still matches it:
-//
-//  1. the stuck-task reaper flips Processing -> Failed once retry_count is
-//     exhausted (worker/scheduler.go), which is exactly the outcome of the
-//     situation this signal exists to prevent — metaCompletionReady blocks
-//     aggregation until every accepted participant is terminal, so one member
-//     who never submits stalls the task until the reaper kills it;
-//  2. CancelSummary writes status=Cancelled and nothing else.
-//
-// Neither touches summary_personal_result, so the member who *did* generate
-// their summary would keep a red dot — and a non-zero space-level
-// attention_count — for a task nobody can revive (Regenerate and Delete are
-// both creator-gated). A badge that cannot return to zero destroys the
-// credibility of the whole signal, so gate it server-side.
-//
-// Completed is deliberately NOT excluded: a personal-only regenerate on a
-// finished task intentionally leaves submitted_at NULL and waits for an
-// explicit submit (worker/personal_processor.go), so the dot is correct there.
-//
-// The constants are inlined rather than bound as parameters on purpose. Every
-// call site lives in hand-assembled SQL whose arguments are positional; adding
-// two placeholders in four statements is precisely the hazard the ordering
-// comment in ListSummaries warns about.
-func pendingSubmitStatusGuard(taskAlias string) string {
-	return fmt.Sprintf(" AND %s.status NOT IN (%d,%d)", taskAlias, model.StatusFailed, model.StatusCancelled)
 }
 
 // R11 Q2 (owner decision 2026-08-14, option 1): a task whose origin was
@@ -620,7 +585,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 				// yet started, pending task invitations, and pending schedule invitations.
 				// Apply it before pagination to keep totals and pages accurate.
 				statusPendingExpr := h.schedulePendingInvitationExpr("summary_task")
-				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1" + pendingSubmitStatusGuard("summary_task") + ") OR " + statusPendingExpr + ")"
+				whereSQL += " AND (status = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ? AND status = ?) OR EXISTS (SELECT 1 FROM summary_personal_result wait_pr WHERE wait_pr.task_id = summary_task.id AND wait_pr.user_id = ? AND wait_pr.worker_status = ? AND wait_pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = summary_task.id) > 1) OR " + statusPendingExpr + ")"
 				args = append(args, v, userID, model.ParticipantPending, userID, model.PersonalStatusCompleted)
 				if h.db.Dialector.Name() == "mysql" {
 					args = append(args, userID)
@@ -693,25 +658,22 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	}
 
 	// Attention is caller-specific. Compute it only after schedule folding, then
-	// sort before pagination. A pending invitation outranks a pending submission,
-	// which outranks unread content; team and personal cursors are compared
-	// independently because their ids belong to different tables.
-	//
-	// All three signals feed needs_attention (the per-card red dot) and
-	// attention_count (the sidebar badge). has_pending_submission is deliberately
-	// NOT cleared by MarkSummaryRead: opening the detail page marks the content
-	// read, but the participant still owes the team an explicit /submit, so the
-	// dot survives until submitted_at is set.
-	// Shared with the attention-count query (attention.go) so the per-card dots
-	// and the badge are computed over identical rows.
-	attentionJoins := attentionJoinsSQL
+	// sort before pagination. A pending invitation outranks unread content; team
+	// and personal cursors are compared independently because their ids belong to
+	// different tables.
+	attentionJoins := `
+ LEFT JOIN summary_user_read sur ON sur.task_id = sub.id AND sur.user_id = ?
+ LEFT JOIN summary_result cr ON cr.id = sub.current_result_id AND cr.task_id = sub.id
+ LEFT JOIN summary_personal_result pr ON pr.task_id = sub.id AND pr.user_id = ?
+ LEFT JOIN summary_personal_result_version pv ON pv.id = pr.current_version_id AND pv.task_id = sub.id AND pv.user_id = ?
+ LEFT JOIN summary_participant me ON me.task_id = sub.id AND me.user_id = ?`
 	// Schedule-level confirmation lives in participant_config rather than
 	// summary_participant. Expand the V5 roster so these invitations share the
 	// same attention/red-dot semantics as ordinary task invitations.
 	schedulePendingExpr := h.schedulePendingInvitationExpr("sub")
 	attentionSelect := `,
  CASE WHEN me.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS has_pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1` + pendingSubmitStatusGuard("sub") + ` THEN 1 ELSE 0 END AS has_pending_submission,
+ CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = sub.id) > 1 THEN 1 ELSE 0 END AS has_pending_submission,
  CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id <> sub.current_result_id))
         OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id <> pr.current_version_id))
       THEN 1 ELSE 0 END AS is_unread,
@@ -721,7 +683,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 	      THEN CASE WHEN cr.generated_at >= pv.generated_at THEN cr.generated_at ELSE pv.generated_at END
 	      ELSE COALESCE(cr.generated_at, pv.generated_at, sub.created_at) END AS activity_at`
 	pageSQL := "SELECT sub.*" + attentionSelect + " FROM (" + innerSQL + ") sub" + attentionJoins +
-		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, has_pending_submission DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
+		" WHERE sub.rn = 1 ORDER BY has_pending_invitation DESC, is_unread DESC, activity_at DESC, " + orderClause + ", sub.id DESC LIMIT ? OFFSET ?"
 	pageArgs := []interface{}{model.ParticipantPending}
 	if h.db.Dialector.Name() == "mysql" {
 		pageArgs = append(pageArgs, userID)
@@ -947,7 +909,7 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 			"is_unread":                    attention.IsUnread,
 			"has_pending_invitation":       attention.HasPendingInvitation,
 			"has_pending_submission":       attention.HasPendingSubmission,
-			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation || attention.HasPendingSubmission,
+			"needs_attention":              attention.IsUnread || attention.HasPendingInvitation,
 			"current_result_id":            attention.ListCurrentResultID,
 			"current_personal_version_id":  attention.CurrentPersonalVersionID,
 			"activity_at":                  attention.ActivityAt,
@@ -957,25 +919,30 @@ func (h *TaskHandler) ListSummaries(c *gin.Context) {
 		})
 	}
 
-	// The badge numbers come from the shared helper (attention.go), which owns
-	// the only copy of the attention statistics SQL. Keeping a second copy here
-	// would let the list badge and the polled badge drift apart.
-	//
-	// This path deliberately does NOT read the cache — it has just executed the
-	// full page query anyway, so a cache read could only serve a staler answer
-	// than the rows being rendered right next to it, which is exactly the
-	// inconsistency (dots say one thing, badge another) worth avoiding. It DOES
-	// populate the cache: the value was computed by the same SQL, so it is no
-	// staler than any other write, and it makes the polls that follow a list
-	// load cheap.
-	counts, err := h.attentionCounts(spaceID, userID)
-	if err != nil {
+	// Counts deliberately ignore the current list filters: the navigation badge
+	// represents all cards that require this user's attention in the space.
+	countInner := "SELECT *, ROW_NUMBER() OVER (PARTITION BY (CASE WHEN schedule_id IS NULL THEN CONCAT('t', id) ELSE CONCAT('s', schedule_id) END) ORDER BY id DESC) AS rn FROM summary_task WHERE space_id = ? AND deleted_at IS NULL AND (creator_id = ? OR id IN (SELECT task_id FROM summary_participant WHERE user_id = ?) OR " + scheduleVisibilityExpr + ")"
+	attentionCountSQL := "SELECT COALESCE(SUM(has_invite),0) pending_invitation_count, COALESCE(SUM(unread),0) unread_count, COALESCE(SUM(CASE WHEN has_invite=1 OR unread=1 THEN 1 ELSE 0 END),0) attention_count FROM (SELECT CASE WHEN me.status=? OR " + schedulePendingExpr + " THEN 1 ELSE 0 END has_invite, CASE WHEN (sub.current_result_id IS NOT NULL AND (sur.last_read_team_result_id IS NULL OR sur.last_read_team_result_id<>sub.current_result_id)) OR (pr.current_version_id IS NOT NULL AND (sur.last_read_personal_version_id IS NULL OR sur.last_read_personal_version_id<>pr.current_version_id)) THEN 1 ELSE 0 END unread FROM (" + countInner + ") sub" + attentionJoins + " WHERE sub.rn=1) attention"
+	var counts struct {
+		AttentionCount         int64 `gorm:"column:attention_count"`
+		UnreadCount            int64 `gorm:"column:unread_count"`
+		PendingInvitationCount int64 `gorm:"column:pending_invitation_count"`
+	}
+	countArgs := []interface{}{model.ParticipantPending}
+	if h.db.Dialector.Name() == "mysql" {
+		countArgs = append(countArgs, userID)
+	}
+	countArgs = append(countArgs, spaceID, userID, userID)
+	if h.db.Dialector.Name() == "mysql" {
+		countArgs = append(countArgs, userID)
+	}
+	countArgs = append(countArgs, userID, userID, userID, userID)
+	if err := h.db.Raw(attentionCountSQL, countArgs...).Scan(&counts).Error; err != nil {
 		log.Printf("list summaries attention count query failed: %v", err)
 		c.JSON(http.StatusInternalServerError, apiResponse{Code: 50000, Message: "failed to list summaries"})
 		return
 	}
-	h.attentionCachePut(attentionCacheKey{userID: userID, spaceID: spaceID}, counts)
-	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount, "pending_submission_count": counts.PendingSubmissionCount})
+	ok(c, gin.H{"total": total, "items": items, "attention_count": counts.AttentionCount, "unread_count": counts.UnreadCount, "pending_invitation_count": counts.PendingInvitationCount})
 }
 
 type markSummaryReadRequest struct {
@@ -1035,19 +1002,13 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 		ReadTeamID        *int64 `gorm:"column:read_team_id"`
 		ReadPersonalID    *int64 `gorm:"column:read_personal_id"`
 		PendingInvitation bool   `gorm:"column:pending_invitation"`
-		PendingSubmission bool   `gorm:"column:pending_submission"`
 	}
 	schedulePendingExpr := h.schedulePendingInvitationExpr("t")
-	// pending_submission mirrors the list projection. Marking content read must
-	// NOT clear it: the participant has seen their personal summary but still
-	// owes the team an explicit /submit. Returning it here keeps the client's
-	// optimistic needs_attention recompute from dropping the dot on read.
 	stateSQL := `SELECT t.current_result_id AS current_team_id,
  pr.current_version_id AS current_personal_id,
  sur.last_read_team_result_id AS read_team_id,
  sur.last_read_personal_version_id AS read_personal_id,
- CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation,
- CASE WHEN pr.worker_status = ? AND pr.submitted_at IS NULL AND (SELECT COUNT(*) FROM summary_participant wait_sp WHERE wait_sp.task_id = t.id) > 1` + pendingSubmitStatusGuard("t") + ` THEN 1 ELSE 0 END AS pending_submission
+ CASE WHEN p.status = ? OR ` + schedulePendingExpr + ` THEN 1 ELSE 0 END AS pending_invitation
  FROM summary_task t
  LEFT JOIN summary_personal_result pr ON pr.task_id=t.id AND pr.user_id=?
  LEFT JOIN summary_user_read sur ON sur.task_id=t.id AND sur.user_id=?
@@ -1057,7 +1018,6 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	if h.db.Dialector.Name() == "mysql" {
 		stateArgs = append(stateArgs, userID)
 	}
-	stateArgs = append(stateArgs, model.PersonalStatusCompleted)
 	stateArgs = append(stateArgs, userID, userID, userID, taskID)
 	if err := h.db.Raw(stateSQL, stateArgs...).Scan(&state).Error; err != nil {
 		log.Printf("mark summary read state query failed: %v", err)
@@ -1070,8 +1030,7 @@ func (h *TaskHandler) MarkSummaryRead(c *gin.Context) {
 	ok(c, gin.H{
 		"task_id": taskID, "team_result_id": req.TeamResultID, "personal_version_id": req.PersonalVersionID,
 		"is_unread": isUnread, "has_pending_invitation": state.PendingInvitation,
-		"has_pending_submission": state.PendingSubmission,
-		"needs_attention":        isUnread || state.PendingInvitation || state.PendingSubmission,
+		"needs_attention": isUnread || state.PendingInvitation,
 	})
 }
 

--- a/internal/api/router/attention_route_test.go
+++ b/internal/api/router/attention_route_test.go
@@ -2,39 +2,49 @@ package router
 
 import (
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 // GET /api/v1/summaries/attention is a static sibling of the /summaries/:id
-// wildcard. gin's radix tree panics at REGISTRATION time on a shape it cannot
-// represent, so building the real router is the assertion that the two routes
-// coexist; serving one request each then proves "attention" is not swallowed as
-// an :id and that the endpoint is mounted behind the human-token group (not the
-// bot group, which must stay a read-only bot surface).
+// wildcard. Assert against the route table rather than response codes: the auth
+// middleware returns 401 before routing matters, so a response-code test cannot
+// distinguish "route exists" from "route is missing and falls through to :id".
+// A route-table assertion proves the handler binding and that the endpoint is
+// not mounted on the bot group.
 func TestAttentionRouteCoexistsWithSummaryIDRoute(t *testing.T) {
 	r := SetupPublic(nil, nil, nil, nil, fixedBotResolver{}, "", 0, false, 0, nil, "", "", "", 0, 0, nil)
 
-	for _, path := range []string{
-		"/api/v1/summaries/attention",
-		"/api/v1/summaries/42",
-	} {
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, path, nil)
-		r.ServeHTTP(w, req)
-		// No token -> the auth middleware rejects before any handler runs.
-		// A 404 here would mean the route is not registered at all.
-		if w.Code != http.StatusUnauthorized {
-			t.Fatalf("%s: expected 401 from the human-token guard, got %d: %s", path, w.Code, w.Body.String())
+	routes := r.Routes()
+
+	// The attention endpoint must be bound to GetAttention on the human-token
+	// group, not swallowed by the /summaries/:id wildcard.
+	found := false
+	for _, rt := range routes {
+		if rt.Method == http.MethodGet && rt.Path == "/api/v1/summaries/attention" {
+			if !strings.Contains(rt.Handler, "GetAttention") {
+				t.Fatalf("GET /api/v1/summaries/attention is bound to %s, not GetAttention", rt.Handler)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("GET /api/v1/summaries/attention is not registered")
+	}
+
+	// /summaries/:id must still resolve to GetSummary, not GetAttention.
+	for _, rt := range routes {
+		if rt.Method == http.MethodGet && rt.Path == "/api/v1/summaries/:id" {
+			if !strings.Contains(rt.Handler, "GetSummary") {
+				t.Fatalf("GET /api/v1/summaries/:id is bound to %s, not GetSummary", rt.Handler)
+			}
 		}
 	}
 
-	// The bot surface must NOT gain the new endpoint.
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/bot/summaries/attention", nil)
-	req.Header.Set("Authorization", "Bearer irrelevant")
-	r.ServeHTTP(w, req)
-	if w.Code == http.StatusOK {
-		t.Fatalf("the attention endpoint must not be mounted on the bot group: %d %s", w.Code, w.Body.String())
+	// The bot surface must NOT gain the attention endpoint.
+	for _, rt := range routes {
+		if strings.HasPrefix(rt.Path, "/api/v1/bot/") && strings.Contains(rt.Handler, "GetAttention") {
+			t.Fatalf("attention endpoint must not be mounted on the bot surface: %s", rt.Path)
+		}
 	}
 }

--- a/internal/api/router/attention_route_test.go
+++ b/internal/api/router/attention_route_test.go
@@ -1,0 +1,40 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// GET /api/v1/summaries/attention is a static sibling of the /summaries/:id
+// wildcard. gin's radix tree panics at REGISTRATION time on a shape it cannot
+// represent, so building the real router is the assertion that the two routes
+// coexist; serving one request each then proves "attention" is not swallowed as
+// an :id and that the endpoint is mounted behind the human-token group (not the
+// bot group, which must stay a read-only bot surface).
+func TestAttentionRouteCoexistsWithSummaryIDRoute(t *testing.T) {
+	r := SetupPublic(nil, nil, nil, nil, fixedBotResolver{}, "", 0, false, 0, nil, "", "", "", 0, 0, nil)
+
+	for _, path := range []string{
+		"/api/v1/summaries/attention",
+		"/api/v1/summaries/42",
+	} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		r.ServeHTTP(w, req)
+		// No token -> the auth middleware rejects before any handler runs.
+		// A 404 here would mean the route is not registered at all.
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("%s: expected 401 from the human-token guard, got %d: %s", path, w.Code, w.Body.String())
+		}
+	}
+
+	// The bot surface must NOT gain the new endpoint.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bot/summaries/attention", nil)
+	req.Header.Set("Authorization", "Bearer irrelevant")
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatalf("the attention endpoint must not be mounted on the bot group: %d %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -83,13 +83,6 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		// session_id. See handler/agent_summary.go.
 		v1.POST("/summaries/batch-status", taskH.BatchStatus)
 		v1.GET("/summaries", taskH.ListSummaries)
-		// Poll-friendly badge endpoint: same numbers GET /summaries returns
-		// alongside its page, without the page rendering cost. Registered as a
-		// static sibling of /summaries/:id, which gin's radix tree accepts
-		// (a static segment is matched before the wildcard at the same position),
-		// so "attention" can never be swallowed as an :id. Add ?fresh=1 to bypass
-		// the short-lived response cache after a user action.
-		v1.GET("/summaries/attention", taskH.GetAttention)
 		v1.GET("/summaries/:id", taskH.GetSummary)
 		v1.POST("/summaries/:id/shares", shareH.Create)
 		v1.GET("/summary-shares/:share_id", shareH.Get)

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -83,6 +83,13 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		// session_id. See handler/agent_summary.go.
 		v1.POST("/summaries/batch-status", taskH.BatchStatus)
 		v1.GET("/summaries", taskH.ListSummaries)
+		// Poll-friendly badge endpoint: same numbers GET /summaries returns
+		// alongside its page, without the page rendering cost. gin's radix tree
+		// gives the static segment priority over the wildcard at the same
+		// position regardless of registration order, so "attention" can never
+		// be swallowed as an :id. Add ?fresh=1 to bypass the short-lived
+		// response cache after a user action.
+		v1.GET("/summaries/attention", taskH.GetAttention)
 		v1.GET("/summaries/:id", taskH.GetSummary)
 		v1.POST("/summaries/:id/shares", shareH.Create)
 		v1.GET("/summary-shares/:share_id", shareH.Get)

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -83,6 +83,13 @@ func SetupPublic(db *gorm.DB, imDB *gorm.DB, hub *ws.Hub, authResolver middlewar
 		// session_id. See handler/agent_summary.go.
 		v1.POST("/summaries/batch-status", taskH.BatchStatus)
 		v1.GET("/summaries", taskH.ListSummaries)
+		// Poll-friendly badge endpoint: same numbers GET /summaries returns
+		// alongside its page, without the page rendering cost. Registered as a
+		// static sibling of /summaries/:id, which gin's radix tree accepts
+		// (a static segment is matched before the wildcard at the same position),
+		// so "attention" can never be swallowed as an :id. Add ?fresh=1 to bypass
+		// the short-lived response cache after a user action.
+		v1.GET("/summaries/attention", taskH.GetAttention)
 		v1.GET("/summaries/:id", taskH.GetSummary)
 		v1.POST("/summaries/:id/shares", shareH.Create)
 		v1.GET("/summary-shares/:share_id", shareH.Get)


### PR DESCRIPTION
## 背景

侧边栏红点目前只能靠重跑 `GET /summaries` 刷新。那个接口为了渲染一页卡片，要查参与人、来源、以及每个任务的结果，而调用方真正需要的只有四个整数。想要红点保持新鲜的客户端，只能在「轮询一个昂贵接口」和「让红点过期」之间二选一。

## 改动

新增 `GET /api/v1/summaries/attention`，只返回：

```json
{
  "attention_count": 3,
  "unread_count": 1,
  "pending_invitation_count": 1,
  "pending_submission_count": 1
}
```

### 1. 统计 SQL 抽成单一实现（本 PR 最重要的部分）

attention 统计查询原样提取为 `TaskHandler.attentionCounts(spaceID, userID)`，`ListSummaries` 改为调用它，不再自己保留一份。join 块同样提为共用常量。

这不是为了少写几行。那条 SQL 是手工拼接的位置参数，一旦存在第二份手抄副本，任一信号的定义发生变化时它们必然漂移——用户会看到「侧边栏显示 1 条，进去有 3 个红点」。`TestGetAttention_MatchesListSummaries` 用同一份 fixture 断言两条路径返回相同数字，把这条路堵死。

### 2. 路由注册位置

`/summaries/attention` 注册在 `/summaries/:id` **之前**。gin 的 radix tree 在同一层级上静态段优先于通配段，所以 `attention` 不会被当作 `:id` 吞掉。`TestAttentionRouteCoexistsWithSummaryIDRoute` 钉住这个共存关系，避免后续调整注册顺序时静默破坏。

### 3. 进程内缓存，5 秒 TTL，key = (userID, spaceID)

**不引入 redis。** 当前 `go.mod` 没有任何缓存依赖，部署副本数为 1（helm `summary.api.replicas` 默认 1，kustomize base 写死 1）。为一个红点的 5 秒缓存新增基础设施依赖不划算。将来扩到多副本时，进程内缓存只是命中率下降，**不会出错**——它是优雅降级而非故障。

**没有任何写路径失效钩子，这是刻意的。** 接受邀请、提交、标记已读、删除、重新生成……每处都挂 invalidate，漏掉任何一个的后果是**红点永久卡住**，比 5 秒陈旧严重得多，且极难复现；耦合面还会随着每个新增写操作持续扩大。

正确性改由 `?fresh=1` 保证：用户动作之后的那次读取带 `fresh=1`，绕过并刷新缓存；后台定时轮询走缓存路径。语义上也更顺——刚点完「接受邀请」的那次刷新本来就该拿最新值，而定时器空转时 5 秒陈旧对红点毫无影响。

缓存有容量上界，不会随用户/Space 数量无限增长。

## 测试

`internal/api/handler/attention_endpoint_test.go`（8 例）+ `internal/api/router/attention_route_test.go`（1 例）：

- 与 `ListSummaries` 数字一致（口径漂移守卫）
- 空 `X-Space-Id` 拒绝（fail-closed，与 `ListSummaries` 同）
- TTL 内命中缓存 / TTL 后过期
- `?fresh=1` 绕过并刷新
- 缓存按 user **且** 按 space 隔离，互不串值
- `ListSummaries` 不读缓存
- 缓存容量有界

```
go build ./...                     通过
go vet ./internal/api/handler/     干净
go test ./internal/api/handler/    ok  29.551s
go test ./internal/api/router/     ok   0.011s
```

## ⚠️ 本方案为过渡，不是终局

这个接口存在的原因，是后端缺少 attention 变更事件：

- `internal/worker/personal_processor.go` 的 "waiting for submit" 分支只有一行 log，没有任何事件出口；
- 邀请创建同理；
- `internal/notify` 只有 `completed` / `failed` 两个 kind。

所以前端只能靠轮询来发现「你被拉进了一个总结」和「该你提交了」。**后端补齐 attention 变更事件（IM CMD 静默指令或 SSE）之后，前端的轮询应当移除，本接口退化为普通查询接口。**

写下这段是因为 PR #852 → PR #1213 已经演过一次：轮询作为权宜之计引入，之后无人记得它当初是权宜之计。

## 依赖关系

> ⚠️ **本 PR 基于 PR #229 分支，非基于 main。** 由于 #229 的分支位于 fork 上，GitHub 无法将其设为 base，因此这里的 base 是 `main`，diff 中会同时包含 #229 的提交。**只需评审最后一个提交 `2447f1d`。** #229 合入后本 PR 的 diff 会自动收敛。

- 基于 PR #229（`feat/summary-attention-pending-submit`），需在其之后合入。
- 配套前端：octo-web `feat/summary-attention-poll`。前端对本接口 404 做了降级（退回 `page_size=1`），因此两边可以独立评审、独立合入。

## 合入前待办

- [ ] 在**有真实任务量的 space** 上压测该 SQL 并附 `EXPLAIN`。空库上的数字没有参考价值。该查询对整个 space 做 `ROW_NUMBER() OVER (PARTITION BY ...)` 全扫，`has_submit` 项还带逐行相关子查询。
- [ ] 前端轮询需重新取得产品确认（PR #1213 是产品拍板删除 5 秒轮询）。本接口本身不受此约束。
