### PR TITLE
refactor(obs): extract internal/metrics registry (#242 S2)

### DIFF
--- a/internal/llmobs/metrics.go
+++ b/internal/llmobs/metrics.go
@@ -12,137 +12,12 @@
 package llmobs
 
 import (
-	"fmt"
 	"io"
-	"sort"
-	"strconv"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/Mininglamp-OSS/octo-smart-summary/internal/llmfallback"
+	"github.com/Mininglamp-OSS/octo-smart-summary/internal/metrics"
 )
-
-// labelSet is a bounded, ordered key/value list used as a map key. Every label
-// value fed into it comes from configuration (model ids) or a closed constant
-// set (path, position, outcome, reason) — never from request data — so the
-// series count stays bounded by models * paths.
-type labelSet string
-
-func labels(pairs ...string) labelSet {
-	if len(pairs)%2 != 0 {
-		panic("llmobs: labels requires key/value pairs")
-	}
-	var b strings.Builder
-	for i := 0; i < len(pairs); i += 2 {
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		b.WriteString(pairs[i])
-		b.WriteString("=\"")
-		b.WriteString(escapeLabelValue(pairs[i+1]))
-		b.WriteString("\"")
-	}
-	return labelSet(b.String())
-}
-
-// labelEscaper is built once at package scope, NOT per call. strings.NewReplacer
-// compiles a trie on construction, so building it inside escapeLabelValue cost
-// ~3.5µs and 6.7KB of garbage per label value (measured) against ~26ns and zero
-// allocations when hoisted — and escapeLabelValue runs on every label of every
-// event on the LLM hot path.
-//
-// \r is escaped alongside the three the text format requires: it is not a
-// separator so it cannot forge a line, but leaving a bare CR in a value makes
-// log/terminal output overwrite itself, and SafeTextForLog already strips it
-// elsewhere in this codebase.
-// CR is replaced with a space, NOT escaped as \r. The Prometheus text format
-// defines only \\, \" and \n inside a label value; \r is an invalid escape and
-// the reference parser aborts the ENTIRE scrape on it, not just that line. So
-// "hardening" a bare CR into \r traded one ugly character for the loss of every
-// metric in the response. Flattening matches what SafeTextForLog already does.
-var labelEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", " ")
-
-// escapeLabelValue applies the Prometheus text-format escaping rules.
-func escapeLabelValue(v string) string {
-	return labelEscaper.Replace(v)
-}
-
-// counterVec is a labelled monotonic counter.
-type counterVec struct {
-	name string
-	help string
-	mu   sync.Mutex
-	vals map[labelSet]float64
-}
-
-func newCounterVec(name, help string) *counterVec {
-	return &counterVec{name: name, help: help, vals: map[labelSet]float64{}}
-}
-
-func (c *counterVec) inc(l labelSet) { c.add(l, 1) }
-
-func (c *counterVec) add(l labelSet, delta float64) {
-	c.mu.Lock()
-	c.vals[l] += delta
-	c.mu.Unlock()
-}
-
-func (c *counterVec) write(w io.Writer) {
-	c.mu.Lock()
-	keys := make([]labelSet, 0, len(c.vals))
-	for k := range c.vals {
-		keys = append(keys, k)
-	}
-	snapshot := make(map[labelSet]float64, len(c.vals))
-	for k, v := range c.vals {
-		snapshot[k] = v
-	}
-	c.mu.Unlock()
-
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n", c.name, c.help, c.name)
-	for _, k := range keys {
-		fmt.Fprintf(w, "%s{%s} %g\n", c.name, k, snapshot[k])
-	}
-}
-
-// gaugeVec is a labelled last-write-wins gauge.
-type gaugeVec struct {
-	name string
-	help string
-	mu   sync.Mutex
-	vals map[labelSet]float64
-}
-
-func newGaugeVec(name, help string) *gaugeVec {
-	return &gaugeVec{name: name, help: help, vals: map[labelSet]float64{}}
-}
-
-func (g *gaugeVec) set(l labelSet, v float64) {
-	g.mu.Lock()
-	g.vals[l] = v
-	g.mu.Unlock()
-}
-
-func (g *gaugeVec) write(w io.Writer) {
-	g.mu.Lock()
-	keys := make([]labelSet, 0, len(g.vals))
-	for k := range g.vals {
-		keys = append(keys, k)
-	}
-	snapshot := make(map[labelSet]float64, len(g.vals))
-	for k, v := range g.vals {
-		snapshot[k] = v
-	}
-	g.mu.Unlock()
-
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", g.name, g.help, g.name)
-	for _, k := range keys {
-		fmt.Fprintf(w, "%s{%s} %g\n", g.name, k, snapshot[k])
-	}
-}
 
 // durationBuckets are the shared second-boundaries for every latency
 // histogram in this package.
@@ -160,122 +35,19 @@ func (g *gaugeVec) write(w io.Writer) {
 // spans a sub-second refine through a 300s long-context turn in one series.
 var durationBuckets = []float64{0.5, 1, 2, 5, 10, 20, 30, 60, 90, 120, 180, 300}
 
-// histogramVec is a labelled cumulative histogram.
-//
-// Buckets are stored as per-bucket hit counts and made cumulative only at
-// render time: an observation touches exactly one slot, so the write path
-// stays O(log n) on the boundary search and O(1) on the update, which matters
-// because ObserveResult runs on every LLM call.
-type histogramVec struct {
-	name    string
-	help    string
-	buckets []float64
-	mu      sync.Mutex
-	counts  map[labelSet][]uint64
-	sums    map[labelSet]float64
-	totals  map[labelSet]uint64
-}
-
-func newHistogramVec(name, help string, buckets []float64) *histogramVec {
-	// Copy: observe relies on sort.SearchFloat64s, which is only correct on a
-	// strictly increasing slice. Keeping the caller's backing array would let a
-	// later append/sort elsewhere silently corrupt every bucket assignment.
-	b := make([]float64, len(buckets))
-	copy(b, buckets)
-	return &histogramVec{
-		name:    name,
-		help:    help,
-		buckets: b,
-		counts:  map[labelSet][]uint64{},
-		sums:    map[labelSet]float64{},
-		totals:  map[labelSet]uint64{},
-	}
-}
-
-// observe records one sample. Values above the last boundary still count
-// toward _sum and _count (and the +Inf bucket), so a pathological outlier is
-// never silently dropped from the total.
-func (h *histogramVec) observe(l labelSet, v float64) {
-	// A negative duration cannot happen from a monotonic clock, but a bad
-	// caller must not corrupt _sum for everyone else on this series.
-	if v < 0 {
-		v = 0
-	}
-	i := sort.SearchFloat64s(h.buckets, v)
-	h.mu.Lock()
-	if h.counts[l] == nil {
-		h.counts[l] = make([]uint64, len(h.buckets))
-	}
-	if i < len(h.buckets) {
-		h.counts[l][i]++
-	}
-	h.sums[l] += v
-	h.totals[l]++
-	h.mu.Unlock()
-}
-
-func (h *histogramVec) write(w io.Writer) {
-	h.mu.Lock()
-	keys := make([]labelSet, 0, len(h.counts))
-	snapCounts := make(map[labelSet][]uint64, len(h.counts))
-	for k, v := range h.counts {
-		keys = append(keys, k)
-		c := make([]uint64, len(v))
-		copy(c, v)
-		snapCounts[k] = c
-	}
-	snapSums := make(map[labelSet]float64, len(h.sums))
-	for k, v := range h.sums {
-		snapSums[k] = v
-	}
-	snapTotals := make(map[labelSet]uint64, len(h.totals))
-	for k, v := range h.totals {
-		snapTotals[k] = v
-	}
-	h.mu.Unlock()
-
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s histogram\n", h.name, h.help, h.name)
-	for _, k := range keys {
-		var cum uint64
-		for i, b := range h.buckets {
-			cum += snapCounts[k][i]
-			fmt.Fprintf(w, "%s_bucket{%s} %d\n", h.name, withLE(k, formatBucket(b)), cum)
-		}
-		total := snapTotals[k]
-		fmt.Fprintf(w, "%s_bucket{%s} %d\n", h.name, withLE(k, "+Inf"), total)
-		fmt.Fprintf(w, "%s_sum{%s} %g\n", h.name, k, snapSums[k])
-		fmt.Fprintf(w, "%s_count{%s} %d\n", h.name, k, total)
-	}
-}
-
-// withLE appends the le dimension that the histogram exposition format
-// requires. It is built here rather than by the caller so no observe path can
-// forget it and emit a bucket line a scraper will reject.
-func withLE(l labelSet, le string) labelSet {
-	if l == "" {
-		return labelSet(`le="` + le + `"`)
-	}
-	return l + labelSet(`,le="`+le+`"`)
-}
-
-// formatBucket renders a boundary the way the text format expects: the
-// shortest representation that round-trips, so 0.5 stays "0.5" and 60 stays
-// "60" rather than "60.000000".
-func formatBucket(b float64) string {
-	return strconv.FormatFloat(b, 'g', -1, 64)
-}
-
 // Metrics is the LLM fallback metric set. The zero value is not usable; call
-// NewMetrics.
+// NewMetrics. The registry primitives it is built from live in internal/metrics
+// (extracted in #242); this struct owns only the LLM-specific names, help text
+// and label choices.
 type Metrics struct {
-	attempts   *counterVec
-	switches   *counterVec
-	calls      *counterVec
-	callSecs   *counterVec
-	runDur     *histogramVec
-	attemptDur *histogramVec
-	lastOK     *gaugeVec
+	attempts   *metrics.CounterVec
+	switches   *metrics.CounterVec
+	calls      *metrics.CounterVec
+	callSecs   *metrics.CounterVec
+	runDur     *metrics.HistogramVec
+	attemptDur *metrics.HistogramVec
+	lastOK     *metrics.GaugeVec
+	reg        *metrics.Registry
 	nowFn      func() time.Time
 }
 
@@ -285,14 +57,14 @@ func NewMetrics(nowFn func() time.Time) *Metrics {
 	if nowFn == nil {
 		nowFn = time.Now
 	}
-	return &Metrics{
-		attempts: newCounterVec("llm_attempts_total",
+	m := &Metrics{
+		attempts: metrics.NewCounterVec("llm_attempts_total",
 			"Upstream LLM attempts by call path, model, list position and classified outcome."),
-		switches: newCounterVec("llm_model_switch_total",
+		switches: metrics.NewCounterVec("llm_model_switch_total",
 			"Cross-model fallback switches. reason=denied means the provider refused this request for this model (HTTP 403 — credentials, entitlement, a WAF rule or a regional restriction); retries_exhausted means the per-model retry budget ran out, usually upstream overload, though a deterministic contract failure (undecodable response, no choices) also lands here; budget_starved means the deadline guard abandoned the remaining retries, which is a configuration fault."),
-		calls: newCounterVec("llm_calls_total",
+		calls: metrics.NewCounterVec("llm_calls_total",
 			"Completed LLM calls by call path, the position of the model that served them, and the outcome: ok; failed (no model could serve it); cancelled (the caller went away — not an upstream fault, do not alert on it); timeout (our own deadline expired before any model answered — nobody walked away, so this one IS alertable)."),
-		callSecs: newCounterVec("llm_call_duration_seconds_total",
+		callSecs: metrics.NewCounterVec("llm_call_duration_seconds_total",
 			"DEPRECATED, prefer llm_run_duration_seconds: this counter is now exactly that histogram's _sum, fed from the same ResultEvent.Duration, and two hand-maintained copies of one quantity will diverge the first time somebody edits one observe site. Retained so existing dashboards keep working. Cumulative wall-clock seconds spent in llmfallback.Run, by call path; a mean needs sum by(path)(llm_call_duration_seconds_total) / sum by(path)(llm_calls_total)."),
 		// Named llm_RUN_duration_seconds, not llm_call_duration_seconds: the
 		// latter would collide with the existing llm_call_duration_seconds_total
@@ -302,7 +74,7 @@ func NewMetrics(nowFn func() time.Time) *Metrics {
 		// prometheus receiver, promtool, OpenMetrics-negotiating scrapers).
 		// Prometheus text format 0.0.4 tolerates it; the rename is free now and
 		// expensive after dashboards exist.
-		runDur: newHistogramVec("llm_run_duration_seconds",
+		runDur: metrics.NewHistogramVec("llm_run_duration_seconds",
 			"Distribution of whole-llmfallback.Run wall-clock, by call path — INCLUDING backoff sleeps and every model tried. Use it to size PARENT budgets (REFINE_TIMEOUT, AGENT_STEP_TIMEOUT): histogram_quantile(0.95, sum by (path, le) (rate(llm_run_duration_seconds_bucket[1h]))). To size a per-attempt cap such as LLM_TIMEOUT, use llm_attempt_duration_seconds instead.",
 			durationBuckets),
 		// A run and an attempt diverge exactly where it matters. LLM_TIMEOUT is
@@ -312,18 +84,24 @@ func NewMetrics(nowFn func() time.Time) *Metrics {
 		// coincide, so a run-level P95 is roughly usable; a run-level P99 is
 		// not, because the P99 IS the retried runs. Sizing a per-attempt cap
 		// from the run distribution therefore over-estimates systematically.
-		attemptDur: newHistogramVec("llm_attempt_duration_seconds",
+		attemptDur: metrics.NewHistogramVec("llm_attempt_duration_seconds",
 			"Distribution of a SINGLE upstream attempt's wall-clock, by call path and classified outcome. Use it to size the per-attempt LLM_TIMEOUT; llm_run_duration_seconds includes backoffs and other models and will over-estimate it. CENSORED ON THE RIGHT: every attempt is already capped by the current LLM_TIMEOUT, so an upstream that would have taken longer is recorded at the cap and the top bucket is a pile-up, not a tail. Sound for deciding whether to LOWER the cap; it cannot tell you what raising it would recover.",
 			durationBuckets),
-		lastOK: newGaugeVec("llm_primary_last_success_timestamp_seconds",
+		lastOK: metrics.NewGaugeVec("llm_primary_last_success_timestamp_seconds",
 			"Unix timestamp of the most recent successful call served by the PRIMARY model, per call path. A stale value means sustained silent degradation onto a fallback."),
 		nowFn: nowFn,
 	}
+	// Registration order IS exposition order (Registry renders in this order),
+	// so it must match the previous hand-written WritePrometheus sequence to
+	// keep scrape output byte-identical.
+	m.reg = metrics.NewRegistry()
+	m.reg.MustRegister(m.attempts, m.switches, m.calls, m.callSecs, m.runDur, m.attemptDur, m.lastOK)
+	return m
 }
 
 // ObserveAttempt implements llmfallback.Observer.
 func (m *Metrics) ObserveAttempt(e llmfallback.AttemptEvent) {
-	m.attempts.inc(labels(
+	m.attempts.Inc(metrics.Labels(
 		"path", string(e.Path),
 		"model", e.Model,
 		"position", e.Position,
@@ -339,7 +117,7 @@ func (m *Metrics) ObserveAttempt(e llmfallback.AttemptEvent) {
 	// person adding a label sees the real cost: paths x outcomes x (buckets+3)
 	// = 8 x 4 x 15 = ~480 series for this family, against 8 x 15 = 120 for
 	// runDur. That is affordable; a third dimension likely is not.
-	m.attemptDur.observe(labels(
+	m.attemptDur.Observe(metrics.Labels(
 		"path", string(e.Path),
 		"outcome", outcomeLabel(e.Outcome),
 	), e.Duration.Seconds())
@@ -347,7 +125,7 @@ func (m *Metrics) ObserveAttempt(e llmfallback.AttemptEvent) {
 
 // ObserveSwitch implements llmfallback.Observer.
 func (m *Metrics) ObserveSwitch(e llmfallback.SwitchEvent) {
-	m.switches.inc(labels(
+	m.switches.Inc(metrics.Labels(
 		"path", string(e.Path),
 		"from", e.From,
 		"to", e.To,
@@ -374,27 +152,21 @@ func (m *Metrics) ObserveResult(e llmfallback.ResultEvent) {
 	if position == "" {
 		position = "none"
 	}
-	m.calls.inc(labels("path", string(e.Path), "position", position, "result", result))
-	m.callSecs.add(labels("path", string(e.Path)), e.Duration.Seconds())
+	m.calls.Inc(metrics.Labels("path", string(e.Path), "position", position, "result", result))
+	m.callSecs.Add(metrics.Labels("path", string(e.Path)), e.Duration.Seconds())
 	// Labelled by path only, exactly like callSecs. Adding result/position here
 	// would multiply every bucket series by those dimensions for a question the
 	// counters already answer.
-	m.runDur.observe(labels("path", string(e.Path)), e.Duration.Seconds())
+	m.runDur.Observe(metrics.Labels("path", string(e.Path)), e.Duration.Seconds())
 
 	if e.OK && e.Position == llmfallback.PositionPrimary {
-		m.lastOK.set(labels("path", string(e.Path)), float64(m.nowFn().Unix()))
+		m.lastOK.Set(metrics.Labels("path", string(e.Path)), float64(m.nowFn().Unix()))
 	}
 }
 
 // WritePrometheus renders the metric set in Prometheus text exposition format.
 func (m *Metrics) WritePrometheus(w io.Writer) {
-	m.attempts.write(w)
-	m.switches.write(w)
-	m.calls.write(w)
-	m.callSecs.write(w)
-	m.runDur.write(w)
-	m.attemptDur.write(w)
-	m.lastOK.write(w)
+	m.reg.WritePrometheus(w)
 }
 
 func outcomeLabel(o llmfallback.Outcome) string {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,287 @@
+// Package metrics is a tiny hand-rolled Prometheus text-exposition registry:
+// labelled counters, gauges and cumulative histograms plus a Registry that
+// renders them.
+//
+// Why hand-rolled instead of prometheus/client_golang: adding that module to
+// this repo currently drags upgrades to golang.org/x/crypto, golang.org/x/net,
+// golang.org/x/sys, golang.org/x/text and protobuf, which this repo's
+// dependency-review / osv-scanner workflows must then re-clear. These vectors
+// emit the standard Prometheus text exposition format, so a scraper cannot tell
+// the difference.
+//
+// This package was lifted out of internal/llmobs (its first consumer) so the
+// worker and agent paths can emit their own metrics without importing the
+// LLM-fallback-specific package — see #242. It carries no domain knowledge: the
+// caller owns metric names, help text, bucket layouts and — crucially — label
+// cardinality. Only ever build a LabelSet from configuration or a closed
+// constant set, never from request data, or the series count is unbounded.
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// LabelSet is a bounded, ordered key/value list used as a map key and rendered
+// verbatim inside the {} of an exposition line. Build it with Labels; the
+// caller is responsible for keeping the value domain bounded.
+type LabelSet string
+
+// Labels builds a LabelSet from alternating key/value arguments, escaping each
+// value per the text format. It panics on an odd argument count — a programming
+// error, never runtime data.
+func Labels(pairs ...string) LabelSet {
+	if len(pairs)%2 != 0 {
+		panic("metrics: Labels requires key/value pairs")
+	}
+	var b strings.Builder
+	for i := 0; i < len(pairs); i += 2 {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(pairs[i])
+		b.WriteString("=\"")
+		b.WriteString(escapeLabelValue(pairs[i+1]))
+		b.WriteString("\"")
+	}
+	return LabelSet(b.String())
+}
+
+// labelEscaper is built once at package scope, NOT per call. strings.NewReplacer
+// compiles a trie on construction, so building it inside escapeLabelValue cost
+// ~3.5µs and 6.7KB of garbage per label value (measured) against ~26ns and zero
+// allocations when hoisted — and escapeLabelValue runs on every label of every
+// event on a hot path.
+//
+// CR is replaced with a space, NOT escaped as \r. The Prometheus text format
+// defines only \\, \" and \n inside a label value; \r is an invalid escape and
+// the reference parser aborts the ENTIRE scrape on it, not just that line. So
+// "hardening" a bare CR into \r traded one ugly character for the loss of every
+// metric in the response. Flattening matches what SafeTextForLog already does.
+var labelEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", " ")
+
+// escapeLabelValue applies the Prometheus text-format escaping rules.
+func escapeLabelValue(v string) string {
+	return labelEscaper.Replace(v)
+}
+
+// Collector is anything the Registry can render. The three vec types below
+// implement it; a consumer may implement it too and register the result.
+type Collector interface {
+	WriteProm(w io.Writer)
+}
+
+// Registry renders a set of Collectors in registration order, so exposition
+// output is deterministic across scrapes.
+type Registry struct {
+	mu sync.Mutex
+	cs []Collector
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry { return &Registry{} }
+
+// MustRegister appends collectors in order. Later WritePrometheus renders them
+// in exactly this order.
+func (r *Registry) MustRegister(cs ...Collector) {
+	r.mu.Lock()
+	r.cs = append(r.cs, cs...)
+	r.mu.Unlock()
+}
+
+// WritePrometheus renders every registered collector, in registration order.
+func (r *Registry) WritePrometheus(w io.Writer) {
+	r.mu.Lock()
+	cs := make([]Collector, len(r.cs))
+	copy(cs, r.cs)
+	r.mu.Unlock()
+	for _, c := range cs {
+		c.WriteProm(w)
+	}
+}
+
+// CounterVec is a labelled monotonic counter.
+type CounterVec struct {
+	name string
+	help string
+	mu   sync.Mutex
+	vals map[LabelSet]float64
+}
+
+func NewCounterVec(name, help string) *CounterVec {
+	return &CounterVec{name: name, help: help, vals: map[LabelSet]float64{}}
+}
+
+func (c *CounterVec) Inc(l LabelSet) { c.Add(l, 1) }
+
+func (c *CounterVec) Add(l LabelSet, delta float64) {
+	c.mu.Lock()
+	c.vals[l] += delta
+	c.mu.Unlock()
+}
+
+func (c *CounterVec) WriteProm(w io.Writer) {
+	c.mu.Lock()
+	keys := make([]LabelSet, 0, len(c.vals))
+	for k := range c.vals {
+		keys = append(keys, k)
+	}
+	snapshot := make(map[LabelSet]float64, len(c.vals))
+	for k, v := range c.vals {
+		snapshot[k] = v
+	}
+	c.mu.Unlock()
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n", c.name, c.help, c.name)
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s{%s} %g\n", c.name, k, snapshot[k])
+	}
+}
+
+// GaugeVec is a labelled last-write-wins gauge.
+type GaugeVec struct {
+	name string
+	help string
+	mu   sync.Mutex
+	vals map[LabelSet]float64
+}
+
+func NewGaugeVec(name, help string) *GaugeVec {
+	return &GaugeVec{name: name, help: help, vals: map[LabelSet]float64{}}
+}
+
+func (g *GaugeVec) Set(l LabelSet, v float64) {
+	g.mu.Lock()
+	g.vals[l] = v
+	g.mu.Unlock()
+}
+
+func (g *GaugeVec) WriteProm(w io.Writer) {
+	g.mu.Lock()
+	keys := make([]LabelSet, 0, len(g.vals))
+	for k := range g.vals {
+		keys = append(keys, k)
+	}
+	snapshot := make(map[LabelSet]float64, len(g.vals))
+	for k, v := range g.vals {
+		snapshot[k] = v
+	}
+	g.mu.Unlock()
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n", g.name, g.help, g.name)
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s{%s} %g\n", g.name, k, snapshot[k])
+	}
+}
+
+// HistogramVec is a labelled cumulative histogram.
+//
+// Buckets are stored as per-bucket hit counts and made cumulative only at
+// render time: an observation touches exactly one slot, so the write path
+// stays O(log n) on the boundary search and O(1) on the update, which matters
+// because Observe can run on every request.
+type HistogramVec struct {
+	name    string
+	help    string
+	buckets []float64
+	mu      sync.Mutex
+	counts  map[LabelSet][]uint64
+	sums    map[LabelSet]float64
+	totals  map[LabelSet]uint64
+}
+
+func NewHistogramVec(name, help string, buckets []float64) *HistogramVec {
+	// Copy: Observe relies on sort.SearchFloat64s, which is only correct on a
+	// strictly increasing slice. Keeping the caller's backing array would let a
+	// later append/sort elsewhere silently corrupt every bucket assignment.
+	b := make([]float64, len(buckets))
+	copy(b, buckets)
+	return &HistogramVec{
+		name:    name,
+		help:    help,
+		buckets: b,
+		counts:  map[LabelSet][]uint64{},
+		sums:    map[LabelSet]float64{},
+		totals:  map[LabelSet]uint64{},
+	}
+}
+
+// Observe records one sample. Values above the last boundary still count
+// toward _sum and _count (and the +Inf bucket), so a pathological outlier is
+// never silently dropped from the total.
+func (h *HistogramVec) Observe(l LabelSet, v float64) {
+	// A negative duration cannot happen from a monotonic clock, but a bad
+	// caller must not corrupt _sum for everyone else on this series.
+	if v < 0 {
+		v = 0
+	}
+	i := sort.SearchFloat64s(h.buckets, v)
+	h.mu.Lock()
+	if h.counts[l] == nil {
+		h.counts[l] = make([]uint64, len(h.buckets))
+	}
+	if i < len(h.buckets) {
+		h.counts[l][i]++
+	}
+	h.sums[l] += v
+	h.totals[l]++
+	h.mu.Unlock()
+}
+
+func (h *HistogramVec) WriteProm(w io.Writer) {
+	h.mu.Lock()
+	keys := make([]LabelSet, 0, len(h.counts))
+	snapCounts := make(map[LabelSet][]uint64, len(h.counts))
+	for k, v := range h.counts {
+		keys = append(keys, k)
+		c := make([]uint64, len(v))
+		copy(c, v)
+		snapCounts[k] = c
+	}
+	snapSums := make(map[LabelSet]float64, len(h.sums))
+	for k, v := range h.sums {
+		snapSums[k] = v
+	}
+	snapTotals := make(map[LabelSet]uint64, len(h.totals))
+	for k, v := range h.totals {
+		snapTotals[k] = v
+	}
+	h.mu.Unlock()
+
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s histogram\n", h.name, h.help, h.name)
+	for _, k := range keys {
+		var cum uint64
+		for i, b := range h.buckets {
+			cum += snapCounts[k][i]
+			fmt.Fprintf(w, "%s_bucket{%s} %d\n", h.name, withLE(k, formatBucket(b)), cum)
+		}
+		total := snapTotals[k]
+		fmt.Fprintf(w, "%s_bucket{%s} %d\n", h.name, withLE(k, "+Inf"), total)
+		fmt.Fprintf(w, "%s_sum{%s} %g\n", h.name, k, snapSums[k])
+		fmt.Fprintf(w, "%s_count{%s} %d\n", h.name, k, total)
+	}
+}
+
+// withLE appends the le dimension that the histogram exposition format
+// requires. It is built here rather than by the caller so no Observe path can
+// forget it and emit a bucket line a scraper will reject.
+func withLE(l LabelSet, le string) LabelSet {
+	if l == "" {
+		return LabelSet(`le="` + le + `"`)
+	}
+	return l + LabelSet(`,le="`+le+`"`)
+}
+
+// formatBucket renders a boundary the way the text format expects: the
+// shortest representation that round-trips, so 0.5 stays "0.5" and 60 stays
+// "60" rather than "60.000000".
+func formatBucket(b float64) string {
+	return strconv.FormatFloat(b, 'g', -1, 64)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestLabels_EscapesValues checks the three characters the text format defines
+// plus the CR-to-space flattening, and that an odd argument count panics.
+func TestLabels_EscapesValues(t *testing.T) {
+	got := string(Labels("model", `we"ird\x`+"\n"+"y", "path", "a\rb"))
+	for _, want := range []string{`model="we\"ird\\x\ny"`, `path="a b"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Labels escaping: %q missing %q", got, want)
+		}
+	}
+	if strings.ContainsRune(got, '\r') {
+		t.Errorf("bare CR survived: %q", got)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("odd pair count did not panic")
+		}
+	}()
+	Labels("only-key")
+}
+
+// TestCounterAndGauge_Exposition covers the counter (monotonic add) and gauge
+// (last-write-wins) render paths and their HELP/TYPE headers.
+func TestCounterAndGauge_Exposition(t *testing.T) {
+	c := NewCounterVec("things_total", "count of things")
+	c.Inc(Labels("kind", "a"))
+	c.Inc(Labels("kind", "a"))
+	c.Add(Labels("kind", "b"), 3)
+
+	g := NewGaugeVec("level", "a level")
+	g.Set(Labels("kind", "a"), 1)
+	g.Set(Labels("kind", "a"), 9) // last write wins
+
+	var buf bytes.Buffer
+	c.WriteProm(&buf)
+	g.WriteProm(&buf)
+	out := buf.String()
+
+	for _, want := range []string{
+		"# TYPE things_total counter",
+		`things_total{kind="a"} 2`,
+		`things_total{kind="b"} 3`,
+		"# TYPE level gauge",
+		`level{kind="a"} 9`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestHistogram_CumulativeAndInf pins the load-bearing histogram semantics:
+// inclusive le boundary, cumulative buckets, +Inf == _count, and _sum.
+func TestHistogram_CumulativeAndInf(t *testing.T) {
+	h := NewHistogramVec("dur_seconds", "durations", []float64{0.5, 5, 300})
+	for _, v := range []float64{0.5, 4, 250, 400} { // 400 is over-range → +Inf only
+		h.Observe(Labels("path", "p"), v)
+	}
+	var buf bytes.Buffer
+	h.WriteProm(&buf)
+	out := buf.String()
+
+	for _, want := range []string{
+		"# TYPE dur_seconds histogram",
+		`dur_seconds_bucket{path="p",le="0.5"} 1`, // 0.5 lands here (inclusive)
+		`dur_seconds_bucket{path="p",le="5"} 2`,   // +4
+		`dur_seconds_bucket{path="p",le="300"} 3`, // +250; 400 excluded
+		`dur_seconds_bucket{path="p",le="+Inf"} 4`,
+		`dur_seconds_sum{path="p"} 654.5`,
+		`dur_seconds_count{path="p"} 4`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestHistogram_NegativeClamped guards the _sum-poisoning path: a negative
+// observation is clamped to 0 rather than corrupting the running total.
+func TestHistogram_NegativeClamped(t *testing.T) {
+	h := NewHistogramVec("d", "", []float64{1})
+	h.Observe(Labels("p", "x"), -5)
+	var buf bytes.Buffer
+	h.WriteProm(&buf)
+	if !strings.Contains(buf.String(), `d_sum{p="x"} 0`) {
+		t.Errorf("negative not clamped:\n%s", buf.String())
+	}
+}
+
+// TestRegistry_RendersInRegistrationOrder is the new surface this package adds:
+// the Registry must render collectors in the order registered, so exposition
+// output is stable across scrapes and callers can control family ordering.
+func TestRegistry_RendersInRegistrationOrder(t *testing.T) {
+	first := NewCounterVec("zzz_total", "z")
+	first.Inc(Labels("a", "1"))
+	second := NewCounterVec("aaa_total", "a")
+	second.Inc(Labels("a", "1"))
+
+	r := NewRegistry()
+	r.MustRegister(first, second) // registered zzz before aaa, on purpose
+
+	var a, b bytes.Buffer
+	r.WritePrometheus(&a)
+	r.WritePrometheus(&b)
+	if a.String() != b.String() {
+		t.Fatal("two scrapes differ; registry order is not deterministic")
+	}
+	if iz, ia := strings.Index(a.String(), "zzz_total"), strings.Index(a.String(), "aaa_total"); iz > ia {
+		t.Errorf("registry did not preserve registration order (zzz should precede aaa):\n%s", a.String())
+	}
+}


### PR DESCRIPTION
## What
Lifts the hand-rolled Prometheus registry primitives out of `internal/llmobs` into a neutral `internal/metrics` package.

- New `internal/metrics`: `LabelSet`/`Labels` (+ value escaping), `CounterVec`, `GaugeVec`, `HistogramVec`, and a `Registry` that renders registered collectors **in registration order**.
- `llmobs.Metrics` now composes `metrics.*` vectors and delegates `WritePrometheus` to a `Registry`, registered in the same order as the previous hand-written write sequence.

## Why (#242 S2)
The registry was welded into `llmobs`, which is LLM-fallback-specific. The upcoming worker/agent app-level metrics (#242 S3-b) must emit without importing `llmobs` (wrong layering / import-cycle risk). A neutral package is the prerequisite.

## Zero behavior change
Pure refactor — no metric names, help text, bucket layouts, or label sets change. Scrape output is **byte-identical**: the existing `internal/llmobs` exposition tests (which parse the text format and assert structure, sorting, escaping, histogram cumulative/`+Inf`/`le` semantics) pass unchanged and are the regression net.

## Tests
- `internal/llmobs`: unchanged, green (byte-identical output guard).
- `internal/metrics`: new standalone tests — label escaping + odd-arg panic, counter/gauge exposition, histogram cumulative buckets / inclusive `le` / `+Inf == _count` / `_sum` / negative-clamp, and `Registry` registration-order determinism. `-race` green.

Tracked in #242. Follow-up: S3-b wires `internal/timing` and `RunTrace.Report` to emit through this registry (consuming `timing.PurposeClass` from #240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)