### PR TITLE
feat(timing): bound LLM-call label cardinality with PurposeClass (#231 S3)

### DIFF
--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -178,26 +178,48 @@ func RecordLLMSince(taskNo, purpose string, start time.Time, tokens int) {
 // on PurposeClass, never on the raw Purpose. The chunk index stays in the log
 // only.
 //
-// The returned set is closed: intent, map_chunk, map_single, reduce,
-// team_reduce, post_retrieval_narrow, other. New purposes fall through to
-// "other" rather than silently widening the label space — add a case here (and
-// a test) when a new call site is introduced.
+// The cases below are the census of every RecordLLM/RecordLLMSince call site at
+// head. The retrieval-prep family is split per forced function rather than
+// merged into one class: the forced-function set is closed (recognize_intent,
+// extract_time_range, resolve_channel_scope, resolve_topic_target — see
+// internal/pipeline/*), so per-function classes stay bounded, and #220 needs
+// recognize_intent's latency percentile as a distinct input — merging would
+// bury it.
+//
+// The returned set is closed: intent, extract_time_range, resolve_channel_scope,
+// resolve_topic_target, retrieval_prep, post_retrieval_narrow, map_single,
+// map_chunk, reduce, team_reduce, other. New purposes fall through to "other"
+// rather than silently widening the label space — add a case here (and a test)
+// when a new call site is introduced.
 func PurposeClass(purpose string) string {
 	switch {
-	case purpose == "意图识别":
+	// Retrieval-prep tool calls: purpose is "检索预处理: " + forceFn, or
+	// "检索预处理(tool-call)" when no function is forced (see
+	// worker/{processor,personal_processor}.go). Match the closed forceFn set
+	// exactly so an unforeseen value falls through to "other" rather than
+	// silently joining a class.
+	case purpose == "检索预处理: recognize_intent":
 		return "intent"
+	case purpose == "检索预处理: extract_time_range":
+		return "extract_time_range"
+	case purpose == "检索预处理: resolve_channel_scope":
+		return "resolve_channel_scope"
+	case purpose == "检索预处理: resolve_topic_target":
+		return "resolve_topic_target"
+	case purpose == "检索预处理(tool-call)":
+		return "retrieval_prep"
+	case strings.Contains(purpose, "PostRetrievalNarrow"):
+		return "post_retrieval_narrow"
 	// Order matters: the chunk-map prefix is the unbounded one and must be
 	// matched before any looser "Map:" rule.
 	case strings.HasPrefix(purpose, "Map: 分块总结 chunk#"):
 		return "map_chunk"
-	case strings.HasPrefix(purpose, "Map: 单次总结") || purpose == "单次总结":
+	case strings.HasPrefix(purpose, "Map: 单次总结"):
 		return "map_single"
 	case strings.HasPrefix(purpose, "团队汇总"):
 		return "team_reduce"
-	case strings.HasPrefix(purpose, "Reduce"):
+	case purpose == "Reduce" || strings.HasPrefix(purpose, "Reduce:"):
 		return "reduce"
-	case strings.Contains(purpose, "PostRetrievalNarrow"):
-		return "post_retrieval_narrow"
 	default:
 		return "other"
 	}

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -167,6 +167,42 @@ func RecordLLMSince(taskNo, purpose string, start time.Time, tokens int) {
 	RecordLLM(taskNo, purpose, time.Since(start), tokens)
 }
 
+// PurposeClass collapses a free-text LLMCall.Purpose into one of a small,
+// closed set of stable identifiers.
+//
+// Why this exists (#231 S3): Purpose is a human-readable string, and one of its
+// values is built as fmt.Sprintf("Map: 分块总结 chunk#%d", idx) — the chunk index
+// is unbounded. Purpose is fine as a log line, but the moment it is used as a
+// metric label it becomes a cardinality bomb: one time series per chunk index,
+// per task, forever. Any metric that wants to break down by call kind MUST label
+// on PurposeClass, never on the raw Purpose. The chunk index stays in the log
+// only.
+//
+// The returned set is closed: intent, map_chunk, map_single, reduce,
+// team_reduce, post_retrieval_narrow, other. New purposes fall through to
+// "other" rather than silently widening the label space — add a case here (and
+// a test) when a new call site is introduced.
+func PurposeClass(purpose string) string {
+	switch {
+	case purpose == "意图识别":
+		return "intent"
+	// Order matters: the chunk-map prefix is the unbounded one and must be
+	// matched before any looser "Map:" rule.
+	case strings.HasPrefix(purpose, "Map: 分块总结 chunk#"):
+		return "map_chunk"
+	case strings.HasPrefix(purpose, "Map: 单次总结") || purpose == "单次总结":
+		return "map_single"
+	case strings.HasPrefix(purpose, "团队汇总"):
+		return "team_reduce"
+	case strings.HasPrefix(purpose, "Reduce"):
+		return "reduce"
+	case strings.Contains(purpose, "PostRetrievalNarrow"):
+		return "post_retrieval_narrow"
+	default:
+		return "other"
+	}
+}
+
 func ensureReportFile() *os.File {
 	reportOnce.Do(func() {
 		acctMu.Lock()

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -324,32 +324,63 @@ func TestRecordLLM_Empty(t *testing.T) {
 	}
 }
 
-// TestPurposeClass_ClosedSet asserts every real call-site purpose maps to its
-// stable class, and — the point of #231 S3 — that the unbounded chunk index in
-// "Map: 分块总结 chunk#%d" collapses to a single class rather than one label
-// value per chunk.
-func TestPurposeClass_ClosedSet(t *testing.T) {
-	cases := []struct {
-		purpose string
-		want    string
-	}{
-		{"意图识别", "intent"},
-		{"Map: 分块总结 chunk#1", "map_chunk"},
-		{"Map: 分块总结 chunk#2", "map_chunk"},
-		{"Map: 分块总结 chunk#9999", "map_chunk"},
-		{"Map: 单次总结(跳过Map-Reduce)", "map_single"},
-		{"单次总结", "map_single"},
-		{"Reduce: 最终总结", "reduce"},
-		{"Reduce: 合并分块总结", "reduce"},
-		{"Reduce", "reduce"},
-		{"团队汇总: 合并各成员总结", "team_reduce"},
-		{"检索后裁剪 PostRetrievalNarrow", "post_retrieval_narrow"},
-		{"something new nobody classified", "other"},
-		{"", "other"},
-	}
-	for _, c := range cases {
+// productionPurposes is the census of every literal (or literal-shaped) value
+// passed to RecordLLM/RecordLLMSince in non-test code at head, paired with the
+// class it MUST map to. Keep this in sync with the call-site census when a new
+// RecordLLM* site is added — the retrieval-prep entries are "检索预处理: " + the
+// closed forceFn set plus the no-force "(tool-call)" case.
+var productionPurposes = []struct {
+	purpose string
+	want    string
+}{
+	{"检索预处理(tool-call)", "retrieval_prep"},
+	{"检索预处理: recognize_intent", "intent"},
+	{"检索预处理: extract_time_range", "extract_time_range"},
+	{"检索预处理: resolve_channel_scope", "resolve_channel_scope"},
+	{"检索预处理: resolve_topic_target", "resolve_topic_target"},
+	{"检索后裁剪 PostRetrievalNarrow", "post_retrieval_narrow"},
+	{"Map: 单次总结(跳过Map-Reduce)", "map_single"},
+	{"Map: 分块总结 chunk#0", "map_chunk"},
+	{"Map: 分块总结 chunk#7", "map_chunk"},
+	{"Reduce: 合并分块总结", "reduce"},
+	{"团队汇总: 合并各成员总结", "team_reduce"},
+}
+
+// TestPurposeClass_RealCallSites pins every production purpose value to its
+// class. Built from the RecordLLM* census rather than the report-rendering
+// strings, so misclassifying any real family fails here.
+func TestPurposeClass_RealCallSites(t *testing.T) {
+	for _, c := range productionPurposes {
 		if got := PurposeClass(c.purpose); got != c.want {
 			t.Errorf("PurposeClass(%q) = %q, want %q", c.purpose, got, c.want)
+		}
+	}
+}
+
+// TestPurposeClass_NoProductionPurposeIsOther is the anti-vacuity guard the
+// review asked for: no real call-site value may land in the "other" junk drawer.
+// Misclassifying any current production family (e.g. dropping the retrieval-prep
+// cases) turns this red, where a table of speculative literals would not.
+func TestPurposeClass_NoProductionPurposeIsOther(t *testing.T) {
+	for _, c := range productionPurposes {
+		if got := PurposeClass(c.purpose); got == "other" {
+			t.Errorf("production purpose %q classified as %q — real latency would be buried in the unclassified bucket", c.purpose, got)
+		}
+	}
+}
+
+// TestPurposeClass_UnknownFallsThrough documents the closed-set contract: a
+// value no call site emits, including a would-be-new forced function, lands in
+// "other" rather than silently widening the label space.
+func TestPurposeClass_UnknownFallsThrough(t *testing.T) {
+	for _, p := range []string{
+		"",
+		"something new nobody classified",
+		"检索预处理: brand_new_forced_fn",
+		"ReducerDebug", // must NOT be caught by the reduce rule
+	} {
+		if got := PurposeClass(p); got != "other" {
+			t.Errorf("PurposeClass(%q) = %q, want other", p, got)
 		}
 	}
 }

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -1,6 +1,7 @@
 package timing
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -320,5 +321,48 @@ func TestRecordLLM_Empty(t *testing.T) {
 
 	if count != 0 {
 		t.Error("RecordLLM with empty taskNo should not record")
+	}
+}
+
+// TestPurposeClass_ClosedSet asserts every real call-site purpose maps to its
+// stable class, and — the point of #231 S3 — that the unbounded chunk index in
+// "Map: 分块总结 chunk#%d" collapses to a single class rather than one label
+// value per chunk.
+func TestPurposeClass_ClosedSet(t *testing.T) {
+	cases := []struct {
+		purpose string
+		want    string
+	}{
+		{"意图识别", "intent"},
+		{"Map: 分块总结 chunk#1", "map_chunk"},
+		{"Map: 分块总结 chunk#2", "map_chunk"},
+		{"Map: 分块总结 chunk#9999", "map_chunk"},
+		{"Map: 单次总结(跳过Map-Reduce)", "map_single"},
+		{"单次总结", "map_single"},
+		{"Reduce: 最终总结", "reduce"},
+		{"Reduce: 合并分块总结", "reduce"},
+		{"Reduce", "reduce"},
+		{"团队汇总: 合并各成员总结", "team_reduce"},
+		{"检索后裁剪 PostRetrievalNarrow", "post_retrieval_narrow"},
+		{"something new nobody classified", "other"},
+		{"", "other"},
+	}
+	for _, c := range cases {
+		if got := PurposeClass(c.purpose); got != c.want {
+			t.Errorf("PurposeClass(%q) = %q, want %q", c.purpose, got, c.want)
+		}
+	}
+}
+
+// TestPurposeClass_ChunkIndexIsBounded is the cardinality guard: a thousand
+// distinct chunk indices must produce exactly one class, or the label space is
+// unbounded and this function has failed its only job.
+func TestPurposeClass_ChunkIndexIsBounded(t *testing.T) {
+	seen := map[string]struct{}{}
+	for i := 0; i < 1000; i++ {
+		seen[PurposeClass(fmt.Sprintf("Map: 分块总结 chunk#%d", i))] = struct{}{}
+	}
+	if len(seen) != 1 {
+		t.Errorf("chunk-map purposes produced %d classes, want 1 — cardinality is not bounded: %v", len(seen), seen)
 	}
 }


### PR DESCRIPTION
## What

Adds `timing.PurposeClass(purpose string) string`, a pure function that collapses the free-text `LLMCall.Purpose` into a small, closed set of stable identifiers:

`intent · map_chunk · map_single · reduce · team_reduce · post_retrieval_narrow · other`

## Why (#231 S3)

`LLMCall.Purpose` is human-readable, and one value is built as `fmt.Sprintf("Map: 分块总结 chunk#%d", idx)` — the chunk index is **unbounded**. That is fine in a log line, but the moment `Purpose` is used as a metric label it becomes a cardinality bomb: one time series per chunk index, per task, forever.

This is the one live cardinality risk flagged in #231's plan. `PurposeClass` is the seam the upcoming worker/agent metrics (#231 S3 emission, e.g. `summary_stage_duration_seconds{stage=...}`) must label on — the raw purpose stays log-only.

## Scope / dependencies

- Touches **only** `internal/timing/` — deliberately independent of PR #232 (histograms), which never touches this package. No merge conflict either way.
- Pure function + tests. No behavior change to existing logging/reporting.

## Tests

- `TestPurposeClass_ClosedSet` — every real call-site purpose maps to its class.
- `TestPurposeClass_ChunkIndexIsBounded` — 1000 distinct chunk indices collapse to exactly one class.

Closed set by design: unknown purposes fall through to `other` rather than silently widening the label space; add a case (and a test) when a new call site is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)