### PR TITLE
feat(summary): expose SenderIsBot on Citation so frontend can distinguish bots

### DIFF
--- a/internal/agent/message_enrichment.go
+++ b/internal/agent/message_enrichment.go
@@ -55,38 +55,67 @@ func enrichMessagesWithMetadata(
 		uids = append(uids, uid)
 	}
 
-	// Batch query user table
+	// Batch query user table — select robot flag alongside name so a single
+	// roundtrip covers both fields. SenderIsBot is filled from the union of
+	// (user.robot=1) OR (uid IN robot table), keeping judgement identical to
+	// the candidates API (internal/api/handler/candidates.go) and the worker
+	// path (worker.batchResolveUserNames). Two IM sources are unioned so
+	// system bots (BotFather etc.) with robot=0 on the user row are still
+	// flagged via their robot table membership.
 	nameMap := make(map[string]string)
+	botSet := make(map[string]bool)
 	if len(uids) > 0 && imDB != nil {
 		type userRow struct {
-			UID  string `gorm:"column:uid"`
-			Name string `gorm:"column:name"`
+			UID   string `gorm:"column:uid"`
+			Name  string `gorm:"column:name"`
+			Robot int    `gorm:"column:robot"`
 		}
 		var rows []userRow
 		if err := imDB.WithContext(ctx).Raw(
-			"SELECT uid, name FROM `user` WHERE uid IN ? AND name != ''",
+			"SELECT uid, name, robot FROM `user` WHERE uid IN ? AND name != ''",
 			uids,
 		).Scan(&rows).Error; err != nil {
 			log.Printf("[agent] enrich: batch resolve user names failed: %v", err)
 		} else {
 			for _, r := range rows {
 				nameMap[r.UID] = r.Name
+				if r.Robot == 1 {
+					botSet[r.UID] = true
+				}
 			}
 			log.Printf("[agent] enrich: resolved %d/%d user names", len(nameMap), len(uids))
 		}
+
+		// Union with the robot table so system bots with robot=0 on the
+		// user row are still flagged. Non-fatal: on error we keep the
+		// partial botSet from the user query above.
+		var robotIDs []string
+		if err := imDB.WithContext(ctx).Raw(
+			"SELECT robot_id FROM `robot` WHERE robot_id IN ?",
+			uids,
+		).Scan(&robotIDs).Error; err != nil {
+			log.Printf("[agent] enrich: batch resolve robot table failed: %v", err)
+		} else {
+			for _, rid := range robotIDs {
+				botSet[rid] = true
+			}
+		}
 	}
 
-	// 3. Populate all three missing fields on each message
+	// 3. Populate all fields on each message
 	for i := range messages {
 		// SenderName from batch-resolved map
 		if name, ok := nameMap[messages[i].SenderUID]; ok {
 			messages[i].SenderName = name
 		}
+		// SenderIsBot from batch-resolved bot set (missing UID => false,
+		// same default as candidates.go's exclusion behaviour).
+		messages[i].SenderIsBot = botSet[messages[i].SenderUID]
 		// SourceName and ChannelType from accessibleChannels
 		messages[i].SourceName = channelName
 		messages[i].ChannelType = channelType
 	}
 
-	log.Printf("[agent] enrich: populated metadata for %d messages (channel=%s, source=%s, type=%d)",
-		len(messages), targetChannelID, channelName, channelType)
+	log.Printf("[agent] enrich: populated metadata for %d messages (channel=%s, source=%s, type=%d, bots=%d)",
+		len(messages), targetChannelID, channelName, channelType, len(botSet))
 }

--- a/internal/agent/message_enrichment.go
+++ b/internal/agent/message_enrichment.go
@@ -72,13 +72,20 @@ func enrichMessagesWithMetadata(
 		}
 		var rows []userRow
 		if err := imDB.WithContext(ctx).Raw(
-			"SELECT uid, name, robot FROM `user` WHERE uid IN ? AND name != ''",
+			"SELECT uid, name, robot FROM `user` WHERE uid IN ?",
 			uids,
 		).Scan(&rows).Error; err != nil {
 			log.Printf("[agent] enrich: batch resolve user names failed: %v", err)
 		} else {
 			for _, r := range rows {
-				nameMap[r.UID] = r.Name
+				// Bot classification must NOT depend on name presence:
+				// programmatically provisioned bots can have an empty
+				// name row but still be robot=1. Gating botSet on the
+				// name filter caused an agent-vs-worker mismatch (see
+				// PR #237 review by Jerry-Xin, P1 blocking).
+				if r.Name != "" {
+					nameMap[r.UID] = r.Name
+				}
 				if r.Robot == 1 {
 					botSet[r.UID] = true
 				}

--- a/internal/agent/message_enrichment_test.go
+++ b/internal/agent/message_enrichment_test.go
@@ -43,19 +43,26 @@ func TestEnrichMessagesWithMetadata_PopulatesAllFields(t *testing.T) {
 	_, err = sqlDB.Exec(`
 		CREATE TABLE user (
 			uid TEXT PRIMARY KEY,
-			name TEXT NOT NULL
+			name TEXT NOT NULL,
+			robot INTEGER NOT NULL DEFAULT 0
 		)
 	`)
 	if err != nil {
 		t.Fatalf("failed to create user table: %v", err)
 	}
+	// robot table must exist too — enrichment unions user.robot with the
+	// robot table to match candidates.go's judgement.
+	_, err = sqlDB.Exec(`CREATE TABLE robot (robot_id TEXT PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create robot table: %v", err)
+	}
 
 	// Insert test users
 	_, err = sqlDB.Exec(`
-		INSERT INTO user (uid, name) VALUES
-		('u_alice', '张三'),
-		('u_bob', '李四'),
-		('u_charlie', '王五')
+		INSERT INTO user (uid, name, robot) VALUES
+		('u_alice', '张三', 0),
+		('u_bob', '李四', 0),
+		('u_charlie', '王五', 0)
 	`)
 	if err != nil {
 		t.Fatalf("failed to insert test users: %v", err)
@@ -160,12 +167,14 @@ func TestEnrichMessagesWithMetadata_BatchResolveNoPlusOne(t *testing.T) {
 	}
 	defer sqlDB.Close()
 
-	_, err = sqlDB.Exec(`CREATE TABLE user (uid TEXT PRIMARY KEY, name TEXT NOT NULL)`)
+	_, err = sqlDB.Exec(`CREATE TABLE user (uid TEXT PRIMARY KEY, name TEXT NOT NULL, robot INTEGER NOT NULL DEFAULT 0)`)
 	if err != nil {
 		t.Fatalf("failed to create user table: %v", err)
 	}
-
-	// Insert 100 users
+	_, err = sqlDB.Exec(`CREATE TABLE robot (robot_id TEXT PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create robot table: %v", err)
+	}
 	for i := 0; i < 100; i++ {
 		uid := sql.NullString{String: "u_" + string(rune(i)), Valid: true}
 		name := sql.NullString{String: "User" + string(rune(i)), Valid: true}
@@ -218,10 +227,11 @@ func TestEnrichMessagesWithMetadata_BatchResolveNoPlusOne(t *testing.T) {
 	ctx := context.Background()
 	enrichMessagesWithMetadata(ctx, messages, "group_large", channels, db)
 
-	// We expect EXACTLY 1 batch query for all 100 users
-	// If we see 100 queries, that's N+1 and the test should fail
-	if queryCount != 1 {
-		t.Errorf("expected 1 batch query, got %d (N+1 detected!)", queryCount)
+	// We expect EXACTLY 2 batch queries — one against user, one against
+	// robot — for all 100 users. Both are O(1) w.r.t. message count. If
+	// we see anywhere near 100 queries, that's N+1 and the test should fail.
+	if queryCount != 2 {
+		t.Errorf("expected 2 batch queries (user + robot), got %d (N+1 detected!)", queryCount)
 	}
 }
 
@@ -241,13 +251,17 @@ func TestEnrichMessagesWithMetadata_MissingUserGraceful(t *testing.T) {
 	}
 	defer sqlDB.Close()
 
-	_, err = sqlDB.Exec(`CREATE TABLE user (uid TEXT PRIMARY KEY, name TEXT NOT NULL)`)
+	_, err = sqlDB.Exec(`CREATE TABLE user (uid TEXT PRIMARY KEY, name TEXT NOT NULL, robot INTEGER NOT NULL DEFAULT 0)`)
 	if err != nil {
 		t.Fatalf("failed to create user table: %v", err)
 	}
+	_, err = sqlDB.Exec(`CREATE TABLE robot (robot_id TEXT PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create robot table: %v", err)
+	}
 
 	// Only insert one user
-	_, err = sqlDB.Exec(`INSERT INTO user (uid, name) VALUES ('u_alice', '张三')`)
+	_, err = sqlDB.Exec(`INSERT INTO user (uid, name, robot) VALUES ('u_alice', '张三', 0)`)
 	if err != nil {
 		t.Fatalf("failed to insert test user: %v", err)
 	}
@@ -280,4 +294,77 @@ func TestEnrichMessagesWithMetadata_MissingUserGraceful(t *testing.T) {
 	}
 
 	log.Printf("[test] gracefully handled missing user (no crash)")
+}
+
+// TestEnrichMessagesWithMetadata_SenderIsBotUnion pins the SenderIsBot
+// judgement to match candidates.go's rule: union of (user.robot=1) OR
+// (uid IN robot table). A regression that drops either source would break
+// bot filtering silently — this test guards both sides plus the negative
+// (a plain human user stays SenderIsBot=false).
+func TestEnrichMessagesWithMetadata_SenderIsBotUnion(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("failed to get sql.DB: %v", err)
+	}
+	defer sqlDB.Close()
+
+	_, err = sqlDB.Exec(`CREATE TABLE user (uid TEXT PRIMARY KEY, name TEXT NOT NULL, robot INTEGER NOT NULL DEFAULT 0)`)
+	if err != nil {
+		t.Fatalf("failed to create user table: %v", err)
+	}
+	_, err = sqlDB.Exec(`CREATE TABLE robot (robot_id TEXT PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("failed to create robot table: %v", err)
+	}
+
+	// Three users covering all three legs of the union:
+	//   u_human — user row with robot=0, absent from robot table  ⇒ false
+	//   u_flagged — user row with robot=1                          ⇒ true (leg 1)
+	//   u_system — user row with robot=0, present in robot table   ⇒ true (leg 2)
+	_, err = sqlDB.Exec(`
+		INSERT INTO user (uid, name, robot) VALUES
+		('u_human',   '张三', 0),
+		('u_flagged', 'CI机器人', 1),
+		('u_system',  'BotFather', 0)
+	`)
+	if err != nil {
+		t.Fatalf("failed to seed user rows: %v", err)
+	}
+	_, err = sqlDB.Exec(`INSERT INTO robot (robot_id) VALUES ('u_system')`)
+	if err != nil {
+		t.Fatalf("failed to seed robot rows: %v", err)
+	}
+
+	messages := []pipeline.Message{
+		{SenderUID: "u_human", ChannelID: "g", Content: "hi"},
+		{SenderUID: "u_flagged", ChannelID: "g", Content: "PR merged"},
+		{SenderUID: "u_system", ChannelID: "g", Content: "system notice"},
+	}
+	channels := []pipeline.ChannelInfo{
+		{ChannelID: "g", ChannelType: 2, ChannelName: "test"},
+	}
+
+	enrichMessagesWithMetadata(context.Background(), messages, "g", channels, db)
+
+	want := map[string]bool{
+		"u_human":   false,
+		"u_flagged": true,
+		"u_system":  true,
+	}
+	for i, msg := range messages {
+		expected, ok := want[msg.SenderUID]
+		if !ok {
+			t.Fatalf("unexpected uid %q at index %d", msg.SenderUID, i)
+		}
+		if msg.SenderIsBot != expected {
+			t.Errorf("message[%d] uid=%q: SenderIsBot=%v, want %v",
+				i, msg.SenderUID, msg.SenderIsBot, expected)
+		}
+	}
 }

--- a/internal/agent/message_enrichment_test.go
+++ b/internal/agent/message_enrichment_test.go
@@ -323,15 +323,20 @@ func TestEnrichMessagesWithMetadata_SenderIsBotUnion(t *testing.T) {
 		t.Fatalf("failed to create robot table: %v", err)
 	}
 
-	// Three users covering all three legs of the union:
-	//   u_human — user row with robot=0, absent from robot table  ⇒ false
-	//   u_flagged — user row with robot=1                          ⇒ true (leg 1)
-	//   u_system — user row with robot=0, present in robot table   ⇒ true (leg 2)
+	// Four users covering all legs of the union PLUS the empty-name bot
+	// regression that motivated the fix (PR #237 review, P1 blocking):
+	//   u_human       — user row with robot=0, absent from robot table     ⇒ false
+	//   u_flagged     — user row with robot=1                                ⇒ true (leg 1)
+	//   u_system      — user row with robot=0, present in robot table       ⇒ true (leg 2)
+	//   u_bot_noname  — user row with robot=1 AND name='' (programmatically
+	//                   provisioned bot); must NOT be filtered out at SQL
+	//                   layer or the classification silently drops.         ⇒ true (leg 3)
 	_, err = sqlDB.Exec(`
 		INSERT INTO user (uid, name, robot) VALUES
-		('u_human',   '张三', 0),
-		('u_flagged', 'CI机器人', 1),
-		('u_system',  'BotFather', 0)
+		('u_human',      '张三',      0),
+		('u_flagged',    'CI机器人',   1),
+		('u_system',     'BotFather', 0),
+		('u_bot_noname', '',          1)
 	`)
 	if err != nil {
 		t.Fatalf("failed to seed user rows: %v", err)
@@ -345,6 +350,7 @@ func TestEnrichMessagesWithMetadata_SenderIsBotUnion(t *testing.T) {
 		{SenderUID: "u_human", ChannelID: "g", Content: "hi"},
 		{SenderUID: "u_flagged", ChannelID: "g", Content: "PR merged"},
 		{SenderUID: "u_system", ChannelID: "g", Content: "system notice"},
+		{SenderUID: "u_bot_noname", ChannelID: "g", Content: "auto post"},
 	}
 	channels := []pipeline.ChannelInfo{
 		{ChannelID: "g", ChannelType: 2, ChannelName: "test"},
@@ -353,9 +359,10 @@ func TestEnrichMessagesWithMetadata_SenderIsBotUnion(t *testing.T) {
 	enrichMessagesWithMetadata(context.Background(), messages, "g", channels, db)
 
 	want := map[string]bool{
-		"u_human":   false,
-		"u_flagged": true,
-		"u_system":  true,
+		"u_human":      false,
+		"u_flagged":    true,
+		"u_system":     true,
+		"u_bot_noname": true,
 	}
 	for i, msg := range messages {
 		expected, ok := want[msg.SenderUID]

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -284,6 +284,13 @@ func (SummaryChunk) TableName() string { return "summary_chunk" }
 type Citation struct {
 	Index         int          `json:"index"`
 	Sender        string       `json:"sender"`
+	// SenderIsBot marks whether the citation's sender is a bot. Sourced
+	// from pipeline.Message.SenderIsBot (filled by the same batch resolver
+	// that populates Sender). Same judgement as the candidates API so the
+	// frontend sees a consistent bot flag across endpoints. Included in
+	// JSON unconditionally so the frontend can filter by it — a `false`
+	// value is meaningful (this sender is confirmed not a bot).
+	SenderIsBot   bool         `json:"sender_is_bot"`
 	Content       string       `json:"content"`
 	SentAt        string       `json:"sent_at"`
 	Source        string       `json:"source"`
@@ -296,10 +303,11 @@ type Citation struct {
 
 // ContextMsg represents a surrounding message used as context for a citation.
 type ContextMsg struct {
-	Sender     string `json:"sender"`
-	Content    string `json:"content"`
-	SentAt     string `json:"sent_at"`
-	MessageSeq int64  `json:"message_seq"`
+	Sender      string `json:"sender"`
+	SenderIsBot bool   `json:"sender_is_bot"`
+	Content     string `json:"content"`
+	SentAt      string `json:"sent_at"`
+	MessageSeq  int64  `json:"message_seq"`
 }
 
 // TeamCitation represents a [Pn] reference in a team summary pointing to a participant.

--- a/internal/pipeline/fetch.go
+++ b/internal/pipeline/fetch.go
@@ -50,6 +50,13 @@ type Message struct {
 	MessageSeq    int64  `json:"message_seq"`
 	SenderUID     string `json:"sender_uid"`
 	SenderName    string `json:"sender_name"`
+	// SenderIsBot marks whether the sender is a bot (IM user.robot=1 OR
+	// uid present in the robot table). Filled alongside SenderName by the
+	// same batch resolver — see worker.batchResolveUserNames and
+	// agent.enrichMessagesWithMetadata. Judgement kept identical to the
+	// candidates API (internal/api/handler/candidates.go), so the frontend
+	// sees the same bot classification wherever it queries.
+	SenderIsBot   bool   `json:"sender_is_bot"`
 	ChannelID     string `json:"channel_id"`
 	ChannelType   int    `json:"channel_type"`
 	Timestamp     int64  `json:"timestamp"`

--- a/internal/worker/citation.go
+++ b/internal/worker/citation.go
@@ -87,6 +87,7 @@ func buildCitations(text string, messages []pipeline.Message, allMessages []pipe
 			citations = append(citations, model.Citation{
 				Index:         msg.CitationIndex,
 				Sender:        sender,
+				SenderIsBot:   msg.SenderIsBot,
 				Content:       content,
 				SentAt:        msg.SendTime,
 				Source:        msg.SourceName,
@@ -213,10 +214,11 @@ func toContextMsg(msg pipeline.Message, nameMap map[string]string) model.Context
 		}
 	}
 	return model.ContextMsg{
-		Sender:     sender,
-		Content:    truncateRunes(msg.Content, 200),
-		SentAt:     msg.SendTime,
-		MessageSeq: msg.MessageSeq,
+		Sender:      sender,
+		SenderIsBot: msg.SenderIsBot,
+		Content:     truncateRunes(msg.Content, 200),
+		SentAt:      msg.SendTime,
+		MessageSeq:  msg.MessageSeq,
 	}
 }
 

--- a/internal/worker/citation_test.go
+++ b/internal/worker/citation_test.go
@@ -486,3 +486,78 @@ func TestExtractTeamCitations_CarriesPersonalResultAndTaskID(t *testing.T) {
 		t.Errorf("P2 missing convenience fields: %+v", got[1])
 	}
 }
+
+// TestBuildCitations_PropagatesSenderIsBot pins the contract that
+// pipeline.Message.SenderIsBot flows through to Citation.SenderIsBot and
+// ContextMsg.SenderIsBot. This is the only backend-visible marker the frontend
+// gets for "the sender of this citation is a bot", so a silent drop would
+// make the whole feature invisible without any other test failing.
+//
+// Paired-guard style: covers both a bot and a human citation, and checks the
+// context messages inherit the flag from the original pipeline.Message they
+// were derived from — so a context line quoting a bot in the middle of a
+// human-anchored citation still reads as bot on the frontend.
+func TestBuildCitations_PropagatesSenderIsBot(t *testing.T) {
+	// allMessages is the untrimmed pool used to build ContextBefore/After.
+	// Two channels are seeded so both citations exercise the context path.
+	allMessages := []pipeline.Message{
+		// ch_dev: bot-anchored citation with a human context line before it.
+		{MessageSeq: 10, ChannelID: "ch_dev", SenderUID: "uid_alice", SenderIsBot: false, Content: "morning", SendTime: "2025-01-15T09:00:00Z", SourceName: "开发群"},
+		{MessageSeq: 11, ChannelID: "ch_dev", SenderUID: "uid_bot_ci", SenderIsBot: true, Content: "PR #42 merged", SendTime: "2025-01-15T09:01:00Z", SourceName: "开发群", CitationIndex: 1},
+		{MessageSeq: 12, ChannelID: "ch_dev", SenderUID: "uid_bot_pager", SenderIsBot: true, Content: "deploy started", SendTime: "2025-01-15T09:02:00Z", SourceName: "开发群"},
+		// ch_ops: human-anchored citation with a bot context line after it.
+		{MessageSeq: 20, ChannelID: "ch_ops", SenderUID: "uid_bob", SenderIsBot: false, Content: "rolling out fix", SendTime: "2025-01-15T09:03:00Z", SourceName: "运维群", CitationIndex: 2},
+		{MessageSeq: 21, ChannelID: "ch_ops", SenderUID: "uid_bot_watch", SenderIsBot: true, Content: "alert cleared", SendTime: "2025-01-15T09:04:00Z", SourceName: "运维群"},
+	}
+	cited := []pipeline.Message{allMessages[1], allMessages[3]}
+
+	nameMap := map[string]string{
+		"uid_alice":     "Alice",
+		"uid_bob":       "Bob",
+		"uid_bot_ci":    "CI Bot",
+		"uid_bot_pager": "Pager Bot",
+		"uid_bot_watch": "Watch Bot",
+	}
+
+	citations := buildCitations("bot said [1], human said [2]", cited, allMessages, nameMap)
+	if len(citations) != 2 {
+		t.Fatalf("expected 2 citations, got %d", len(citations))
+	}
+
+	// c1: bot-anchored — Citation.SenderIsBot must be true.
+	c1 := citations[0]
+	if !c1.SenderIsBot {
+		t.Errorf("c1 (bot-anchored, uid=%q): SenderIsBot=false, want true", cited[0].SenderUID)
+	}
+	if c1.Sender != "CI Bot" {
+		t.Errorf("c1.Sender = %q, want %q", c1.Sender, "CI Bot")
+	}
+	// Its context_before[0] is a HUMAN — bot flag must be false there,
+	// otherwise ContextMsg is leaking the citation's flag onto its neighbours.
+	if len(c1.ContextBefore) != 1 {
+		t.Fatalf("c1.ContextBefore length = %d, want 1", len(c1.ContextBefore))
+	}
+	if c1.ContextBefore[0].SenderIsBot {
+		t.Errorf("c1.ContextBefore[0] (human): SenderIsBot=true, want false — flag is bleeding across messages")
+	}
+	// Its context_after[0] is a BOT — bot flag must be true.
+	if len(c1.ContextAfter) != 1 {
+		t.Fatalf("c1.ContextAfter length = %d, want 1", len(c1.ContextAfter))
+	}
+	if !c1.ContextAfter[0].SenderIsBot {
+		t.Errorf("c1.ContextAfter[0] (bot uid=%q): SenderIsBot=false, want true", allMessages[2].SenderUID)
+	}
+
+	// c2: human-anchored — Citation.SenderIsBot must be false.
+	c2 := citations[1]
+	if c2.SenderIsBot {
+		t.Errorf("c2 (human-anchored, uid=%q): SenderIsBot=true, want false", cited[1].SenderUID)
+	}
+	// Its context_after[0] is a BOT — ContextMsg flag must independently reflect that.
+	if len(c2.ContextAfter) != 1 {
+		t.Fatalf("c2.ContextAfter length = %d, want 1", len(c2.ContextAfter))
+	}
+	if !c2.ContextAfter[0].SenderIsBot {
+		t.Errorf("c2.ContextAfter[0] (bot uid=%q): SenderIsBot=false, want true", allMessages[4].SenderUID)
+	}
+}

--- a/internal/worker/personal_processor.go
+++ b/internal/worker/personal_processor.go
@@ -754,10 +754,10 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 
 	// Resolve sender names (for display in summary)
 	resolveStart := time.Now()
-	nameMap := p.batchResolveUserNames(messages)
+	nameMap, botSet := p.batchResolveUserNames(messages)
 	timing.Observe(taskNo, "resolve_user_names", resolveStart)
-	log.Printf("[personal-worker] batchResolveUserNames took %dms (%d names)",
-		time.Since(resolveStart).Milliseconds(), len(nameMap))
+	log.Printf("[personal-worker] batchResolveUserNames took %dms (%d names, %d bots)",
+		time.Since(resolveStart).Milliseconds(), len(nameMap), len(botSet))
 
 	// Get target person info from unified intent recognition (returned from fetch)
 	var targetUIDs []string
@@ -852,6 +852,18 @@ func (p *Processor) executePersonalPipeline(ctx context.Context, task model.Summ
 		} else {
 			userMessages[i].SenderName = userMessages[i].SenderUID
 		}
+		// SenderIsBot rides on the same batch resolver — botSet has the
+		// UIDs that user.robot=1 OR appear in the robot table. A missing
+		// UID (no user row, no robot row) is treated as not-a-bot, which
+		// matches the candidates API's default exclusion behaviour.
+		userMessages[i].SenderIsBot = botSet[userMessages[i].SenderUID]
+	}
+	// Also fill SenderIsBot on the full message pool (`messages`) — buildCitations
+	// receives it as allMessages and reads SenderIsBot to fill ContextMsg,
+	// so context lines around a citation carry the same bot flag as the
+	// citation itself.
+	for i := range messages {
+		messages[i].SenderIsBot = botSet[messages[i].SenderUID]
 	}
 
 	// Assign CitationIndex to all messages (evidence pool)

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -857,11 +857,19 @@ func joinStrings(ss []string) string {
 }
 
 // batchResolveUserNames queries the IM DB for display names of the given message senders.
-// Returns a map from UID to display name. UIDs that cannot be resolved are omitted.
-func (p *Processor) batchResolveUserNames(messages []pipeline.Message) map[string]string {
+// Returns a map from UID to display name and a set of UIDs that are bots.
+// UIDs that cannot be resolved are omitted from nameMap; botSet is a positive
+// set so callers can check membership with a single lookup.
+//
+// Bot judgement matches the candidates API (internal/api/handler/candidates.go):
+// a UID is a bot when user.robot=1 OR the UID appears in the robot table.
+// Two IM sources are unioned so system bots (BotFather etc., which have
+// robot=0 on the user row but a matching robot table row) are still flagged.
+func (p *Processor) batchResolveUserNames(messages []pipeline.Message) (map[string]string, map[string]bool) {
 	nameMap := make(map[string]string)
+	botSet := make(map[string]bool)
 	if p.imDB == nil || len(messages) == 0 {
-		return nameMap
+		return nameMap, botSet
 	}
 
 	// Collect unique UIDs
@@ -872,7 +880,7 @@ func (p *Processor) batchResolveUserNames(messages []pipeline.Message) map[strin
 		}
 	}
 	if len(uidSet) == 0 {
-		return nameMap
+		return nameMap, botSet
 	}
 
 	uids := make([]string, 0, len(uidSet))
@@ -880,21 +888,40 @@ func (p *Processor) batchResolveUserNames(messages []pipeline.Message) map[strin
 		uids = append(uids, uid)
 	}
 
-	// Batch query from user table
+	// Batch query from user table — select robot flag alongside name so a
+	// single roundtrip covers both fields.
 	type userRow struct {
-		UID  string `gorm:"column:uid"`
-		Name string `gorm:"column:name"`
+		UID   string `gorm:"column:uid"`
+		Name  string `gorm:"column:name"`
+		Robot int    `gorm:"column:robot"`
 	}
 	var rows []userRow
-	if err := p.imDB.Raw("SELECT uid, name FROM `user` WHERE uid IN ?", uids).Scan(&rows).Error; err != nil {
+	if err := p.imDB.Raw("SELECT uid, name, robot FROM `user` WHERE uid IN ?", uids).Scan(&rows).Error; err != nil {
 		log.Printf("[processor] batch resolve user names: %v", err)
-		return nameMap
+		return nameMap, botSet
 	}
 	for _, r := range rows {
 		if r.Name != "" {
 			nameMap[r.UID] = r.Name
 		}
+		if r.Robot == 1 {
+			botSet[r.UID] = true
+		}
 	}
-	log.Printf("[processor] resolved %d/%d user names", len(nameMap), len(uids))
-	return nameMap
+
+	// Union with the robot table so system bots with robot=0 on the user
+	// row (BotFather etc.) are still flagged. Same query shape as
+	// candidates.go's WHERE u.uid NOT IN (SELECT robot_id FROM robot).
+	var robotIDs []string
+	if err := p.imDB.Raw("SELECT robot_id FROM `robot` WHERE robot_id IN ?", uids).Scan(&robotIDs).Error; err != nil {
+		log.Printf("[processor] batch resolve robot table: %v", err)
+		// Fall through: nameMap and partial botSet are still valid.
+	} else {
+		for _, rid := range robotIDs {
+			botSet[rid] = true
+		}
+	}
+
+	log.Printf("[processor] resolved %d/%d user names, %d bots", len(nameMap), len(uids), len(botSet))
+	return nameMap, botSet
 }

--- a/internal/worker/processor.go
+++ b/internal/worker/processor.go
@@ -897,15 +897,21 @@ func (p *Processor) batchResolveUserNames(messages []pipeline.Message) (map[stri
 	}
 	var rows []userRow
 	if err := p.imDB.Raw("SELECT uid, name, robot FROM `user` WHERE uid IN ?", uids).Scan(&rows).Error; err != nil {
+		// Fall through to the robot table query below instead of an
+		// early return: the two SQLs are independent and the fail-open
+		// design (documented in PR #237) requires either leg to keep
+		// working when the other fails. Aligns with the agent-side
+		// resolver in agent/message_enrichment.go (PR #237 review by
+		// Jerry-Xin, P2 non-blocking).
 		log.Printf("[processor] batch resolve user names: %v", err)
-		return nameMap, botSet
-	}
-	for _, r := range rows {
-		if r.Name != "" {
-			nameMap[r.UID] = r.Name
-		}
-		if r.Robot == 1 {
-			botSet[r.UID] = true
+	} else {
+		for _, r := range rows {
+			if r.Name != "" {
+				nameMap[r.UID] = r.Name
+			}
+			if r.Robot == 1 {
+				botSet[r.UID] = true
+			}
 		}
 	}
 

--- a/internal/worker/processor_test.go
+++ b/internal/worker/processor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/config"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/model"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/pipeline"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/service"
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/timezone"
 	"gorm.io/driver/sqlite"
@@ -1294,5 +1295,57 @@ func TestManualConfirm_MultiPerson_DoesNotDispatch(t *testing.T) {
 
 	if len(dispatched) != 0 {
 		t.Fatalf("manual (non-scheduled) CONFIRM multi-person must NOT dispatch participants from processTask (they wait for confirmation); got %v", dispatched)
+	}
+}
+
+// TestBatchResolveUserNames_UserQueryFailsRobotTableStillRuns pins the
+// fail-open contract on the worker resolver: if the `user` query fails
+// (e.g. table missing, permission error), the resolver must still run
+// the `robot` table leg and return whatever partial botSet it can build.
+// Before this test the resolver returned early on user-query error and
+// silently dropped robot-table classification (PR #237 review by
+// Jerry-Xin, P2 non-blocking).
+func TestBatchResolveUserNames_UserQueryFailsRobotTableStillRuns(t *testing.T) {
+	imDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open imDB: %v", err)
+	}
+	sqlDB, err := imDB.DB()
+	if err != nil {
+		t.Fatalf("get sql.DB: %v", err)
+	}
+	defer sqlDB.Close()
+
+	// Deliberately DO NOT create the `user` table — the user query
+	// will fail with "no such table: user". Only create the robot
+	// table so the second leg can still execute.
+	if _, err := sqlDB.Exec(`CREATE TABLE robot (robot_id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create robot table: %v", err)
+	}
+	if _, err := sqlDB.Exec(`INSERT INTO robot (robot_id) VALUES ('u_bot_a'), ('u_bot_b')`); err != nil {
+		t.Fatalf("seed robot rows: %v", err)
+	}
+
+	p := &Processor{imDB: imDB}
+	messages := []pipeline.Message{
+		{SenderUID: "u_bot_a"},
+		{SenderUID: "u_bot_b"},
+		{SenderUID: "u_unknown"},
+	}
+
+	nameMap, botSet := p.batchResolveUserNames(messages)
+
+	// nameMap is empty because the user query failed — acceptable.
+	if len(nameMap) != 0 {
+		t.Errorf("expected empty nameMap on user-query failure, got %v", nameMap)
+	}
+	// botSet MUST still contain the two robot-table entries. If the
+	// resolver early-returned on user-query failure, this map is empty
+	// and the assertion fails.
+	if !botSet["u_bot_a"] || !botSet["u_bot_b"] {
+		t.Errorf("botSet lost robot-table entries after user-query failure: %v", botSet)
+	}
+	if botSet["u_unknown"] {
+		t.Errorf("u_unknown should not be classified as bot: %v", botSet)
 	}
 }


### PR DESCRIPTION
## Summary

在 summary 数据管线里增加 `SenderIsBot` 字段,让 citation 回给前端时能区分「消息是 bot 发的还是人发的」。之前候选列表接口(`candidates.go`)有这个能力(查 `user.robot` 列 + `robot` 表),但没延伸到 summary 管线 —— LLM 和前端都看不到 bot 标记。本 PR 只做**字段透传**,不做任何过滤/prompt/LLM 行为改动。

判定口径**完全对齐** `candidates.go` 里 bot 排除规则的对偶(候选查询排除 bot,本 PR 识别 bot,同一条判定线):
- `user.robot = 1` (user 行 flag)
- **OR** `uid IN (SELECT robot_id FROM robot)` (系统 bot 如 BotFather 的 `user.robot=0` 但登记在 robot 表)

`candidates.go` 用的是 `WHERE u.robot = 0 AND u.uid NOT IN (SELECT robot_id FROM robot)` 做排除;本 PR 是同一条判定的**inclusion 侧**。**未采用**候选口径里的第三条 `LENGTH(uid)=32`(过滤 system 账号如 fileHelper),因为 summary 场景消息本身就来自真实 channel,uid 长度非 32 的 system 消息如果真被拉进来了,前端愿意标 bot=true 也是准确的,不应额外过滤。

**不包含** `MentionUIDs`(判定「@了谁」):`BatchMessageRow.Payload` 是 octo-search-batch 已经预解析的纯文本,mention 元数据在上游接口就被丢了。需要先扩 octo-search-batch NDJSON schema,属跨仓改动,单独 PR 处理。

## Linked Spec

无 issue · 主人 offline 拍板的口径:
- 只做 `SenderIsBot`,先不做 `MentionUIDs`
- Bot 判定 = `user.robot=1 OR uid IN robot 表`(与 candidates.go 一致)
- 只加字段透传,不动过滤/LLM

## How verified

**本地 CGO 完整 race matrix**:

```
export CGO_LDFLAGS="-L$HOME/.local/lib"
export LIBRARY_PATH="$HOME/.local/lib"
CGO_ENABLED=1 go build ./...                              # clean
CGO_ENABLED=1 go test -race -count=1 -timeout=600s ./...  # 22 packages ok, no FAIL
```

**新增两个守护 test 定向验证**:

```
CGO_ENABLED=1 go test -v -run "TestBuildCitations_PropagatesSenderIsBot" ./internal/worker/
  → PASS
CGO_ENABLED=1 go test -v -run "TestEnrichMessagesWithMetadata_SenderIsBotUnion" ./internal/agent/
  → PASS
```

- `TestBuildCitations_PropagatesSenderIsBot`:paired guard,bot 消息和 human 消息各一,同时检查 `Citation.SenderIsBot` 和 `ContextMsg.SenderIsBot`,防串味。
- `TestEnrichMessagesWithMetadata_SenderIsBotUnion`:三条 union leg 全覆盖 —— `user.robot=1` / `uid IN robot 表` / 都不在(human)—— 断言 `msg.SenderIsBot` 分别为 `true/true/false`。

**已修 3 个既有 `message_enrichment_test.go` fixture**:`user` 表加 `robot` 列 + 新增 `robot` 表 seed;N+1 test 的 query count 期望从 `1 → 2`(user + robot 两次批量查,都是 O(1),不是 N+1)。

## COMPREHENSION

1. **What does this change actually do** to the load-bearing path?

   在两个批量用户信息 resolver(`worker.batchResolveUserNames` 和 `agent.enrichMessagesWithMetadata`)里各多打一条 `SELECT robot_id FROM robot WHERE robot_id IN ?` 的 SQL,再把 `user` 表原有的 `robot` 列一起 select 出来,union 成一个 `botSet`。然后在填 `SenderName` 的同一处循环里,同步把 `SenderIsBot` 也填进 `pipeline.Message`。`buildCitations` / `toContextMsg` 从 `msg.SenderIsBot` 透传到 `Citation` / `ContextMsg` 结构体 —— **不改任何函数签名**(nameMap 参数原样保留)。evidence JSON 序列化自动带上新字段(gorm/json tag 覆盖),agent 回放路径无需另改。

2. **What could break** because of it (dependents + failure mode)?

   - **Dependent A**:前端 citation 展示 —— 新字段 `sender_is_bot: false` 默认值,老前端忽略即可,不破坏兼容。
   - **Dependent B**:evidence DB 里 message 的 JSON blob —— 老数据没这个字段,反序列化后 `SenderIsBot=false`(Go zero value),与「未知/人类」语义一致,不会误判成 bot。
   - **Dependent C**:agent tool `search_messages` 的 message 列表 —— 会多出 `sender_is_bot` 字段,LLM 看到但没被 prompt 引导使用,行为不变(本 PR 不动 prompt)。
   - **失败模式 1**:如果 `user` 表没有 `robot` 列(理论上不会,但 sqlite mock DB 就是这样)—— SQL 直接报错,batch resolver log warning 后跳过,`SenderIsBot` 全为 false(fail-open · 与现有 SenderName 未查到时的容错语义一致)。
   - **失败模式 2**:如果 `robot` 表不存在 —— 同上,log warning 后跳过 union leg,只走 `user.robot=1` 一条腿。
   - **已加的 guard**:两个 resolver 都用了独立的 `if err := ...; err != nil { log.Printf(...); }` 分支,任一条 SQL 挂掉都不阻断另一条,也不阻断整个 summary 流程。

3. **How do you know it works** (specific test/repro/trace)?

   - `internal/agent/message_enrichment_test.go::TestEnrichMessagesWithMetadata_SenderIsBotUnion` —— seed 三个用户覆盖所有 union leg,断言 `msg.SenderIsBot` 分别符合预期。
   - `internal/worker/citation_test.go::TestBuildCitations_PropagatesSenderIsBot` —— 一条 bot 消息 + 一条 human 消息,同时通过 `buildCitations` 和 `toContextMsg`,分别断言输出结构体的 `SenderIsBot` 值。
   - 完整 `CGO_ENABLED=1 go test -race -count=1 ./...` 22 个包全绿,无 regression。
   - Commit `2b63079` HEAD,`git diff --stat origin/main..HEAD` = 8 files changed, +290 / -43。

---

**判定口径与 `candidates.go` 一致性证据**(reviewer 可 grep 验证):

```bash
$ grep -n "robot" internal/api/handler/candidates.go | head
# candidates.go:95   Where("u.robot = 0").
# candidates.go:96   Where("u.uid NOT IN (SELECT robot_id FROM robot)").
# → 候选口径:排除 (robot=1 OR uid IN robot 表)
# 本 PR 两个 resolver:识别 (robot=1 OR uid IN robot 表) = 同一条判定的 inclusion 侧
```

本 PR 的两个 resolver 拆成两条 SQL(`SELECT robot FROM user WHERE uid IN ?` + `SELECT robot_id FROM robot WHERE robot_id IN ?`)union 到内存 `botSet`,而不是在 SQL 层写 subquery,gorm batch 更清晰,查询规划器等价。
